### PR TITLE
Ensure that the adb server has started before trying to request connecte...

### DIFF
--- a/lib/mobile/mobile-core/device-discovery.ts
+++ b/lib/mobile/mobile-core/device-discovery.ts
@@ -136,6 +136,7 @@ export class AndroidDeviceDiscovery extends DeviceDiscovery {
 
 	public startLookingForDevices(): IFuture<void> {
 		return(()=> {
+			this.ensureAdbServerStarted().wait();
 
 			var requestAllDevicesCommand = util.format("%s devices", AndroidDeviceDiscovery.ADB);
 			var result = this.$childProcess.exec(requestAllDevicesCommand).wait();
@@ -149,6 +150,11 @@ export class AndroidDeviceDiscovery extends DeviceDiscovery {
 					this.createAndAddDevice(identifier);
 				});
 		}).future<void>()();
+	}
+
+	private ensureAdbServerStarted(): IFuture<void> {
+		var startAdbServerCommand = util.format("%s start-server", AndroidDeviceDiscovery.ADB);
+		return this.$childProcess.exec(startAdbServerCommand);
 	}
 }
 $injector.register("androidDeviceDiscovery", AndroidDeviceDiscovery);


### PR DESCRIPTION
...d devices

This will fix the following response when the adb server is not running:
1: '\* daemon started successfully *' android
2: 'List of devices attached ' android
3: 'emulator-5554' android

Here only the last one is an actual device.
