### PR TITLE
Fixed waiting for downloading simulator dependencies before running it

### DIFF
--- a/lib/commands/simulate.ts
+++ b/lib/commands/simulate.ts
@@ -38,10 +38,8 @@ export class SimulateCommand implements ICommand {
 		this.serverVersion = config.assemblyVersion;
 		this.$logger.debug("Server version: %s", this.serverVersion);
 
-		Future.wait([
-			this.prepareSimulator(),
-			this.prepareCordovaPlugins()
-		]);
+		this.prepareSimulator().wait();
+		this.prepareCordovaPlugins().wait();
 
 		this.runSimulator();
 	}
@@ -57,7 +55,6 @@ export class SimulateCommand implements ICommand {
 			this.$logger.trace("Simulator path: %s", this.simulatorPath);
 
 			var cachedVersion  = "0.0.0.0";
-
 
 			if (this.$fs.exists(serverVersionFile).wait()) {
 				cachedVersion = this.$fs.readJson(serverVersionFile).wait().version;

--- a/lib/login.ts
+++ b/lib/login.ts
@@ -95,10 +95,8 @@ export class LoginManager implements ILoginManager {
 		return (() => {
 			this.$logger.debug("Logging out...");
 
-			Future.wait([
-				this.$userDataStore.setCookie(null),
-				this.$userDataStore.setUser(null)
-			]);
+			this.$userDataStore.setCookie(null).wait();
+			this.$userDataStore.setUser(null).wait();
 
 			this.$logger.debug("Logout completed.");
 		}).future<void>()();


### PR DESCRIPTION
Fixes the wrong syntax to call Future.wait(...) for multiple futures. This used to prevent waiting on downloading the prerequisites for the simulator and it could not run.
