### PR TITLE
Execute commands with expired account

### DIFF
--- a/lib/.d.ts
+++ b/lib/.d.ts
@@ -76,6 +76,7 @@
 /// <reference path="validators/cryptographic-identity-validators.ts" />
 /// <reference path="validators/ios-deployment-validator.ts" />
 /// <reference path="validators/project-name-validator.ts" />
+/// <reference path="validators/tenant-validator.ts" />
 /// <reference path="validators/validation-result.ts" />
 /// <reference path="yok.ts" />
 //grunt-end

--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -79,6 +79,7 @@ $injector.require("androidDevice", "./mobile/android/android-device");
 $injector.require("devicesServices", "./mobile/mobile-core/devices-services");
 $injector.require("prompter", "./prompter");
 
+$injector.require("tenantValidator", "./validators/tenant-validator");
 
 $injector.require("identityManager", "./commands/cryptographic-identities");
 $injector.requireCommand("list-provisions", "./commands/cryptographic-identities");
@@ -94,3 +95,4 @@ $injector.requireCommand("user", "./commands/user-status");
 
 $injector.requireCommand("appstore-list", "./commands/itunes-connect");
 $injector.requireCommand("appstore-upload", "./commands/itunes-connect");
+

--- a/lib/commands-service.ts
+++ b/lib/commands-service.ts
@@ -2,14 +2,16 @@
 "use strict";
 
 import _ = require("underscore");
+import helpers = require("./helpers");
 
 export class CommandsService implements ICommandsService {
-	constructor(private $errors: IErrors) {}
+	constructor(private $errors: IErrors,
+		private $tenantValidator: ITenantValidator) { }
 	public executeCommand(commandName: string, commandArguments: string[]): boolean {
 		return this.$errors.beginCommand(() => {
 			var command: ICommand = $injector.resolveCommand(commandName);
 			if (command) {
-				command.execute(commandArguments);
+				this.$tenantValidator.executeCommandIfAuthorized(command.requiresActiveAccount, () => command.execute(commandArguments));
 				return true;
 			}
 
@@ -63,5 +65,5 @@ export class CommandsService implements ICommandsService {
 
 		return true;
 	}
-	}
+}
 $injector.register("commandsService", CommandsService);

--- a/lib/commands/cryptographic-identities.ts
+++ b/lib/commands/cryptographic-identities.ts
@@ -126,8 +126,8 @@ export class IdentityManager implements Server.IIdentityManager {
 	}
 }
 $injector.register("identityManager", IdentityManager);
-helpers.registerCommand("identityManager", "list-certificates", (identityManager, args) => identityManager.listCertificates());
-helpers.registerCommand('identityManager', "list-provisions", (identityManager, args) => identityManager.listProvisions());
+helpers.registerCommand("identityManager", "list-certificates", false, (identityManager, args) => identityManager.listCertificates());
+helpers.registerCommand('identityManager', "list-provisions", false, (identityManager, args) => identityManager.listProvisions());
 
 class IdentityGenerationData {
 	private static derObjectIdentifierNames = {

--- a/lib/commands/deploy.ts
+++ b/lib/commands/deploy.ts
@@ -45,6 +45,8 @@ export class DeployCommand implements ICommand {
 			}
 		}).future<void>()().wait();
 	}
+
+	public get requiresActiveAccount(): boolean { return true; }
 }
 $injector.registerCommand("deploy", DeployCommand);
 

--- a/lib/commands/edit-configuration.ts
+++ b/lib/commands/edit-configuration.ts
@@ -44,6 +44,8 @@ export class EditConfigurationCommand implements ICommand {
 		}).future<void>()().wait();
 	}
 
+	public get requiresActiveAccount(): boolean { return true; }
+
 	private executeImplementation(data: EditConfigurationCommandData): IFuture<void> {
 		return (() => {
 			if (data.template) {

--- a/lib/commands/fetch-plugin.ts
+++ b/lib/commands/fetch-plugin.ts
@@ -29,6 +29,8 @@ export class FetchPluginCommand implements ICommand {
 		}
 	}
 
+	public get requiresActiveAccount(): boolean { return true; }
+
 	private isLocalPath(pluginId: string): boolean {
 		return fs.existsSync(pluginId);
 	}

--- a/lib/commands/find-plugins.ts
+++ b/lib/commands/find-plugins.ts
@@ -15,6 +15,8 @@ export class FindPluginsCommand implements ICommand {
 		this.printPlugins(plugins);
 	}
 
+	public get requiresActiveAccount(): boolean { return true; }
+
 	private printPlugins(plugins) {
 		_.each(plugins, (plugin) => {
 			var pluginDescription = this.composePluginDescription(plugin);

--- a/lib/commands/list-devices.ts
+++ b/lib/commands/list-devices.ts
@@ -16,5 +16,7 @@ export class ListDevicesCommand implements ICommand {
 
 		this.$devicesServices.executeOnAllConnectedDevices(action, platform).wait();
 	}
+
+	public get requiresActiveAccount(): boolean { return true; }
 }
 $injector.registerCommand("list-devices", ListDevicesCommand);

--- a/lib/commands/open-device-log-stream.ts
+++ b/lib/commands/open-device-log-stream.ts
@@ -17,6 +17,8 @@ export class OpenDeviceLogStreamCommand implements ICommand {
 			this.$logger.fatal("Invalid device identifier or index. Run $ice list-devices command to see all connected devices.");
 		}
 	}
+
+	public get requiresActiveAccount(): boolean { return true; }
 }
 $injector.registerCommand("open-device-log-stream", OpenDeviceLogStreamCommand);
 

--- a/lib/commands/simulate.ts
+++ b/lib/commands/simulate.ts
@@ -46,6 +46,8 @@ export class SimulateCommand implements ICommand {
 		}).future<void>()().wait();
 	}
 
+	public get requiresActiveAccount(): boolean { return true; }
+
 	private prepareSimulator(): IFuture<void> {
 		return ((): void => {
 			this.simulatorPath = path.join(this.cacheDir, this.PACKAGE_NAME);

--- a/lib/commands/sync.ts
+++ b/lib/commands/sync.ts
@@ -49,6 +49,8 @@ export class SyncCommand implements ICommand {
 		}).future<void>()().wait();
 	}
 
+	public get requiresActiveAccount(): boolean { return true; }
+
 	private sync(platform: string, appIdentifier: string, projectDir: string, projectFiles: string[]): IFuture<void> {
 		return(() => {
 			var action = (device: Mobile.IDevice): IFuture<void> => {

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -74,5 +74,5 @@ export class Configuration implements IConfiguration {
 	}
 }
 $injector.register("config", Configuration);
-helpers.registerCommand("config", "config-reset", (config, args) => config.reset());
-helpers.registerCommand("config", "config-apply", (config, args) => config.apply(args[0]));
+helpers.registerCommand("config", "config-reset", false, (config, args) => config.reset());
+helpers.registerCommand("config", "config-apply", false, (config, args) => config.apply(args[0]));

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -240,3 +240,6 @@ interface IPrompter {
 	history(name: string): IPromptHistoryValue;
 	override(object: any): void;
 }
+
+interface ITenantValidator {
+	executeCommandIfAuthorized(requiresActiveAccount: boolean, action: Function);}

--- a/lib/definitions/commands.d.ts
+++ b/lib/definitions/commands.d.ts
@@ -1,3 +1,4 @@
 interface ICommand {
 	execute(args: string[]): void;
+	requiresActiveAccount?: boolean;
 }

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -127,13 +127,14 @@ export function isStringOptionEmpty(optionValue) {
 	return optionValue === undefined || optionValue === null || optionValue === "null" || optionValue === "false" || optionValue === "true";
 }
 
-export function registerCommand(module: string, commandName: string, executor: (module, args: string[]) => IFuture<void>) {
+export function registerCommand(module: string, commandName: string, requiresActiveAccount: boolean, executor: (module, args: string[]) => IFuture<void>) {
 	var factory = function (): ICommand {
+		var tenantValidator = $injector.resolve("tenantValidator");
 		return {
 			execute: (args: string[]): void => {
-				var mod = $injector.resolve(module);
-				executor(mod, args).wait();
-			}
+					var mod = $injector.resolve(module);
+					tenantValidator.executeCommandIfAuthorized(requiresActiveAccount, () => executor(mod, args).wait());
+				}
 		};
 	};
 

--- a/lib/identity.ts
+++ b/lib/identity.ts
@@ -100,5 +100,5 @@ export class IdentityManager implements Server.IIdentityManager {
 	}
 }
 $injector.register("identityManager", IdentityManager);
-helpers.registerCommand("identityManager", "list-certificates", (identityManager, args) => identityManager.listCertificates());
-helpers.registerCommand("identityManager", "list-provisions", (identityManager, args) => identityManager.listProvisions());
+helpers.registerCommand("identityManager", "list-certificates", false, (identityManager, args) => identityManager.listCertificates());
+helpers.registerCommand("identityManager", "list-provisions", false, (identityManager, args) => identityManager.listProvisions());

--- a/lib/login.ts
+++ b/lib/login.ts
@@ -232,6 +232,6 @@ export class LoginManager implements ILoginManager {
 	}
 }
 $injector.register("loginManager", LoginManager);
-helpers.registerCommand("loginManager", "login", (loginManager, args) => loginManager.login());
-helpers.registerCommand("loginManager", "logout", (loginManager, args) => loginManager.logout());
-helpers.registerCommand("loginManager", "telerik-login", (loginManager, args) => loginManager.basicLogin(args[0], args[1]));
+helpers.registerCommand("loginManager", "login", false, (loginManager, args) => loginManager.login());
+helpers.registerCommand("loginManager", "logout", false, (loginManager, args) => loginManager.logout());
+helpers.registerCommand("loginManager", "telerik-login", false, (loginManager, args) => loginManager.basicLogin(args[0], args[1]));

--- a/lib/project.ts
+++ b/lib/project.ts
@@ -764,11 +764,11 @@ export class Project implements Project.IProject {
 }
 $injector.register("project", Project);
 
-helpers.registerCommand("project", "build", (project, args) => project.executeBuild(args[0]));
-helpers.registerCommand("project", "update", (project, args) => project.importProject());
-helpers.registerCommand("project", "create", (project, args) => project.createNewProject(args[0]));
+helpers.registerCommand("project", "build", true, (project, args) => project.executeBuild(args[0]));
+helpers.registerCommand("project", "update", true, (project, args) => project.importProject());
+helpers.registerCommand("project", "create", true, (project, args) => project.createNewProject(args[0]));
 _.each(["add", "set", "del"], (operation) => {
-	helpers.registerCommand("project", "prop-" + operation,
+	helpers.registerCommand("project", "prop-" + operation, false,
 		(project, args) => project.updateProjectPropertyAndSave(operation, args[0], _.rest(args, 1)));
 });
-helpers.registerCommand("project", "prop-print", (project, args) => project.printProjectProperty(args[0]));
+helpers.registerCommand("project", "prop-print", false, (project, args) => project.printProjectProperty(args[0]));

--- a/lib/remote-projects.ts
+++ b/lib/remote-projects.ts
@@ -103,5 +103,5 @@ class RemoteProjectExporter {
 }
 $injector.register("remoteProjectsExporter", RemoteProjectExporter);
 
-helpers.registerCommand("remoteProjectsExporter", "list-projects", (exporter) => exporter.listProjects());
-helpers.registerCommand("remoteProjectsExporter", "export-project", (exporter, args) => exporter.exportProject(args[0]));
+helpers.registerCommand("remoteProjectsExporter", "list-projects", false, (exporter) => exporter.listProjects());
+helpers.registerCommand("remoteProjectsExporter", "export-project", true, (exporter, args) => exporter.exportProject(args[0]));

--- a/lib/validators/tenant-validator.ts
+++ b/lib/validators/tenant-validator.ts
@@ -1,0 +1,34 @@
+///<reference path="../.d.ts"/>
+
+"use strict";
+import util = require("util");
+
+export class TenantValidator implements ITenantValidator {
+
+	constructor(private $logger: ILogger,
+		private $config: IConfiguration,
+		private $userDataStore: IUserDataStore) { }
+
+	private isSubscriptionExpired(): IFuture<boolean> {
+		return(() => {
+			var user = this.$userDataStore.getUser().wait();
+			return Date.parse(user.tenant.expSoft) < new Date().getTime();
+		}).future<boolean>()();
+	}
+
+	public executeCommandIfAuthorized(requiresActiveAccount: boolean, action: Function): void {
+		if(requiresActiveAccount) {
+			if(this.isSubscriptionExpired().wait()) {
+				var subscriptionUrl = util.format("%s://%s/account/subscription", this.$config.AB_SERVER_PROTO, this.$config.AB_SERVER);
+				this.$logger.out("Your subscription has expired. Click %s [Ctrl-Click] to manage your subscription. Note: After you renew your subscription, " +
+					"log out and log back in for the changes to take effect.", subscriptionUrl);
+			} else {
+				action();
+			}
+		} else  {
+			action();
+		}
+	}
+}
+
+$injector.register("tenantValidator", TenantValidator);


### PR DESCRIPTION
Show error message if one the following command is executed with expired account:
*create (the should not be able to create project)
*build
*deploy
*update
*sync
*open-device-log-stream
*find-plugins
*fetch-plugins
*simulate
*export-projects
*edit-configuration
*list-devices
