### PR TITLE
Add automatic grunt compile for ts files on change

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -33,6 +33,26 @@ module.exports = function(grunt) {
 			}
 		},
 
+		watch: {
+			devlib: {
+				files: ['lib/**/*.ts'],
+				tasks: ['ts:devlib'],
+				options: {
+				  atBegin: true,
+				  interrupt: true
+				},
+			},
+
+			devtest: {
+				files: ['test/**/*.ts'],
+				tasks: ['ts:devtest'],
+				options: {
+				  atBegin: true,
+				  interrupt: true
+				},
+			}
+		},
+
 		clean: {
 			src: ["test/**/*.js*", "lib/**/*.js*"]
 		}
@@ -40,6 +60,7 @@ module.exports = function(grunt) {
 
 	grunt.loadNpmTasks("grunt-ts");
 	grunt.loadNpmTasks("grunt-contrib-clean");
+	grunt.loadNpmTasks('grunt-contrib-watch');
 
 	grunt.registerTask("default", ["ts:devlib", "ts:devtest"]);
 };

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "grunt-ts": "1.5.1",
     "grunt-contrib-clean": "0.5.0",
     "mocha-fibers": "git+https://git@github.com/tailsu/mocha-fibers.git",
-    "temp": "0.6.0"
+    "temp": "0.6.0",
+    "grunt-contrib-watch": "0.5.3"
   },
   "bundledDependencies": [],
   "license": "Apache-2.0",


### PR DESCRIPTION
Running `grunt watch` will compile devlib and devtest and then wait for changes. When a file is changed/saved/deleted a grunt compile for the corresponding project will be triggered.
@tailsu @teobugslayer 
