### PR TITLE
Don't add devices that are not authorized

### DIFF
--- a/lib/mobile/mobile-core/device-discovery.ts
+++ b/lib/mobile/mobile-core/device-discovery.ts
@@ -167,6 +167,7 @@ export class AndroidDeviceDiscovery extends DeviceDiscovery {
 					return element && !element.isEmpty();
 				})
 				.map((element) => {
+					// http://developer.android.com/tools/help/adb.html#devicestatus
 					var parts = element.split("\t");
 					var identifier = parts[0];
 					var state = parts[1];


### PR DESCRIPTION
This is the same logic we use in our windows client. Only show devices that are in ready ("device") state.
@tailsu 
