### PR TITLE
Fix deploy and sync commands

### DIFF
--- a/lib/commands/deploy.ts
+++ b/lib/commands/deploy.ts
@@ -16,32 +16,30 @@ export class DeployCommand implements ICommand {
 	public execute(args: string[]): IFuture<void> {
 		return (() => {
 			var platform = this.$devicesServices.checkPlatformAndDevice(args[0], options.device).wait();
-			if (this.$devicesServices.hasDevices(platform)) {
-				var canExecute = (device: Mobile.IDevice): boolean => {
-					if (MobileHelper.isiOSPlatform(device.getPlatform())) {
-						var iOSDeploymentValidator = this.$injector.resolve(iOSDeploymentValidatorLib.IOSDeploymentValidator, {appIdentifier: packageName, device: device});
-						iOSDeploymentValidator.throwIfInvalid({provisionOption: options.provision, certificateOption: options.certificate}).wait();
-					}
-					return true;
+			var canExecute = (device: Mobile.IDevice): boolean => {
+				if (MobileHelper.isiOSPlatform(device.getPlatform())) {
+					var iOSDeploymentValidator = this.$injector.resolve(iOSDeploymentValidatorLib.IOSDeploymentValidator, {appIdentifier: packageName, device: device});
+					iOSDeploymentValidator.throwIfInvalid({provisionOption: options.provision, certificateOption: options.certificate}).wait();
 				}
+				return true;
+			}
 
-				var packageDefs = this.$project.deploy(platform).wait();
-				var packageFile = packageDefs[0].localFile;
+			var packageDefs = this.$project.deploy(platform).wait();
+			var packageFile = packageDefs[0].localFile;
 
-				this.$logger.debug("Ready to deploy %s", packageDefs);
-				this.$logger.debug("File is %d bytes", this.$fs.getFileSize(packageFile).wait());
+			this.$logger.debug("Ready to deploy %s", packageDefs);
+			this.$logger.debug("File is %d bytes", this.$fs.getFileSize(packageFile).wait());
 
-				var packageName = this.$project.projectData.AppIdentifier;
+			var packageName = this.$project.projectData.AppIdentifier;
 
-				var action = (device: Mobile.IDevice): IFuture<void> => {
-					return device.deploy(packageFile, packageName);
-				};
+			var action = (device: Mobile.IDevice): IFuture<void> => {
+				return device.deploy(packageFile, packageName);
+			};
 
-				if(options.device) {
-					this.$devicesServices.executeOnDevice(action, options.device).wait();
-				} else {
-					this.$devicesServices.executeOnAllConnectedDevices(action, platform, canExecute).wait();
-				}
+			if(options.device) {
+				this.$devicesServices.executeOnDevice(action, options.device).wait();
+			} else {
+				this.$devicesServices.executeOnAllConnectedDevices(action, platform, canExecute).wait();
 			}
 		}).future<void>()();
 	}

--- a/lib/commands/live-sync.ts
+++ b/lib/commands/live-sync.ts
@@ -29,22 +29,20 @@ export class LiveSyncCommand implements ICommand {
 				? "com.telerik.Icenium"
 				: this.$project.projectData.AppIdentifier;
 
-			if (this.$devicesServices.hasDevices(platform)) {
-				if (options.watch) {
-					this.liveSyncDevices(platform, projectDir, appIdentifier);
-				} else {
-					if (options.file) {
-						var isExistFile = this.$fs.exists((options.file)).wait();
-						if(isExistFile) {
-							var projectFiles = [path.resolve(options.file)];
-							this.sync(platform, appIdentifier, projectDir, projectFiles).wait();
-						} else {
-							this.$errors.fail("The file %s does not exist.", options.file);
-						}
-					} else {
-						var projectFiles = this.$project.enumerateProjectFiles(this.excludedProjectDirsAndFiles);
+			if (options.watch) {
+				this.liveSyncDevices(platform, projectDir, appIdentifier);
+			} else {
+				if (options.file) {
+					var isExistFile = this.$fs.exists((options.file)).wait();
+					if (isExistFile) {
+						var projectFiles = [path.resolve(options.file)];
 						this.sync(platform, appIdentifier, projectDir, projectFiles).wait();
+					} else {
+						this.$errors.fail("The file %s does not exist.", options.file);
 					}
+				} else {
+					var projectFiles = this.$project.enumerateProjectFiles(this.excludedProjectDirsAndFiles);
+					this.sync(platform, appIdentifier, projectDir, projectFiles).wait();
 				}
 			}
 		}).future<void>()();

--- a/lib/definitions/mobile.d.ts
+++ b/lib/definitions/mobile.d.ts
@@ -26,7 +26,6 @@ declare module Mobile {
 		executeOnAllConnectedDevices(action:  (device: Mobile.IDevice) => IFuture<any>, platform?: string, canExecute?: (dev: Mobile.IDevice) => boolean): IFuture<void>;
 		executeOnDevice(action: any, deviceOptions: string, canExecute?: (dev: Mobile.IDevice) => boolean): IFuture<void>;
 		checkPlatformAndDevice(platform: string, deviceOption: string): IFuture<string>;
-		hasDevices(platform?: string): boolean;
 		hasDevice(identifier: string): boolean;
 	}
 

--- a/lib/mobile/mobile-core/devices-services.ts
+++ b/lib/mobile/mobile-core/devices-services.ts
@@ -183,14 +183,6 @@ export class DevicesServices implements Mobile.IDevicesServices {
 		}).future<string>()();
 	}
 
-	public hasDevices(platform?: string): boolean {
-		if (!platform) {
-			return this.getDevices().length !== 0;
-		} else {
-			return this.filterDevicesByPlatform(this.getPlatform(platform)).length !== 0;
-		}
-	}
-
 	public hasDevice(identifier: string): boolean {
 		return _.some(this.getDevices(), (device: Mobile.IDevice) => { return device.getIdentifier() === identifier });
 	}


### PR DESCRIPTION
The `hasDevices` command was broken before and returned true if there were 0 devices. After fixing it started to always return false, because the device list gets populated before executing a command on a device and not when we called `hasDevices`. Currently I am removing the `hasDevices` so the behavior is the same as before. After 2.0 we should rewrite the code properly.
@tailsu @teobugslayer @Fatme @paletov 
