### PR TITLE
Hide dev commands from mispelled suggestions

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -62,14 +62,14 @@ module.exports = function(grunt) {
 
 			ci_unit_tests: {
 				command: [
-					"node bin\\appbuilder.js config-apply cibuild",
+					"node bin\\appbuilder.js dev-config-apply cibuild",
 					"call node_modules\\.bin\\mocha.cmd --ui mocha-fibers --recursive --reporter xunit --require test/test-bootstrap.js --timeout 15000 test/ > test-reports.xml"
 				].join("&&")
 			},
 
 			build_package: {
 				command: [
-					"node bin\\appbuilder.js config-apply <%= deploymentEnvironment %>",
+					"node bin\\appbuilder.js dev-config-apply <%= deploymentEnvironment %>",
 					"npm pack"
 				].join("&&")
 			}

--- a/lib/appbuilder-cli.ts
+++ b/lib/appbuilder-cli.ts
@@ -46,7 +46,7 @@ class CommandDispatcher {
 	}
 
 	private tryToMatchCommand(commandName): void {
-		var allCommands = this.$commandsService.allCommands();
+		var allCommands = _.reject(this.$commandsService.allCommands(), (command) => command.startsWith("dev-"));
 		var similarCommands = [];
 		_.each(allCommands, (command) => {
 			var distance = jaroWinklerDistance(commandName, command);

--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -2,8 +2,8 @@ global.$injector = require("./yok").injector;
 
 $injector.require("serverConfiguration", "./server-config");
 $injector.require("config", "./config");
-$injector.requireCommand("config-apply", "./config");
-$injector.requireCommand("config-reset", "./config");
+$injector.requireCommand("dev-config-apply", "./config");
+$injector.requireCommand("dev-config-reset", "./config");
 $injector.require("errors", "./errors");
 $injector.require("fs", "./file-system");
 $injector.require("childProcess", "./child-process");
@@ -33,12 +33,11 @@ $injector.require("loginManager", "./login");
 $injector.require("userDataStore", "./login");
 $injector.requireCommand("login", "./login");
 $injector.requireCommand("logout", "./login");
-$injector.requireCommand("telerik-login", "./login");
+$injector.requireCommand("dev-telerik-login", "./login");
 
 $injector.require("buildService", "./project");
 $injector.require("project", "./project");
 $injector.requireCommand("build", "./project");
-$injector.requireCommand("ion", "./project");
 $injector.requireCommand("cloud-sync", "./project");
 $injector.requireCommand("create", "./project");
 $injector.requireCommand("init", "./project");

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -77,5 +77,5 @@ export class Configuration implements IConfiguration {
 	public version: string = require("../package.json").version;
 }
 $injector.register("config", Configuration);
-helpers.registerCommand("config", "config-reset", (config, args) => config.reset());
-helpers.registerCommand("config", "config-apply", (config, args) => config.apply(args[0]));
+helpers.registerCommand("config", "dev-config-reset", (config, args) => config.reset());
+helpers.registerCommand("config", "dev-config-apply", (config, args) => config.apply(args[0]));

--- a/lib/login.ts
+++ b/lib/login.ts
@@ -236,4 +236,4 @@ export class LoginManager implements ILoginManager {
 $injector.register("loginManager", LoginManager);
 helpers.registerCommand("loginManager", "login", (loginManager, args) => loginManager.login());
 helpers.registerCommand("loginManager", "logout", (loginManager, args) => loginManager.logout());
-helpers.registerCommand("loginManager", "telerik-login", (loginManager, args) => loginManager.basicLogin(args[0], args[1]));
+helpers.registerCommand("loginManager", "dev-telerik-login", (loginManager, args) => loginManager.basicLogin(args[0], args[1]));


### PR DESCRIPTION
WARNING: This will break our current builds and the command executions in them should be changed to start with `dev-`
