### PR TITLE
Wait for stdin end when livesyncing with enabled watcher

### DIFF
--- a/lib/commands/live-sync.ts
+++ b/lib/commands/live-sync.ts
@@ -30,9 +30,7 @@ export class LiveSyncCommand implements ICommand {
 
 			if (options.watch) {
 				this.liveSyncDevices(this.$devicesServices.platform, projectDir, appIdentifier);
-
-				process.stdin.once("data", () => {});
-				process.stdin.on("end", () => process.exit());
+				helpers.exitOnStdinEnd();
 			} else {
 				if (options.file) {
 					var isExistFile = this.$fs.exists((options.file)).wait();

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -225,3 +225,8 @@ export function findByNameOrIndex<T>(identityStr: string, data: T[], selector: (
 
 	return undefined;
 }
+
+export function exitOnStdinEnd(): void {
+	process.stdin.on("data", () => {});
+	process.stdin.on("end", () => process.exit());
+}


### PR DESCRIPTION
This enables us to close the node process from a parent process using the stdin pipe.
Its end event will be fired when we close the pipe manually or close the parent process.
