### PR TITLE
Adding the --save-to option to the build command

### DIFF
--- a/lib/services/build.ts
+++ b/lib/services/build.ts
@@ -295,7 +295,15 @@ export class BuildService implements Project.IBuildService {
 
 			if (settings.downloadFiles) {
 				packageDefs.forEach((pkg: Server.IPackageDef) => {
-					var targetFileName = path.join(this.$project.getProjectDir(), path.basename(pkg.solutionPath));
+					var targetFileName = "";
+
+					if(options["save-to"]) {
+						targetFileName = options["save-to"];
+					}
+					else {
+						targetFileName = path.join(this.$project.getProjectDir(), path.basename(pkg.solutionPath));
+					}
+
 					this.$logger.info("Downloading file '%s/%s' into '%s'", pkg.solution, pkg.solutionPath, targetFileName);
 					var targetFile = this.$fs.createWriteStream(targetFileName);
 					this.$server.filesystem.getContent(pkg.solution, pkg.solutionPath, targetFile).wait();

--- a/resources/help.txt
+++ b/resources/help.txt
@@ -164,6 +164,8 @@ Options:
         Sets the provisioning profile that you want to use for code signing your iOS app. Must match the selected 
         certificate. You can set a provisioning profile by index or name.
     --no-livesync - If set, disables LiveSync of code changes with the three-finger tap and hold gesture.
+    --save-to - If set, downloads the application package to the provided path instead of the .ab directory. Use full 
+        path including fileName and extension.
 
 --[/]--
 


### PR DESCRIPTION
This commit adds the ability to save the downloaded apps in a folder other than .ab. 
