### PR TITLE
fix open-device-log-stream printing wrong message

### DIFF
--- a/lib/commands/open-device-log-stream.ts
+++ b/lib/commands/open-device-log-stream.ts
@@ -12,7 +12,7 @@ export class OpenDeviceLogStreamCommand implements ICommand {
 
 	public execute(args: string[]): IFuture<void> {
 		return (() => {
-			this.$devicesServices.initialize(undefined, options.device).wait();
+			this.$devicesServices.initialize(undefined, options.device, {skipInferPlatform: true}).wait();
 
 			if (this.$devicesServices.deviceCount !== 1) {
 				this.$commandsService.executeCommand("list-devices", []);

--- a/lib/mobile/mobile-core/devices-services.ts
+++ b/lib/mobile/mobile-core/devices-services.ts
@@ -94,7 +94,6 @@ export class DevicesServices implements Mobile.IDevicesServices {
 			} else if(MobileHelper.isAndroidPlatform(this._platform)) {
 				this.$androidDeviceDiscovery.startLookingForDevices().wait();
 			}
-			this._isInitialized = true;
 		}).future<void>()();
 	}
 
@@ -186,6 +185,9 @@ export class DevicesServices implements Mobile.IDevicesServices {
 
 	public initialize(platform: string, deviceOption?: string, options?: Mobile.IDevicesServicesInitializationOptions): IFuture<void> {
 		options = options || {};
+		if (this._isInitialized) {
+			return Future.fromResult();
+		}
 		return(() => {
 			if(platform && deviceOption) {
 				this._device = this.getDevice(deviceOption).wait();
@@ -220,6 +222,7 @@ export class DevicesServices implements Mobile.IDevicesServices {
 					}
 				}
 			}
+			this._isInitialized = true;
 		}).future<void>()();
 	}
 


### PR DESCRIPTION
when devices from different platforms are connected, open-device-log-stream without arguments printed the wrong error message instead of listing all devices.
