### PR TITLE
Fix open-device-log-stream throwing wrong error when 0 devices found

### DIFF
--- a/lib/commands/open-device-log-stream.ts
+++ b/lib/commands/open-device-log-stream.ts
@@ -14,7 +14,7 @@ export class OpenDeviceLogStreamCommand implements ICommand {
 		return (() => {
 			this.$devicesServices.initialize(undefined, options.device, {skipInferPlatform: true}).wait();
 
-			if (this.$devicesServices.deviceCount !== 1) {
+			if (this.$devicesServices.deviceCount > 1) {
 				this.$commandsService.executeCommand("list-devices", []);
 				this.$errors.fail(OpenDeviceLogStreamCommand.NOT_SPECIFIED_DEVICE_ERROR_MESSAGE);
 			}


### PR DESCRIPTION
@paletov @Fatme 
