### PR TITLE
Fix android livesync crashing on old devices

### DIFF
--- a/lib/mobile/android/android-device.ts
+++ b/lib/mobile/android/android-device.ts
@@ -156,7 +156,7 @@ export class AndroidDevice implements Mobile.IDevice {
 			if (appIdentifier.isLiveSyncSupported(this).wait()) {
 				this.pushFilesOnDevice(localToDevicePaths).wait();
 				if (!options.skipRefresh) {
-					this.sendBroadcastToDevice(AndroidDevice.CHANGE_LIVESYNC_URL_INTENT_NAME, {liveSyncUrl: ""}).wait();
+					this.sendBroadcastToDevice(AndroidDevice.CHANGE_LIVESYNC_URL_INTENT_NAME, {liveSyncUrl: "icenium://"}).wait();
 					this.sendBroadcastToDevice(AndroidDevice.REFRESH_WEB_VIEW_INTENT_NAME).wait();
 				}
 				this.$logger.info("Successfully synced device with identifier '%s'", this.getIdentifier());


### PR DESCRIPTION
Sending a broadcast with empty intent crashes on old devices. This was synchronized with [ION for Android](https://github.com/Icenium/ion-android/pull/3)
