### PR TITLE
Fixes unzipping and starting of the Mac simulator

### DIFF
--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -296,7 +296,6 @@ interface IPrompter {
 
 interface ISimulatorPlatformServices {
 	getPackageName() : string;
-	preparePackage(simulatorPath: string): void;
 	runSimulator(simulatorPath: string, simulatorParams: string[]);
 }
 


### PR DESCRIPTION
Use built-in 'unzip' to extract the simulator. Remove all hard-coded names and manual work to fix the extracted files.

ping @Icenium/core @nedyalkov @KristinaKoeva @bkulov
