### PR TITLE
don't track the usage of login commands

### DIFF
--- a/lib/commands-service.ts
+++ b/lib/commands-service.ts
@@ -13,8 +13,10 @@ export class CommandsService implements ICommandsService {
 	public executeCommandUnchecked(commandName: string, commandArguments: string[]): boolean {
 		var command = this.$injector.resolveCommand(commandName);
 		if (command) {
-			this.$analyticsService.checkConsent(commandName).wait();
-			this.$analyticsService.trackFeature(commandName).wait();
+			if (!command.disableAnalytics) {
+				this.$analyticsService.checkConsent(commandName).wait();
+				this.$analyticsService.trackFeature(commandName).wait();
+			}
 			command.execute(commandArguments).wait();
 			return true;
 		} else {

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -350,3 +350,6 @@ interface IUserSettingsService {
 	userSettingsFilePath?: string;
 }
 
+interface ICommandOptions {
+	disableAnalytics?: boolean;
+}

--- a/lib/definitions/commands.d.ts
+++ b/lib/definitions/commands.d.ts
@@ -1,3 +1,3 @@
-interface ICommand {
+interface ICommand extends ICommandOptions {
 	execute(args: string[]): IFuture<void>;
 }

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -81,13 +81,14 @@ export function isStringOptionEmpty(optionValue) {
 	return optionValue === undefined || optionValue === null || optionValue === "null" || optionValue === "false" || optionValue === "true";
 }
 
-export function registerCommand(module: string, commandName: string, executor: (module, args: string[]) => IFuture<void>) {
+export function registerCommand(module: string, commandName: string, executor: (module, args: string[]) => IFuture<void>, opts?: ICommandOptions) {
 	var factory = function (): ICommand {
 		return {
 			execute: (args: string[]): IFuture<void> => {
 				var mod = $injector.resolve(module);
 				return executor(mod, args);
-			}
+			},
+			disableAnalytics: opts && opts.disableAnalytics
 		};
 	};
 

--- a/lib/login.ts
+++ b/lib/login.ts
@@ -242,6 +242,6 @@ export class LoginManager implements ILoginManager {
 	}
 }
 $injector.register("loginManager", LoginManager);
-helpers.registerCommand("loginManager", "login", (loginManager, args) => loginManager.login());
-helpers.registerCommand("loginManager", "logout", (loginManager, args) => loginManager.logout());
-helpers.registerCommand("loginManager", "dev-telerik-login", (loginManager, args) => loginManager.basicLogin(args[0], args[1]));
+helpers.registerCommand("loginManager", "login", (loginManager, args) => loginManager.login(), {disableAnalytics: true});
+helpers.registerCommand("loginManager", "logout", (loginManager, args) => loginManager.logout(), {disableAnalytics: true});
+helpers.registerCommand("loginManager", "dev-telerik-login", (loginManager, args) => loginManager.basicLogin(args[0], args[1]), {disableAnalytics: true});

--- a/lib/services/user-settings-service.ts
+++ b/lib/services/user-settings-service.ts
@@ -78,26 +78,22 @@ export  class SharedUserSettingsService implements IUserSettingsService {
 						var timeDiff = Math.abs(new Date().getTime() - fileInfo.mtime.getTime());
 						var diffDays = Math.ceil(timeDiff / (1000 * 3600 * 24));
 						if(diffDays > 1) {
-							this.makeServerRequest().wait();
+							this.downloadUserSettings().wait();
 						} else {
 							this.userSettingsData = xmlMapping.tojson(this.$fs.readText(this.userSettingsFile).wait());
 						}
 					} else {
-						this.makeServerRequest().wait();
+						this.downloadUserSettings().wait();
 					}
 				}
 			}
 		}).future<void>()();
 	}
 
-	private makeServerRequest(): IFuture<void> {
+	private downloadUserSettings(): IFuture<void> {
 		return(() => {
-			try {
-				this.$server.rawSettings.getUserSettings(this.$fs.createWriteStream(this.userSettingsFile)).wait();
-				this.userSettingsData = xmlMapping.tojson(this.$fs.readText(this.userSettingsFile).wait());
-			} catch (e) {
-				this.userSettingsData = null;
-			}
+			this.$server.rawSettings.getUserSettings(this.$fs.createWriteStream(this.userSettingsFile)).wait();
+			this.userSettingsData = xmlMapping.tojson(this.$fs.readText(this.userSettingsFile).wait());
 		}).future<void>()();
 	}
 
@@ -123,7 +119,7 @@ export  class SharedUserSettingsService implements IUserSettingsService {
 
 	public saveSettings(data: {[key: string]: {}}): IFuture<void> {
 		return (() => {
-			this.loadUserSettingsFile().wait();
+			this.downloadUserSettings().wait();
 
 			this.userSettingsData = this.userSettingsData || {};
 


### PR DESCRIPTION
because usage tracking requires you to be logged in in the first place

also:
- don't clobber user settings
- don't prompt for consent when the login cookie is expired
