### PR TITLE
fix Ctrl-C on open-device-log-stream command

### DIFF
--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -257,3 +257,13 @@ export function mergeRecursive(obj1: Object, obj2: Object): Object {
 
 	return obj1;
 }
+
+export function block(operation: () => void): void {
+	if (isInteractive()) {
+		process.stdin.setRawMode(false);
+	}
+	operation();
+	if (isInteractive()) {
+		process.stdin.setRawMode(true);
+	}
+}

--- a/lib/mobile/ios/ios-core.ts
+++ b/lib/mobile/ios/ios-core.ts
@@ -577,7 +577,10 @@ class WinSocket implements Mobile.IiOSDeviceSocket {
 
 	private read(bytes: number): NodeBuffer {
 		var data = new Buffer(bytes);
-		var result = this.winSocketLibrary.recv(this.service, data, bytes, 0);
+		var result: Number;
+		helpers.block(() => {
+			result = this.winSocketLibrary.recv(this.service, data, bytes, 0);
+		});
 		if (result < 0) {
 			this.$errors.fail("Error receiving data: %s", result);
 		}

--- a/lib/prompter.ts
+++ b/lib/prompter.ts
@@ -16,14 +16,13 @@ export class Prompter implements IPrompter {
 
 		if (helpers.isInteractive()) {
 			process.stdin.setRawMode(true);
-			process.on("SIGINT", () => process.exit());
 
 			this.ctrlcReader = readline.createInterface(<any>{
 				input: process.stdin,
 				output: process.stdout
 			});
 
-			this.ctrlcReader.on("SIGINT", () => process.emit("SIGINT"));
+			this.ctrlcReader.on("SIGINT", () => process.exit());
 		}
 	}
 


### PR DESCRIPTION
on Windows with iOS device
