### PR TITLE
Make .abignore logic work with absolute paths

### DIFF
--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -380,7 +380,7 @@ interface IServerExtensionsService {
 
 interface IPathFilteringService {
 	getRulesFromFile(file: string) : string[];
-	filterIgnoredFiles(files: string[], rules: string[]) :string[];
+	filterIgnoredFiles(files: string[], rules: string[], rootDir: string) :string[];
 }
 
 interface ICordovaMigrationService {

--- a/lib/project.ts
+++ b/lib/project.ts
@@ -72,7 +72,7 @@ export class Project implements Project.IProject {
 
 		var ignoreFilesRules = this.$pathFilteringService.getRulesFromFile(path.join(this.getProjectDir(), Project.IGNORE_FILE));
 
-		projectFiles = this.$pathFilteringService.filterIgnoredFiles(projectFiles, ignoreFilesRules);
+		projectFiles = this.$pathFilteringService.filterIgnoredFiles(projectFiles, ignoreFilesRules, this.getProjectDir());
 
 		this.$logger.trace("enumerateProjectFiles: %s", util.inspect(projectFiles));
 		return projectFiles;

--- a/lib/services/path-filtering.ts
+++ b/lib/services/path-filtering.ts
@@ -26,8 +26,9 @@ export class PathFilteringService implements IPathFilteringService {
 		return rules;
 	}
 
-	public filterIgnoredFiles(files: string[], rules: string[]) :string[] {
+	public filterIgnoredFiles(files: string[], rules: string[], rootDir: string): string[]{
 		var selectedFiles = _.select(files, (file: string) => {
+			file = file.replace(rootDir, "");
 			var fileMatched = true;
 			_.forEach(rules, rule => {
 				// minimatch treats starting '!' as pattern negation


### PR DESCRIPTION
.abignore logic only works when given relative paths, but the project service works with absolute paths.
@teobugslayer
