### PR TITLE
prepackage server resources, instead of downloading them on post-install

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -22,8 +22,3 @@ lib/**/*.js.map
 
 scratch/
 test/
-
-resources/App_Resources
-resources/Cordova
-resources/ItemTemplates
-resources/ProjectTemplates

--- a/BuildPackage.cmd
+++ b/BuildPackage.cmd
@@ -1,5 +1,10 @@
 call "c:\Program Files (x86)\nodejs\nodevars.bat"
-call npm.cmd install
 call npm.cmd install -g grunt-cli
+
+set APPBUILDER_SKIP_POSTINSTALL_TASKS=1
+call npm.cmd install
+set APPBUILDER_SKIP_POSTINSTALL_TASKS=
+
 call grunt.cmd pack --no-color
+
 call npm.cmd cache rm appbuilder

--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -112,7 +112,7 @@ $injector.requireCommand("user", "./commands/user-status");
 $injector.requireCommand("appstore|list", "./commands/itunes-connect");
 $injector.requireCommand("appstore|upload", "./commands/itunes-connect");
 
-$injector.requireCommand("dev-post-install", "./commands/post-install");
+$injector.requireCommand("dev-prepackage", "./commands/post-install");
 $injector.require("platformServices", "./commands/simulate");
 $injector.require("analyticsService", "./services/analytics-service");
 $injector.requireCommand("feature-usage-tracking", "./services/analytics-service");

--- a/lib/commands/post-install.ts
+++ b/lib/commands/post-install.ts
@@ -34,4 +34,4 @@ export class PostInstallCommand implements ICommand {
 	}
 }
 
-$injector.registerCommand("dev-post-install", PostInstallCommand);
+$injector.registerCommand("dev-prepackage", PostInstallCommand);

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test": "node_modules\\.bin\\mocha --ui mocha-fibers --recursive --no-colors --reporter spec --require test/test-bootstrap.js --timeout 15000 test/",
     "preinstall": "node preinstall.js",
     "postinstall": "node postinstall.js",
-    "preuninstall": "node preuninstall.js"
+    "preuninstall": "node preuninstall.js",
+    "prepublish": "node prepublish.js"
   },
   "main": "./lib/appbuilder-cli.js",
   "repository": {
@@ -71,7 +72,8 @@
     "temp": "0.6.0",
     "grunt-contrib-watch": "0.5.3",
     "grunt-shell": "0.6.4",
-    "grunt-contrib-copy": "0.5.0"
+    "grunt-contrib-copy": "0.5.0",
+    "grunt-curl": "1.5.1"
   },
   "bundledDependencies": [],
   "license": "Apache-2.0",

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,7 +1,13 @@
+var skipPostinstallTasks = process.env["APPBUILDER_SKIP_POSTINSTALL_TASKS"];
+if (skipPostinstallTasks) {
+	return;
+}
+
 var fs = require("fs");
 var path = require("path");
 var child_process = require("child_process");
 var util = require("util");
+var homeDir = process.env.USERPROFILE || process.env.HOME || process.env.HOMEPATH;
 
 if (process.platform !== "win32") {
 	fs.chmod(util.format("resources/platform-tools/android/%s/adb", process.platform), "755", function (err) {
@@ -10,8 +16,6 @@ if (process.platform !== "win32") {
 		}
 	});
 }
-
-var homeDir = process.env.USERPROFILE || process.env.HOME || process.env.HOMEPATH;
 
 var scriptsOk = true;
 var outstandingUpdates = 0;
@@ -73,24 +77,3 @@ if (fs.existsSync(bashProfileFileName)) {
 
 // zsh - http://www.acm.uiuc.edu/workshops/zsh/startup_files.html
 updateShellScript(".zshrc");
-
-function invokeGrunt(callback) {
-	if (fs.existsSync("Gruntfile.js")) {
-		var grunt = require("grunt");
-		grunt.cli.tasks = ["ts:devall"];
-		grunt.cli(null, callback);
-	} else {
-		process.nextTick(callback);
-	}
-}
-
-invokeGrunt(function() {
-	var child = child_process.exec("node bin/appbuilder.js dev-post-install", function (error) {
-		if (error) {
-			console.error("Failed to complete all post-install steps.");
-			throw error;
-		}
-	});
-
-	child.stdout.pipe(process.stdout);
-});

--- a/prepublish.js
+++ b/prepublish.js
@@ -1,3 +1,8 @@
+var skipPostinstallTasks = process.env["APPBUILDER_SKIP_POSTINSTALL_TASKS"];
+if (skipPostinstallTasks) {
+	return;
+}
+
 var fs = require("fs");
 var path = require("path");
 var child_process = require("child_process");
@@ -5,7 +10,7 @@ var child_process = require("child_process");
 function invokeGrunt(callback) {
 	if (!fs.existsSync("lib/appbuilder-cli.js")) {
 		var grunt = require("grunt");
-		grunt.cli.options.color = false;
+		grunt.cli.tasks = ["ts:devall"];
 		grunt.cli(null, callback);
 	} else {
 		process.nextTick(callback);
@@ -15,20 +20,8 @@ function invokeGrunt(callback) {
 invokeGrunt(function() {
 	var child = child_process.exec("node bin/appbuilder.js dev-prepackage", function (error) {
 		if (error) {
-			// don't rethrow if this step fails as part running 'npm install' in a Jenkins job,
-
-			var doThrow = true;
-			if (process.env["JOB_NAME"]) {
-				var argv = JSON.parse(process.env["npm_config_argv"]);
-				if (argv.cooked[0] && argv.cooked[0].toLowerCase() === "install") {
-					doThrow = false;
-				}
-			}
-
-			if (doThrow) {
-				console.error("Failed to complete all pre-publishing steps.");
-				throw error;
-			}
+			console.error("Failed to complete all pre-publishing steps.");
+			throw error;
 		}
 	});
 


### PR DESCRIPTION
also:
- save the server version against which the package is built into config.json
- fix the misleading build errors cropping up in the build log
