### PR TITLE
Make sure init and sample commands don't fail in rare cases

### DIFF
--- a/lib/project.ts
+++ b/lib/project.ts
@@ -158,6 +158,7 @@ export class Project implements Project.IProject {
 			} else {
 				version = _.last(this.$cordovaMigrationService.getSupportedVersions().wait());
 			}
+			
 			return this.$cordovaMigrationService.pluginsForVersion(version).wait();
 		}).future<string[]>()();
 	}
@@ -463,7 +464,7 @@ export class Project implements Project.IProject {
 				this.$injector.dynamicCall(propData.onChanging, [propertyValue]).wait();
 			}
 
-				projectData[property] = propertyValue;
+			projectData[property] = propertyValue;
 		}).future<void>()();
 	}
 
@@ -572,7 +573,7 @@ export class ProjectPropertiesService implements IProjectPropertiesService {
 			var propertyGroup: any = result.Project.PropertyGroup[0];
 
 			var projectSchema = helpers.getProjectFileSchema();
-			Object.keys(projectSchema).forEach((propertyName) => {
+			_.sortBy(Object.keys(projectSchema), key => key === "FrameworkVersion" ? -1 : 1).forEach((propertyName) => {
 				if (propertyGroup.hasOwnProperty(propertyName)) {
 					properties[propertyName] = propertyGroup[propertyName][0];
 

--- a/lib/services/samples-service.ts
+++ b/lib/services/samples-service.ts
@@ -98,7 +98,12 @@ export class SamplesService implements ISamplesService {
 					throw error;
 				}
 			} finally {
-				this.$fs.deleteDirectory(tempDir).wait();
+				try {
+					this.$fs.deleteDirectory(tempDir).wait();
+				}
+				catch (error) {
+					this.$logger.debug(error);
+				}
 			}
 		}).future<void>()();
 	}


### PR DESCRIPTION
When we parse an xml project file we should always set the framework version first so we know which plugins are supported for this version.
ping @tailsu @teobugslayer @Fatme 
