### PR TITLE
Instruct mac unzip to update existing files when unzipping

### DIFF
--- a/lib/file-system.ts
+++ b/lib/file-system.ts
@@ -61,7 +61,7 @@ export class FileSystem implements IFileSystem {
 	public unzip(zipFile: string, destinationDir: string): IFuture<void> {
 		if (helpers.isDarwin()) {
 			var $childProcess = $injector.resolve("$childProcess");
-			var unzipProc = $childProcess.spawn('unzip', [zipFile, '-d', destinationDir],
+			var unzipProc = $childProcess.spawn('unzip', ['-uqo', zipFile, '-d', destinationDir],
 				{ stdio: "ignore", detached: true });
 			return this.futureFromEvent(unzipProc, "close");
 		}


### PR DESCRIPTION
Mac unzip tool requires explicit option to overwrite existing files.

refs #265740
