### PR TITLE
ProjectName validation logic is shared among all clients

### DIFF
--- a/lib/validators/project-name-validator.ts
+++ b/lib/validators/project-name-validator.ts
@@ -18,7 +18,7 @@ export class ProjectNameValidator {
 	private static INVALID_EXTENSIONS = [];
 
 	private validateName(name: string): ValidationResult.ValidationResult {
-		var validNameRegex = new RegExp("^[a-zA-Z0-9_.+\\-@$&;() ,]*$");
+		var validNameRegex = new RegExp("^[a-zA-Z0-9_.\- ]*$");
 		var ext = path.extname(name);
 
 		if(helpers.isNullOrWhitespace(name)) {


### PR DESCRIPTION
Change ProjectName validation logic to be the same among windows client, web client, tap, mist, simulator and the cli

refs #251289
