### PR TITLE
Set default project template to kendo.tabstrip

### DIFF
--- a/config/config-base.json
+++ b/config/config-base.json
@@ -6,7 +6,7 @@
 	"PROJECT_FILE_NAME": ".abproject",
 	"SOLUTION_SPACE_NAME": "Private_Build_Folder",
 	"QR_SIZE": 300,
-	"DEFAULT_CORDOVA_PROJECT_TEMPLATE": "KendoUI",
+	"DEFAULT_CORDOVA_PROJECT_TEMPLATE": "KendoUI.TabStrip",
 	"DEFAULT_NATIVESCRIPT_PROJECT_TEMPLATE": "Blank",
 	"CORDOVA_PLUGINS_REGISTRY": "http://registry.cordova.io",
 	"WRAP_CLIENT_ID": "uri:ice",

--- a/config/config.json
+++ b/config/config.json
@@ -6,7 +6,7 @@
 	"PROJECT_FILE_NAME": ".abproject",
 	"SOLUTION_SPACE_NAME": "Private_Build_Folder",
 	"QR_SIZE": 300,
-	"DEFAULT_CORDOVA_PROJECT_TEMPLATE": "KendoUI",
+	"DEFAULT_CORDOVA_PROJECT_TEMPLATE": "KendoUI.TabStrip",
 	"DEFAULT_NATIVESCRIPT_PROJECT_TEMPLATE": "Blank",
 	"CORDOVA_PLUGINS_REGISTRY": "http://registry.cordova.io",
 	"WRAP_CLIENT_ID": "uri:ice",

--- a/lib/project.ts
+++ b/lib/project.ts
@@ -308,18 +308,6 @@ export class Project implements Project.IProject {
 				template = options.template || this.defaultProjectForType[projectType],
 				templateFileName;
 
-			if (projectType === this.$projectTypes.Cordova && template.toLowerCase() === "kendouidataviz") {
-				this.$loginManager.ensureLoggedIn().wait();
-				var user = this.$userDataStore.getUser().wait();
-				if (!user.tenant.features["Kendo UI DataViz"]) {
-					this.$errors.fail("You cannot create Kendo UI DataViz projects " +
-						"with your current subscription plan. To use this feature, " +
-						"upgrade your subscription plan to Business or greater, " +
-						"or contact the account owner.\n" +
-						"http://www.telerik.com/purchase/platform");
-				}
-			}
-
 			templateFileName = path.join(templatesDir, this.$templatesService.getTemplateFilename(projectType, template));
 			this.$logger.trace("Using template '%s'", templateFileName);
 			if (this.$fs.exists(templateFileName).wait()) {


### PR DESCRIPTION
Set default project template to kendo.tabstrip
Remove obsoleted code related to kendouidataviz, because this template no longer exists

fixes #270107
