### PR TITLE
Expanding the BundleVersion to 4 numbers

### DIFF
--- a/resources/project-properties-common.json
+++ b/resources/project-properties-common.json
@@ -24,8 +24,8 @@
 	},
 	"BundleVersion": {
 		"description": "The application (or bundle) version.",
-		"regex": "^(\\d+)(\\.\\d+)?(\\.\\d+)?$",
-		"validationMessage": "The version must consist of two or three numbers separated with dots."
+		"regex": "^(\\d+)(\\.\\d+)?(\\.\\d+)?(\\.\\d+)?$",
+		"validationMessage": "The version must consist of two, three or four numbers separated with dots."
 	},
 	"AndroidPermissions": {
 		"description": "Android permissions required by the app.",


### PR DESCRIPTION
Expanding the BundleVersion to 4 numbers separated by dot to accommodate for Semantic Versioning with high patch version. 

Example : 

9.9.234.124

9 - major
9 - minor
234 - first 3 of patch number
124 - second 3 of patch number
