### PR TITLE
Fix livesync for android

### DIFF
--- a/lib/commands/live-sync.ts
+++ b/lib/commands/live-sync.ts
@@ -1,5 +1,5 @@
 ///<reference path="../.d.ts"/>
-
+"use strict";
 import util = require("util");
 import path = require("path");
 import watchr = require("watchr");
@@ -26,9 +26,7 @@ export class LiveSyncCommand implements ICommand {
 		private $fs: IFileSystem,
 		private $errors: IErrors,
 		private $project: Project.IProject,
-		private $dispatcher: IFutureDispatcher,
-		private $projectTypes: IProjectTypes) {
-	}
+		private $dispatcher: IFutureDispatcher) { }
 
 	public execute(args: string[]): IFuture<void> {
 		return (() => {


### PR DESCRIPTION
We are using non-consecutive numbers in our enum to distinguish project types, but the old code uses consecutive ones.

Fix: Use named constants instead of hard-coded numbers. We must resolve the constants inside the method, instead of constructor injection, because these imports are available only in the Cordova CLI.

The meat of the bugfixing code is in the shared lib. Here we update it to a version containing the fix.

Fixes bug #273415
