### PR TITLE
When importing VS .proj files, do not read new-style properties

### DIFF
--- a/lib/project.ts
+++ b/lib/project.ts
@@ -217,7 +217,7 @@ export class Project implements Project.IProject {
 			}
 			var appname = path.basename(projectDir);
 			var properties = this.getProjectPropertiesFromExistingProject(projectDir, appname).wait();
-			if (!properties) {
+			if (properties) {
 				properties = this.alterPropertiesForNewProject({}, appname);
 			}
 
@@ -225,9 +225,8 @@ export class Project implements Project.IProject {
 				this.createProjectFile(projectDir, projectType, properties).wait();
 				this.$logger.info("Successfully initialized project in the folder!");
 			}
-			catch (ex) {
-				this.$logger.error("There was an error while initialising the project:");
-				throw ex;
+			catch (e) {
+				this.$errors.fail("There was an error while initialising the project: " + os.EOL + e);
 			}
 
 		}).future<void>()();

--- a/lib/services/project-properties-service.ts
+++ b/lib/services/project-properties-service.ts
@@ -19,7 +19,9 @@ export class ProjectPropertiesService implements IProjectPropertiesService {
 			var properties = isJsonProjectFile ? this.$fs.readJson(projectFile).wait() :
 				this.getProjectPropertiesFromXmlProjectFile(projectFile).wait();
 
-			this.completeProjectProperties(properties);
+			if (properties) {
+				this.completeProjectProperties(properties);
+			}
 
 			return properties;
 		}).future<IProjectData>()();
@@ -50,7 +52,12 @@ export class ProjectPropertiesService implements IProjectPropertiesService {
 				}
 			});
 
-			properties.ProjectName = propertyGroup.ProjectName[0];
+			// only old style .proj files (before project unification) have ProjectName
+			if (propertyGroup.ProjectName) {
+				properties.ProjectName = propertyGroup.ProjectName[0];
+			} else {
+				properties = null;
+			}
 
 			return properties;
 		}).future<any>()();


### PR DESCRIPTION
When importing VS .proj files, do not read new-style (unified) project properties.
Instead, create a clean .abproject file.

Fixes #269492
