### PR TITLE
Merge Mac packages for Simulator and Debugger

### DIFF
--- a/lib/commands/debug.ts
+++ b/lib/commands/debug.ts
@@ -116,7 +116,7 @@ class WinDebuggerPlatformServices extends  BaseDebuggerPlatformServices implemen
 }
 
 class DarwinDebuggerPlatformServices extends BaseDebuggerPlatformServices implements IExtensionPlatformServices {
-	private static PACKAGE_NAME_OSX: string = "Telerik.BlackDragon.Client.Mobile.Debugger.Mac.Package";
+	private static PACKAGE_NAME_OSX: string = "Telerik.BlackDragon.Client.Mobile.Tools.Mac.Package";
 	private static EXECUTABLE_NAME_OSX = "AppBuilder Debugger.app";
 
 	constructor(private $childProcess: IChildProcess,

--- a/lib/commands/simulate.ts
+++ b/lib/commands/simulate.ts
@@ -130,13 +130,11 @@ class WinSimulatorPlatformServices implements IExtensionPlatformServices {
 }
 
 class MacSimulatorPlatformServices implements IExtensionPlatformServices {
-	private static PACKAGE_NAME_MAC: string = "Telerik.BlackDragon.Client.Mobile.Simulator.Mac.Package";
+	private static PACKAGE_NAME_MAC: string = "Telerik.BlackDragon.Client.Mobile.Tools.Mac.Package";
 	private static EXECUTABLE_NAME_MAC = "AppBuilder Simulator";
 	private static EXECUTABLE_NAME_MAC_APP = MacSimulatorPlatformServices.EXECUTABLE_NAME_MAC + ".app";
 
-	constructor(private $fs: IFileSystem,
-				private $childProcess: IChildProcess) {
-	}
+	constructor(private $childProcess: IChildProcess) { }
 
 	public getPackageName() : string {
 		return MacSimulatorPlatformServices.PACKAGE_NAME_MAC;


### PR DESCRIPTION
The Mac packages for Simulator and Debugging Tools were merged into one package. Change the CLI to use the new package.

Depends on https://github.com/Icenium/Ice/pull/1958 .
