### PR TITLE
Clean temp dir on each ios-sim launch

### DIFF
--- a/lib/commands/remote.ts
+++ b/lib/commands/remote.ts
@@ -65,6 +65,10 @@ export class RemoteCommand implements ICommand {
 	private onLaunchRequest(req: express.Request, res: express.Response): IFuture<void> {
 		return (() => {
 			this.$logger.info("launch simulator request received ... ");
+			
+			// Clean the tempdir before new launch
+			this.$fs.deleteDirectory(this.appBuilderDir).wait();
+			this.$fs.createDirectory(this.appBuilderDir).wait();
 
 			var deviceFamily = req.query.deviceFamily.toLowerCase();
 			var archive = this.$fs.createWriteStream(this.packageLocation);


### PR DESCRIPTION
When using remote command we are launching the ios-sim and installing app from the same temp folder. We should clean the temp folder before unzipping the new app as the unzip process will not remove files from old app.

Fixes http://teampulse.telerik.com/view#item/278326 
