### PR TITLE
Appstore commands prompt for AppleID

### DIFF
--- a/resources/help.txt
+++ b/resources/help.txt
@@ -718,12 +718,12 @@ You must run the appstore command with a related command.
 
 --[appstore|list]--
 Usage:
-    $ appbuilder appstore list <AppleID> [<Password>]
+    $ appbuilder appstore list [<AppleID>] [<Password>]
 
 Lists all application records in iTunes Connect that are in the Waiting for Upload state. The list contains name, version, and
 bundle ID for each application record.
-<Apple ID> and <Password> are your credentials for logging in iTunes Connect. If you do not provide your Apple ID password when
-        running the command, the Telerik AppBuilder CLI will prompt you to provide it.
+<Apple ID> and <Password> are your credentials for logging in iTunes Connect. If you do not provide them when
+        running the command, the Telerik AppBuilder CLI will prompt you to provide them.
 
 When running $ appbuilder appstore upload, you need to provide the name for the application record.
 
@@ -731,14 +731,14 @@ When running $ appbuilder appstore upload, you need to provide the name for the 
 
 --[appstore|upload]--
 Usage:
-    $ appbuilder appstore upload <Application Name> <AppleID> [<Password>]
+    $ appbuilder appstore upload <Application Name> [<AppleID>] [<Password>]
                  --certificate <Certificate ID> --provision <Provision ID>
 
 Builds the project and uploads the application to iTunes Connect.
 <Application Name> is the name for an application record in the Waiting for Upload state. To retrieve the names of your application
         records that are in the Waiting for Upload state in iTunes Connect, run $ appbuilder appstore list.
-<AppleID> and <Password> are your credentials for logging into iTunes Connect. If you do not provide your Apple ID password when
-        running the command, Telerik AppBuilder will prompt you to provide it.
+<AppleID> and <Password> are your credentials for logging into iTunes Connect. If you do not provide them when
+        running the command, Telerik AppBuilder will prompt you to provide them.
 <Certificate ID> is the index or name of the certificate as listed by $ appbuilder certificate.
 <Provision ID> is the index or name of the provisioning profile as listed by $ appbuilder provision.
 


### PR DESCRIPTION
If you do not specify AppleID, appstore commands prompt you to provide it instead of failing with error. Add AppstoreApplicationCommandBase and change current appstore commands to extend it. Add getAppleId method in order to get the id. Changes in help.txt to show that AppleID is no longer mandatory parameter.

http://teampulse.telerik.com/view#item/274748
