### PR TITLE
Use master of fibers repos

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "cookie": "0.1.0",
     "express": "4.8.5",
     "ffi": "https://github.com/icenium/node-ffi/tarball/master",
-    "fibers": "https://github.com/icenium/node-fibers/tarball/release",
+    "fibers": "https://github.com/icenium/node-fibers/tarball/master",
     "filesize": "2.0.3",
     "hex": "0.0.1",
     "iconv-lite": "0.4.3",
@@ -78,7 +78,7 @@
     "grunt": "0.4.2",
     "grunt-ts": "1.11.2",
     "grunt-contrib-clean": "0.5.0",
-    "mocha-fibers": "https://github.com/Icenium/mocha-fibers/tarball/release",
+    "mocha-fibers": "https://github.com/Icenium/mocha-fibers/tarball/master",
     "grunt-contrib-watch": "0.5.3",
     "grunt-shell": "0.6.4",
     "grunt-contrib-copy": "0.5.0"


### PR DESCRIPTION
Update package.json to use master branches of node-fibers and mocha-fibers repos, so we can test the changes that are applied there. Release branches should be used only in release state.
