### PR TITLE
Show helpful error message when $appbuilder deploy  is executed in a folder that isn’t an AppBuilder project

### DIFF
--- a/lib/hooks/typescript-compilation.ts
+++ b/lib/hooks/typescript-compilation.ts
@@ -8,6 +8,7 @@ fiberBootstrap.run(() => {
 	$injector.require("typeScriptCompilationService", "./common/services/typescript-compilation-service");
 
 	var project: Project.IProject = $injector.resolve("project");
+	project.ensureProject();
 	var projectFiles = project.enumerateProjectFiles().wait();
 
 	var typeScriptFiles = _.filter(projectFiles, file => path.extname(file) === ".ts");


### PR DESCRIPTION
Fixes http://teampulse.telerik.com/view#item/279028
