### PR TITLE
Fix --save-to option

### DIFF
--- a/lib/options.ts
+++ b/lib/options.ts
@@ -20,6 +20,7 @@ var knownOpts: any = {
 		"file": String,
 		"livesync": Boolean,
 		"save-to": String,
+		"saveTo": String,
 		"client": String,
 		"available": Boolean
 	},

--- a/test/options.ts
+++ b/test/options.ts
@@ -1,0 +1,25 @@
+///<reference path=".d.ts"/>
+"use strict";
+
+import options = require("../lib/options");
+import _ = require("underscore");
+var assert = require("chai").assert;
+var yargs: any = require("yargs");
+
+describe("options", () => {
+	describe("dashed known options", () => {
+		it("are added correctly", () => {
+			// yargs adds dashed values to yargs.argv in two ways:
+			// with dash and without dash, replacing first symbol after it with its toUpper equivalent
+			// for example --save-to is added to yargs.argv as "save-to" and "saveTo"
+			// this test assures all options with dash are added to knownOpts in both ways
+			var knowOptionsKeys = _.keys(options.knownOpts);
+			var dashedOptions = _.filter(knowOptionsKeys, (opt: string) => _.contains(opt, "-"));
+			_.forEach(dashedOptions, (opt: string) => {
+				var dashIndex = opt.indexOf("-");
+				var secondaryPresentation = opt.slice(0, dashIndex) + opt[dashIndex + 1].toUpperCase() + opt.slice(dashIndex + 2);
+				assert.include(knowOptionsKeys, secondaryPresentation, "option " + opt + " is not added to knownOpts correctly. It should be added as " + opt + " and " + secondaryPresentation);
+			});
+		});
+	});
+});


### PR DESCRIPTION
We are validating all -- options. Options which have dash ("-") are added by yargs in two ways, in this case --save-to is passed to our code as save-to and saveTo. As we have not added saveTo to known options, trying to use --save-to fails. Added saveTo option to knownOpts. Added test that verifies all options, which have "-" are added correctly to options (in both ways).

Fixes http://teampulse.telerik.com/view#item/278006
