### PR TITLE
Ensure there is a project when emulator starts

### DIFF
--- a/lib/services/emulator-settings-service.ts
+++ b/lib/services/emulator-settings-service.ts
@@ -9,6 +9,7 @@ export class EmulatorSettingsService implements Mobile.IEmulatorSettingsService 
 
 	public canStart(platform: string): IFuture<boolean> {
 		return (() => {
+			this.$project.ensureProject();
 			return _.contains(this.$project.projectTargets.wait(), platform.toLowerCase());
 		}).future<boolean>()();
 	}


### PR DESCRIPTION
Make sure there's a project when emulator checks if it can start. Fixes: http://teampulse.telerik.com/view#item/279773
