### PR TITLE
Fix certificate create-self-signed command

### DIFF
--- a/lib/commands/cryptographic-identities.ts
+++ b/lib/commands/cryptographic-identities.ts
@@ -382,7 +382,9 @@ export class CreateSelfSignedIdentity implements ICommand {
 		}).future<void>()();
 	}
 
-	allowedParameters: ICommandParameter[] = [];
+	allowedParameters: ICommandParameter[] = [new commandParams.StringCommandParameter(), new commandParams.StringCommandParameter(),
+		new commandParams.StringCommandParameter(), new commandParams.StringCommandParameter(),
+		new commandParams.StringCommandParameter(), new commandParams.StringCommandParameter()];
 
 	private getPromptSchema(defaults: any): IPromptSchema {
 		var promptSchema: IPromptSchema = {


### PR DESCRIPTION
Fix for certificate create-self-signed command. Add six non-mandatory parameters. If any of them is missing, the command will prompt the user to fill them.

Fixes http://teampulse.telerik.com/view#item/279831
