### PR TITLE
Remove # from listing

### DIFF
--- a/lib/commands/cloud-projects.ts
+++ b/lib/commands/cloud-projects.ts
@@ -34,7 +34,7 @@ export class CloudListProjectsCommand implements ICommand {
 	private printProjects(projects: any) {
 		this.$logger.out("Projects:");
 		projects.forEach((project: any, index: number) => {
-			this.$logger.out("#%s: '%s'", (index + 1).toString(), project.name);
+			this.$logger.out("%s: '%s'", (index + 1).toString(), project.name);
 		});
 	}
 

--- a/lib/commands/cryptographic-identities.ts
+++ b/lib/commands/cryptographic-identities.ts
@@ -61,7 +61,7 @@ export class IdentityManager implements Server.IIdentityManager {
 			identities = _.sortBy(identities, (identity) => identity.Alias);
 			_.forEach(identities, (identity, index) => {
 				var cert = this.$x509.load(identity.Certificate);
-				this.$logger.out("#%d: '%s', expires on %s, issued by %s", (index + 1).toString(), identity.Alias,
+				this.$logger.out("%s: '%s', expires on %s, issued by %s", (index + 1).toString(), identity.Alias,
 					cert.expiresOn.toDateString(), cert.issuerData["CN"]);
 			});
 			if(!identities.length) {
@@ -72,7 +72,7 @@ export class IdentityManager implements Server.IIdentityManager {
 	}
 
 	private printProvisionData(provision: IProvision, provisionIndex: number): void {
-		this.$logger.out("#%d: '%s', type: %s, App ID: '%s.%s'", (provisionIndex + 1).toString(), provision.Name, provision.ProvisionType,
+		this.$logger.out("%s: '%s', type: %s, App ID: '%s.%s'", (provisionIndex + 1).toString(), provision.Name, provision.ProvisionType,
 			provision.ApplicationIdentifierPrefix, provision.ApplicationIdentifier);
 		if (options.verbose || options.v) {
 			var devices = provision.ProvisionedDevices;
@@ -637,7 +637,7 @@ class ListCertificateSigningRequestsCommand implements ICommand {
 			var requests: any[] = this.$server.identityStore.getCertificateRequests().wait();
 			requests = _.sortBy(requests, (req) => req.UniqueName);
 			_.forEach(requests, (req, i, list) => {
-				this.$logger.out("#%s: %s", (i + 1).toString(), req.Subject);
+				this.$logger.out("%s: %s", (i + 1).toString(), req.Subject);
 			})
 			if(!requests.length) {
 				this.$logger.info("No certificate signing requests.");

--- a/lib/commands/list-devices.ts
+++ b/lib/commands/list-devices.ts
@@ -32,7 +32,7 @@ export class ListDevicesCommand implements ICommand {
 				};
 			} else {
 				action = (device) => {
-					return (() => { this.$logger.out("#%d: '%s'", (index++).toString(), device.getDisplayName(), device.getPlatform(), device.getIdentifier()); }).future<void>()();
+					return (() => { this.$logger.out("%s: '%s'", (index++).toString(), device.getDisplayName(), device.getPlatform(), device.getIdentifier()); }).future<void>()();
 				};
 			}
 


### PR DESCRIPTION
Remove # sign when listing available certificates, provisions, cloud projects and devices (appbuilder certificate, appbuilder provision, appbuilder cloud and appbuilder device commands).

Currently some of our commands print lists and place numbers at the beginning of each row, for example:
#1: "Project 1"
#2: "Project 2"

This leads to confusion when passing arguments to commands like --certificate, where it is expected to pass the number (1), but some customers pass #1. In shell scripts # is sign for comment, so everything after it is ignored and not passed as command parameter, which leads to incorrect behavior. So remove the # in order to make it easier for the customers to understand that we require the number (or the name).

Related to http://teampulse.telerik.com/view#item/278003
