### PR TITLE
Fix parsing of .abignore file

### DIFF
--- a/lib/services/path-filtering.ts
+++ b/lib/services/path-filtering.ts
@@ -1,13 +1,12 @@
 ///<reference path="../.d.ts"/>
-"use strict"
+"use strict";
 import _ = require("underscore");
 import os = require("os");
 import minimatch = require("minimatch");
 
 export class PathFilteringService implements IPathFilteringService {
 
-	constructor(private $fs: IFileSystem) {
-	}
+	constructor(private $fs: IFileSystem) {	}
 
 	public getRulesFromFile(fullFilePath: string) : string[] {
 		var COMMENT_START = '#';
@@ -15,7 +14,7 @@ export class PathFilteringService implements IPathFilteringService {
 
 		try {
 			var fileContent = this.$fs.readText(fullFilePath).wait();
-			rules = _.reject(fileContent.split(os.EOL),
+			rules = _.reject(fileContent.split(/[\n\r]/),
 				(line: string) => line.length === 0 || line[0] === COMMENT_START);
 
 		} catch(e) {

--- a/test/path-filtering.ts
+++ b/test/path-filtering.ts
@@ -57,4 +57,34 @@ describe("PathFilteringService", () => {
 		var expected:string[] = [];
 		assert.deepEqual(actual, expected);
 	});
+
+	it("different OS line endings -> \\n", () => {
+		var fs: IFileSystem = testInjector.resolve("fs");
+		var ignoreRules = "a\nb";
+		fs.readText = () => ((_:string) => ignoreRules).future<string>()();
+
+		var actual = testInjector.resolve("pathFilteringService").getRulesFromFile("<ignored>");
+		var expected = ["a","b"];
+		assert.deepEqual(actual, expected);
+	});
+
+	it("different OS line endings -> \\r", () => {
+		var fs = testInjector.resolve("fs");
+		var ignoreRules = "a\rb";
+		fs.readText = () => (() => ignoreRules).future<string>()();
+
+		var actual = testInjector.resolve("pathFilteringService").getRulesFromFile("<ignored>");
+		var expected = ["a","b"];
+		assert.deepEqual(actual, expected);
+	});
+
+	it("different OS line endings -> \\r\\n", () => {
+		var fs = testInjector.resolve("fs");
+		var ignoreRules = "a\r\nb";
+		fs.readText = () => (() => ignoreRules).future<string>()();
+
+		var actual = testInjector.resolve("pathFilteringService").getRulesFromFile("<ignored>");
+		var expected = ["a","b"];
+		assert.deepEqual(actual, expected);
+	});
 });


### PR DESCRIPTION
We used to parse using the current OS line endings, but the file could be created with different style line endings

The fix is to switch to a regex with all combinations

Also, added some unit tests to guard against this

Fixes http://teampulse.telerik.com/view#item/280494
