### PR TITLE
Use cordova 3.7.0 as experimental

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -124,3 +124,5 @@ $injector.require("domainNameSystem", "./dns");
 $injector.require("remoteProjectService", "./services/remote-projects-service");
 $injector.require("optionsService", "./services/options-service");
 $injector.require("processInfo", "./process-info");
+$injector.requireCommand("mobileframework|*print", "./commands/framework-versions/print-versions");
+$injector.requireCommand("mobileframework|set", "./commands/framework-versions/set-version");

--- a/lib/commands/framework-versions/print-versions.ts
+++ b/lib/commands/framework-versions/print-versions.ts
@@ -1,0 +1,41 @@
+///<reference path="../../.d.ts"/>
+"use strict";
+
+import projectTypes = require("../../project-types");
+
+export class PrintFrameworkVersionsCommand implements ICommand {
+	constructor(private $cordovaMigrationService: ICordovaMigrationService,
+		private $project: Project.IProject,
+		private $logger: ILogger,
+		private $errors: IErrors) { }
+
+	public execute(args: string[]): IFuture<void> {
+		return (() => {
+			var supportedVersions: Server.FrameworkVersion[] = this.$cordovaMigrationService.getSupportedFrameworks().wait();
+
+			if(this.$project.projectData) {
+				this.$logger.info("Your project is using version " + this.$cordovaMigrationService.getDisplayNameForVersion(this.$project.projectData["FrameworkVersion"]).wait());
+			}
+
+			this.$logger.info("Supported versions are: ");
+			_.each(supportedVersions, (sv: Server.FrameworkVersion) => {
+				this.$logger.info(sv.DisplayName);
+			});
+		}).future<void>()();
+	}
+
+	public allowedParameters: ICommandParameter[] = [];
+
+	public canExecute(args: string[]): IFuture<boolean> {
+		return (() => {
+			this.$project.ensureCordovaProject();
+
+			if(this.$project.projectType !== projectTypes.Cordova) {
+				this.$errors.fail("This command is valid only for hybrid projects.");
+			}
+
+			return true;
+		}).future<boolean>()();
+	}
+}
+$injector.registerCommand("mobileframework|*print", PrintFrameworkVersionsCommand);

--- a/lib/commands/framework-versions/set-version.ts
+++ b/lib/commands/framework-versions/set-version.ts
@@ -1,0 +1,47 @@
+///<reference path="../../.d.ts"/>
+"use strict";
+
+import projectTypes = require("../../project-types");
+
+export class SetFrameworkVersionCommand implements ICommand {
+	constructor(private $cordovaMigrationService: ICordovaMigrationService,
+		private $project: Project.IProject) { }
+
+	public execute(args: string[]): IFuture<void> {
+		return (() => {
+			this.$project.onFrameworkVersionChanging(args[0]).wait();
+			this.$project.projectData["FrameworkVersion"] = args[0];
+			this.$project.saveProject().wait();
+		}).future<void>()();
+	}
+
+	public allowedParameters: ICommandParameter[] = [$injector.resolve(MobileFrameworkCommandParameter)];
+}
+$injector.registerCommand("mobileframework|set", SetFrameworkVersionCommand);
+
+export class MobileFrameworkCommandParameter implements ICommandParameter {
+	private static VERSION_REGEX = new RegExp("^(\\d+\\.){2}\\d+$");
+
+	constructor(private $cordovaMigrationService: ICordovaMigrationService,
+		private $project: Project.IProject,
+		private $errors: IErrors) { }
+
+	public mandatory = true;
+
+	public validate(value: string, errorMessage?: string): IFuture<boolean> {
+		return (() => {
+			this.$project.ensureCordovaProject();
+
+			if(value.match(MobileFrameworkCommandParameter.VERSION_REGEX)) {
+				var supportedVersions = this.$cordovaMigrationService.getSupportedVersions().wait();
+				if(_.contains(supportedVersions, value)) {
+					return true;
+				}
+
+				this.$errors.fail("The value %s is not a supported version. Supported versions are: %s", value, supportedVersions);
+			}
+
+			this.$errors.fail("Version is not in correct format. Correct format is <Major>.<Minor>.<Patch>, for example '3.5.0'.");
+		}).future<boolean>()();
+	}
+}

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -148,6 +148,7 @@ declare module Project {
 		projectTargets: IFuture<string[]>;
 		getProjectDir(): IFuture<string>;
 		ensureProject(): void;
+		ensureCordovaProject(): void;
 		enumerateProjectFiles(additionalExcludedProjectDirsAndFiles?: string[]): IFuture<string[]>;
 		isProjectFileExcluded(projectDir: string, filePath: string, additionalExcludedDirsAndFiles?: string[]): boolean;
 		updateProjectPropertyAndSave(mode: string, propertyName: string, propertyValues: string[]): IFuture<void>;
@@ -156,7 +157,7 @@ declare module Project {
 		createProjectFileFromExistingProject(projectType: number): IFuture<void>;
 		createProjectFile(projectDir: string, projectType: number, properties: any): IFuture<void>;
 		createTemplateFolder(projectDir: string): IFuture<void>;
-		getTempDir(extraSubdir?:string): IFuture<string>;
+		getTempDir(extraSubdir?: string): IFuture<string>;
 		saveProject(projectDir?: string): IFuture<void>;
 		validateProjectProperty(property: string, args: string[], mode: string): IFuture<boolean>;
 		getNewProjectDir(): void;
@@ -165,6 +166,7 @@ declare module Project {
 		configurationSpecificData: IDictionary<IDictionary<any>>;
 		configurations: string[];
 		hasBuildConfigurations(): boolean;
+		onFrameworkVersionChanging(newVersion: string): IFuture<void>;
 	}
 
 	interface IPlatformMigrator {
@@ -334,6 +336,8 @@ interface ICordovaMigrationService {
 	getSupportedVersions(): IFuture<string[]>;
 	pluginsForVersion(version: string): IFuture<string[]>;
 	migratePlugins(plugins: string[], fromVersion: string, toVersion: string): IFuture<string[]>;
+	getSupportedFrameworks(): IFuture<Server.FrameworkVersion[]>;
+	getDisplayNameForVersion(version: string): IFuture<string>;
 }
 
 interface ISamplesService {

--- a/lib/server-api.d.ts
+++ b/lib/server-api.d.ts
@@ -67,9 +67,14 @@ declare module Server{
 		OldName: string;
 		NewName: string;
 	}
+	interface FrameworkVersion{
+		Version: string;
+		DisplayName: string;
+	}
 	interface CordovaMigrationData{
 		RenamedPlugins: Server.CordovaRenamedPlugin[];
 		SupportedVersions: string[];
+		SupportedFrameworkVersions: Server.FrameworkVersion[];
 		IntegratedPlugins: any;
 	}
 	interface PropertyMigration{
@@ -98,6 +103,7 @@ declare module Server{
 		getMigrationData(): IFuture<Server.CordovaMigrationData>;
 		getPluginsPackage($resultStream: any): IFuture<void>;
 		getCordovaVersions(): IFuture<string[]>;
+		getCordovaFrameworkVersions(): IFuture<Server.FrameworkVersion[]>;
 		getMarketplacePluginData(pluginId: string, version: string): IFuture<Server.CordovaPluginData>;
 		getCurrentPlatforms(solutionName: string, projectName: string): IFuture<Server.DevicePlatform[]>;
 		addPlatform(platform: Server.DevicePlatform, solutionName: string, projectName: string): IFuture<Server.MigrationResult>;

--- a/lib/server-api.ts
+++ b/lib/server-api.ts
@@ -52,6 +52,9 @@ export class CordovaService implements Server.ICordovaServiceContract{
 	public getCordovaVersions(): IFuture<string[]>{
 		return this.$serviceProxy.call<string[]>('GetCordovaVersions', 'GET', ['api','cordova','versions'].join('/'), 'application/json', null, null);
 	}
+	public getCordovaFrameworkVersions(): IFuture<Server.FrameworkVersion[]>{
+		return this.$serviceProxy.call<Server.FrameworkVersion[]>('GetCordovaFrameworkVersions', 'GET', ['api','cordova','frameworkVersions'].join('/'), 'application/json', null, null);
+	}
 	public getMarketplacePluginData(pluginId: string, version: string): IFuture<Server.CordovaPluginData>{
 		return this.$serviceProxy.call<Server.CordovaPluginData>('GetMarketplacePluginData', 'GET', ['api','cordova','marketplace',encodeURI(pluginId.replace(/\\/g, '/')),encodeURI(version.replace(/\\/g, '/'))].join('/'), 'application/json', null, null);
 	}

--- a/resources/help.txt
+++ b/resources/help.txt
@@ -37,6 +37,8 @@ Project development commands:
     cloud                           Lists all projects associated with your Telerik Platform account.
     cloud export                    Exports a selected project from the cloud and initializes it for development.
     update-kendoui                  Updates or adds Kendo UI Core or Kendo UI Professional to your project.
+    mobileframework                 Lists all supported versions of the mobile framework.
+    mobileframework set             Sets the selected framework version for the project and updates the plugins according to the new version.
 
 Device commands:
     device                          Lists all recognized connected devices.
@@ -948,4 +950,32 @@ IMPORTANT: If you want to listen on a port in the range of 0 through 1023, run t
 <Port> is a non-negative integer that specifies a port on your OS X system. 
        Make sure that the port is open and that your firewall allows traffic on it, if configured. 
        Make sure that your Windows system can reach and send traffic to the OS X system on the specified port. 
+--[/]--
+
+--[mobileframework]--
+Usage:
+    $appbuilder mobileframework [<Command>] [--path <Directory>]
+
+Lists all supported versions of the mobile framework for the current hybrid project.
+
+<Command> is a related command that extends the mobileframework command. You can run the following related commands:
+	set - Sets the selected framework version for the project and updates the plugins according to the new version.
+
+Options:
+    --path - Specifies the directory that contains the project. If not specified, the project is searched
+            for in the current directory and all directories above it.
+--[/]--
+
+--[mobileframework|set]--
+Usage:
+    $ appbuilder mobileframework set <Version> [--path <Directory>]
+
+Sets the selected framework version for the project and updates the plugins according to the new version.
+<Version> is the version of the framework in the 
+        following format Major.Minor.Patch
+You can use appbuilder mobileframework to get list of supported versions.
+
+Options:
+    --path - Specifies the directory that contains the project. If not specified, the project is searched
+            for in the current directory and all directories above it.
 --[/]--

--- a/test/cordova-migration-service.ts
+++ b/test/cordova-migration-service.ts
@@ -11,6 +11,8 @@ var assert: chai.Assert = chai.assert;
 
 var testInjector = new yok.Yok();
 testInjector.register("server", {});
+testInjector.register("errors", {});
+testInjector.register("loginManager", { ensureLoggedIn: (): IFuture<void> => { return (() => { }).future<void>()() }});
 
 function registerMockedFS(mockResult: any): void {
     testInjector.register("fs", {

--- a/test/framework-versions.ts
+++ b/test/framework-versions.ts
@@ -1,0 +1,115 @@
+///<reference path=".d.ts"/>
+"use strict";
+
+import yok = require("../lib/common/yok");
+
+import Future = require("fibers/future");
+import stubs = require("./stubs");
+import util = require("util");
+var assert = require("chai").assert;
+
+var fileSystemFile = require("../lib/common/file-system");
+var hashServiceFile = require("../lib/services/hash-service");
+var printVersionsFile = require("../lib/commands/framework-versions/print-versions");
+var setVersionFile = require("../lib/commands/framework-versions/set-version");
+
+function createTestInjector(): IInjector {
+	var testInjector = new yok.Yok();
+
+	testInjector.register("fs", fileSystemFile.FileSystem);
+	testInjector.register("errors", {
+		fail: (...args: any[]) => { throw new Error(args[0]); }
+	});
+
+	testInjector.register("project", {
+		ensureProject: () => { },
+		ensureCordovaProject: () => { },
+		projectData: { "FrameworkVersion": "" },
+		saveProject: (): IFuture<void> => { return (() => { }).future<void>()() },
+		onFrameworkVersionChanging: (): IFuture<void> => { return (() => { }).future<void>()() },
+		projectType: 1 //Cordova
+	});
+
+	testInjector.register("cordovaMigrationService", {
+		getSupportedVersions: (): IFuture<string[]> => { 
+			return (() => {
+				return ["1.0.0", "1.0.1", "1.0.2"];
+			}).future<string[]>()()
+		},
+
+		getSupportedFrameworks: (): IFuture<Server.FrameworkVersion[]> => {
+			return (() => {
+				return [{ DisplayName: "version_1_0_0", Version: "1.0.0" }, { DisplayName: "version_1_0_1", Version: "1.0.1" }]
+			}).future<Server.FrameworkVersion[]>()();
+		},
+
+		getDisplayNameForVersion: (version: string): IFuture<string> => {
+			return ((): string => {
+				return "version_1_0_0";
+			}).future<string>()();
+		}
+	});
+
+	testInjector.register("mobileframework|*print", printVersionsFile.PrintFrameworkVersionsCommand);
+	testInjector.register("mobileframework|set", setVersionFile.SetFrameworkVersionCommand);
+
+	return testInjector;
+}
+
+describe("mobileframework", () => {
+	describe("MobileFrameworkCommandParameter", () => {
+		it("fails when version is not in correct format", () => {
+			var testInjector = createTestInjector();
+			var message: string;
+			var mobileFwCP: ICommandParameter = new setVersionFile.MobileFrameworkCommandParameter(testInjector.resolve("cordovaMigrationService"),
+				testInjector.resolve("project"), testInjector.resolve("errors"));
+			try {
+				mobileFwCP.validate("1").wait();
+			} catch(e) {
+				message = e.message;
+			}
+
+			assert.isTrue(message.indexOf("not in correct format") > -1);
+		});
+
+		it("fails when version is not supported", () => {
+			var testInjector = createTestInjector();
+			var message: string;
+			var mobileFwCP: ICommandParameter = new setVersionFile.MobileFrameworkCommandParameter(testInjector.resolve("cordovaMigrationService"),
+				testInjector.resolve("project"), testInjector.resolve("errors"));
+			try {
+				mobileFwCP.validate("1.0.5").wait();
+			} catch(e) {
+				message = e.message;
+			}
+
+			assert.isTrue(message.indexOf("not a supported version") > -1);
+		});
+
+		it("returns true when version is correct", () => {
+			var testInjector = createTestInjector();
+			var mobileFwCP: ICommandParameter = new setVersionFile.MobileFrameworkCommandParameter(testInjector.resolve("cordovaMigrationService"),
+				testInjector.resolve("project"), testInjector.resolve("errors"));
+
+			assert.isTrue(mobileFwCP.validate("1.0.0").wait());
+		});
+	});
+
+	describe("print", () => {
+		it("prints display names of supported versions", () => {
+			var expectedOutput = ["version_1_0_0", "version_1_0_1"];
+			var testInjector = createTestInjector();
+			var message: string;
+			testInjector.register("logger", {
+				info: (formatStr: string, ...args: string[]) => {
+					message += formatStr;
+				}
+			});
+			var mbFrm: ICommand = testInjector.resolve("mobileframework|*print");
+			mbFrm.execute([]).wait();
+			_.each(expectedOutput, version => {
+				assert.isTrue(message.indexOf(version) > -1);
+			});
+		});
+	});
+});


### PR DESCRIPTION
Add new commands for easier checking of the supported framework versions and changing it in the project. The commands are mobileframework print (default one) and mobileframework set. Use the new server API and FrameworkVersion in order to show which versions are experimental.
Should be merged after https://github.com/Icenium/Ice/pull/2586

http://teampulse.telerik.com/view#item/279602
