### PR TITLE
Fix ts compilation

### DIFF
--- a/lib/hooks/typescript-compilation.ts
+++ b/lib/hooks/typescript-compilation.ts
@@ -4,12 +4,13 @@ import path = require("path");
 
 require("./../bootstrap");
 import fiberBootstrap = require("./../fiber-bootstrap");
+import commonHelpers = require("./../common/helpers");
 fiberBootstrap.run(() => {
 	$injector.require("typeScriptCompilationService", "./common/services/typescript-compilation-service");
 
 	var project: Project.IProject = $injector.resolve("project");
 	project.ensureProject();
-	var projectFiles = project.enumerateProjectFiles().wait();
+	var projectFiles = commonHelpers.enumerateFilesInDirectorySync(project.getProjectDir().wait());
 
 	var typeScriptFiles = _.filter(projectFiles, file => path.extname(file) === ".ts");
 	var definitionFiles = _.filter(typeScriptFiles, file => file.endsWith(".d.ts"));


### PR DESCRIPTION
http://teampulse.telerik.com/view#item/281768

We shouldn't use `project.enumerateProjectFiles` because .abignore rules are triggered inside the function.
