### PR TITLE
Fix printing of error message when .net framework 4.0 is missing

### DIFF
--- a/lib/host-info.ts
+++ b/lib/host-info.ts
@@ -31,7 +31,7 @@ export function isDotNet40Installed(message: string) : IFuture<boolean> {
 	});
 	regKey.get("Version", (err: Error, value: string) => {
 		if (err) {
-			this.$errors.fail({ formatStr: message, suppressCommandHelp: true });
+			(<IErrors>$injector.resolve("$errors")).fail({ formatStr: message, suppressCommandHelp: true });
 		}
 		result.return(true);
 	});


### PR DESCRIPTION
Manually resolve the dependency through Yok

refs http://teampulse.telerik.com/view#item/281235
