### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "cookie": "0.1.0",
     "express": "4.8.5",
     "ffi": "https://github.com/icenium/node-ffi/tarball/master",
-    "fibers": "https://github.com/icenium/node-fibers/tarball/master",
+    "fibers": "https://github.com/icenium/node-fibers/tarball/v1.0.2.0",
     "filesize": "2.0.3",
     "hex": "0.0.1",
     "iconv-lite": "0.4.3",
@@ -88,6 +88,6 @@
   "bundledDependencies": [],
   "license": "Apache-2.0",
   "engines": {
-    "node": "~0.10.22"
+    "node": ">=0.10.26 <0.10.34 || >=0.10.35"
   }
 }


### PR DESCRIPTION
Update package.json to use v1.0.2.0 of icenium fibers fork and updated node requirements to exclude version 0.10.34.

Fixes http://teampulse.telerik.com/view#item/282812 and http://teampulse.telerik.com/view#item/282652