### PR TITLE
Init command to determine project type

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -68,6 +68,7 @@ $injector.require("projectPropertiesService", "./services/project-properties-ser
 $injector.requireCommand("create|hybrid", "./commands/project");
 $injector.requireCommand("create|native", "./commands/project");
 $injector.requireCommand("create|website", "./commands/project");
+$injector.requireCommand("init|*unknown", "./commands/project");
 $injector.requireCommand("init|hybrid", "./commands/project");
 $injector.requireCommand("init|native", "./commands/project");
 $injector.requireCommand("init|website", "./commands/project");

--- a/lib/commands/project.ts
+++ b/lib/commands/project.ts
@@ -1,12 +1,16 @@
 ///<reference path="../.d.ts"/>
 "use strict";
 import projectTypes = require("../project-types");
+import MobileHelper = require("../common/mobile/mobile-helper");
+import util = require("util");
+import path = require("path");
+import Future = require("fibers/future")
 
 export class ProjectCommandBase implements ICommand {
-	constructor(private $project: Project.IProject,
-				private $errors: IErrors,
+	constructor(protected $project: Project.IProject,
+				protected $errors: IErrors,
 				protected $projectNameValidator?: IProjectNameValidator) {
-		if (this.$project.projectData) {
+		if(this.$project.projectData) {
 			this.$errors.fail("Cannot create project in this location because the specified directory is part of an existing project. Switch to or specify another location and try again.");
 		}
 	}
@@ -14,7 +18,9 @@ export class ProjectCommandBase implements ICommand {
 	public enableHooks = false;
 
 	public execute(args: string[]): IFuture<void> {
-		return null;
+		return (() => {
+			throw new Error("Unexpected error. Please, contact Telerik Support and provide the following error message for reference: 'ProjectCommandBase execute method has been called'.");
+		}).future<void>()();
 	}
 
 	allowedParameters: ICommandParameter[] = [];
@@ -28,25 +34,114 @@ export class ProjectCommandBase implements ICommand {
 	}
 }
 
+export class FileDescriptor {
+	constructor(public path: string, public type: string) { }
+}
+
+export class InitProjectCommandBase extends ProjectCommandBase {
+	private cordovaFiles: FileDescriptor[];
+	protected projectDir: string;
+	protected tnsModulesDir: FileDescriptor;
+	protected bootstrapFile: FileDescriptor;
+	protected indexHtml: FileDescriptor;
+	protected projectFilesDescriptors: any;
+
+	constructor(protected $project: Project.IProject,
+				protected $errors: IErrors,
+				protected $fs: IFileSystem,
+				protected $logger: ILogger,
+				protected $projectNameValidator?: IProjectNameValidator) {
+		super($project, $errors, $projectNameValidator);
+
+		this.projectDir = this.$project.getNewProjectDir();
+		this.tnsModulesDir = new FileDescriptor(path.join(this.projectDir, "tns_modules"), "directory");
+		this.bootstrapFile = new FileDescriptor(path.join(this.projectDir, "app", "bootstrap.js"), "file");
+		this.indexHtml = new FileDescriptor(path.join(this.projectDir, "index.html"), "file");
+		this.cordovaFiles = _.map(Object.keys(MobileHelper.platformCapabilities), platform => {
+			return new FileDescriptor(util.format("cordova.%s.js", platform).toLowerCase(), "file");
+		});
+
+		this.generateMandatoryAndForbiddenFiles();
+	}
+
+	protected isProjectType(projectType: string): IFuture<boolean> {
+		return (() => {
+			var result = true;
+			var projectData = this.projectFilesDescriptors[projectType];
+
+			_.each(projectData.mandatoryFiles, (file: FileDescriptor) => {
+				if(!this.$fs.exists(file.path).wait()) {
+					this.$logger.trace("Missing %s %s. The project type is not %s.", file.path, file.type, projectType);
+					result = false;
+					// break execution of _.each
+					return false;
+				}
+			});
+
+			if(result) {
+				_.each(projectData.forbiddenFiles, (file: FileDescriptor) => {
+					if(this.$fs.exists(file.path).wait()) {
+						this.$logger.trace("Found %s %s. The project type is not %s.", file.path, file.type, projectType);
+						result = false;
+						// break execution of _.each
+						return false;
+					}
+				});
+			}
+
+			return result;
+		}).future<boolean>()();
+	}
+
+	
+	private generateMandatoryAndForbiddenFiles() {
+		this.projectFilesDescriptors = {
+			"Apache Cordova": {
+				"mandatoryFiles": this.cordovaFiles,
+				"forbiddenFiles": [this.bootstrapFile, this.tnsModulesDir]
+			},
+
+			"NativeScript": {
+				"mandatoryFiles": [this.bootstrapFile, this.tnsModulesDir],
+			},
+
+			"Mobile Website": {
+				"mandatoryFiles": [this.indexHtml],
+			}
+		};
+
+		this.projectFilesDescriptors["NativeScript"].forbiddenFiles = this.cordovaFiles.concat([this.indexHtml]);
+		this.projectFilesDescriptors["Mobile Website"].forbiddenFiles = this.cordovaFiles.concat([this.bootstrapFile, this.tnsModulesDir]);
+	}
+
+	public execute(args: string[]): IFuture<void> {
+		return (() => {
+			throw new Error("Unexpected error. Please, contact Telerik Support and provide the following error message for reference: 'InitProjectCommandBase execute method has been called'.");
+		}).future<void>()();
+	}
+
+	allowedParameters: ICommandParameter[] = [];
+}
+
 export class CreateHybridCommand extends ProjectCommandBase {
 	constructor($project: Project.IProject,
 		$errors: IErrors,
-        $projectNameValidator: IProjectNameValidator) {
+		$projectNameValidator: IProjectNameValidator) {
 		super($project, $errors, $projectNameValidator);
 	}
 
 	public execute(args: string[]): IFuture<void> {
 		return this.createNewProject(projectTypes.Cordova, args[0]);
 	}
-    
+
 	allowedParameters = [new NameParameter(this.$projectNameValidator)];
 }
 $injector.registerCommand("create|hybrid", CreateHybridCommand);
 
 export class CreateWebSiteCommand extends ProjectCommandBase {
 	constructor($project: Project.IProject,
-				$errors: IErrors,
-				$projectNameValidator: IProjectNameValidator) {
+		$errors: IErrors,
+		$projectNameValidator: IProjectNameValidator) {
 		super($project, $errors, $projectNameValidator);
 	}
 
@@ -88,10 +183,39 @@ export class CreateNativeCommand extends ProjectCommandBase {
 }
 $injector.registerCommand("create|native", CreateNativeCommand);
 
-export class InitHybridCommand extends ProjectCommandBase {
+export class InitCommand extends InitProjectCommandBase {
 	constructor($project: Project.IProject,
-		$errors: IErrors) {
-		super($project, $errors);
+		$errors: IErrors,
+		$fs: IFileSystem,
+		$logger: ILogger) {
+		super($project, $errors, $fs, $logger);
+	}
+
+	public execute(args: string[]): IFuture<void> {
+		return (() => {
+			if(this.isProjectType("Apache Cordova").wait()) {
+				this.$logger.info("Attempting to initialize Apache Cordova project.");
+				this.createProjectFileFromExistingProject(projectTypes.Cordova).wait();
+			} else if(this.isProjectType("NativeScript").wait()) {
+				this.$logger.info("Attempting to initialize  NativeScript project.");
+				this.createProjectFileFromExistingProject(projectTypes.NativeScript).wait();
+			} else if(this.isProjectType("Mobile Website").wait()) {
+				this.$logger.info("Attempting to initialize Mobile Website project.");
+				this.createProjectFileFromExistingProject(projectTypes.MobileWebsite).wait();
+			} else {
+				this.$errors.fail("Cannot determine project type. Specify project type and try again.");
+			}
+		}).future<void>()();
+	}
+}
+$injector.registerCommand("init|*unknown", InitCommand);
+
+export class InitHybridCommand extends InitProjectCommandBase {
+	constructor($project: Project.IProject,
+		$errors: IErrors,
+		$fs: IFileSystem,
+		$logger: ILogger) {
+		super($project, $errors, $fs, $logger);
 	}
 
 	public execute(args: string[]): IFuture<void> {
@@ -100,10 +224,12 @@ export class InitHybridCommand extends ProjectCommandBase {
 }
 $injector.registerCommand("init|hybrid", InitHybridCommand);
 
-export class InitNativeCommand extends ProjectCommandBase {
+export class InitNativeCommand extends InitProjectCommandBase {
 	constructor($project: Project.IProject,
-		$errors: IErrors) {
-		super($project, $errors);
+		$errors: IErrors,
+		$fs: IFileSystem,
+		$logger: ILogger) {
+		super($project, $errors, $fs, $logger);
 	}
 
 	public execute(args: string[]): IFuture<void> {
@@ -112,10 +238,12 @@ export class InitNativeCommand extends ProjectCommandBase {
 }
 $injector.registerCommand("init|native", InitNativeCommand);
 
-export class InitWebsiteCommand extends ProjectCommandBase {
+export class InitWebsiteCommand extends InitProjectCommandBase {
 	constructor($project: Project.IProject,
-				$errors: IErrors) {
-		super($project, $errors);
+		$errors: IErrors,
+		$fs: IFileSystem,
+		$logger: ILogger) {
+		super($project, $errors, $fs, $logger);
 	}
 
 	public execute(args: string[]): IFuture<void> {

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -160,7 +160,7 @@ declare module Project {
 		getTempDir(extraSubdir?: string): IFuture<string>;
 		saveProject(projectDir?: string): IFuture<void>;
 		validateProjectProperty(property: string, args: string[], mode: string): IFuture<boolean>;
-		getNewProjectDir(): void;
+		getNewProjectDir(): string;
 		getProperty(propertyName: string, configuration: string): any;
 		setProperty(propertyName: string, value: any, configuration: string): void;
 		configurationSpecificData: IDictionary<IDictionary<any>>;

--- a/lib/project.ts
+++ b/lib/project.ts
@@ -507,7 +507,7 @@ export class Project implements Project.IProject {
 		return properties;
 	}
 
-	public getNewProjectDir() {
+	public getNewProjectDir(): string {
 		return options.path || process.cwd();
 	}
 

--- a/resources/help.txt
+++ b/resources/help.txt
@@ -203,13 +203,16 @@ Options:
 --[init]--
 
 Usage:
+    $appbuilder init
     $appbuilder init [<Command>]
 
-Initializes an existing hybrid or native project for development. You must run the init command with a related command.
+Initializes an existing project for development. 
+The command attempts to determine the project type based on the files in the working directory. To specify the project type yourself, run $ appbuilder init <Command>
 
 <Command> is a related command that extends the init command. You can run the following related commands:
     hybrid - Initializes an existing Apache Cordova project for development in the current directory.
     native - Initializes an existing NativeScript project for development in the current directory.
+    website - Initializes an existing Mobile Website project for development in the current directory.
 
 --[/]--
 
@@ -218,7 +221,7 @@ Initializes an existing hybrid or native project for development. You must run t
 Usage:
     $ appbuilder init hybrid [--appid <App ID>]
 
-Initializes an existing Apache Cordova project for development in the current directory. If the folder contains an existing AppBuilder project (created with
+Initializes an existing Apache Cordova project for development in the current directory. If the directory contains an existing AppBuilder project (created with
 the Telerik AppBuilder extension for Visual Studio or synchronized from GitHub), the project retains the existing project configuration.
 
 Options:
@@ -234,7 +237,7 @@ Options:
 Usage:
     $ appbuilder init native [--appid <App ID>]
 
-Initializes an existing NativeScript project for development in the current directory. If the folder contains an existing AppBuilder project (created with
+Initializes an existing NativeScript project for development in the current directory. If the directory contains an existing AppBuilder project (created with
 the Telerik AppBuilder extension for Visual Studio or synchronized from GitHub), the project retains the existing project configuration.
 
 Options:
@@ -242,6 +245,16 @@ Options:
         alphanumeric strings, separated by a dot (.). Each string must start with a letter.
         The application identifier corresponds to the Bundle ID for iOS apps and to the package identifier for Android apps.
         If not specified, the application identifier is set to com.telerik.<current directory name>.
+
+--[/]--
+
+--[init|website]--
+
+Usage:
+    $ appbuilder init website
+
+Initializes an existing Mobile Website project for development in the current directory. If the directory contains an existing AppBuilder project 
+synchronized from GitHub, the project retains the existing project configuration.
 
 --[/]--
 

--- a/test/project.ts
+++ b/test/project.ts
@@ -12,6 +12,8 @@ import temp = require("temp");
 import options = require("./../lib/options");
 import helpers = require("../lib/helpers");
 import projectTypes = require("../lib/project-types");
+import MobileHelper = require("../lib/common/mobile/mobile-helper");
+import util = require("util");
 var assert = require("chai").assert;
 temp.track();
 
@@ -87,7 +89,7 @@ describe("project integration tests", () => {
 			delete testProperties.WP8PublisherID;
 
 			assert.deepEqual(Object.keys(testProperties).sort(), Object.keys(correctProperties).sort());
-			for (var key in testProperties) {
+			for(var key in testProperties) {
 				assert.deepEqual(testProperties[key], correctProperties[key]);
 			}
 		});
@@ -118,9 +120,159 @@ describe("project integration tests", () => {
 			delete testProperties.WP8PublisherID;
 
 			assert.deepEqual(Object.keys(testProperties).sort(), Object.keys(correctProperties).sort());
-			for (var key in testProperties) {
+			for(var key in testProperties) {
 				assert.deepEqual(testProperties[key], correctProperties[key]);
 			}
+		});
+	});
+
+	describe("Init command mandatory files tests", () => {
+		describe("NativeScript project", () => {
+			it("Blank template has all mandatory files)", () => {
+				var options: any = require("./../lib/options");
+				var tempFolder = temp.mkdirSync("template");
+				var projectName = "Test";
+
+				options.path = tempFolder;
+				options.template = "Blank";
+				options.appid = "com.telerik.Test";
+
+				project.createNewProject(projectTypes.NativeScript, projectName).wait();
+				var projectDir = project.getProjectDir().wait();
+				var bootstrapJsFile = path.join(projectDir, "app", "bootstrap.js");
+				assert.isTrue(fs.existsSync(bootstrapJsFile), "NativeScript Blank template does not contain mandatory 'app/bootstrap.js' file. This file is required in init command. You should check if this is problem with the template or change init command to use another file.");
+
+				var tnsDir = path.join(projectDir, "tns_modules");
+				assert.isTrue(fs.existsSync(tnsDir), "NativeScript Blank template does not contain mandatory 'tns_modules' directory. This directory is required in init command. You should check if this is problem with the template or change init command to use another file.");
+			});
+
+			it("TypeScript.Blank template has mandatory files)", () => {
+				var options: any = require("./../lib/options");
+				var tempFolder = temp.mkdirSync("template");
+				var projectName = "Test";
+
+				options.path = tempFolder;
+				options.template = "TypeScript.Blank";
+				options.appid = "com.telerik.Test";
+
+				project.createNewProject(projectTypes.NativeScript, projectName).wait();
+				var projectDir = project.getProjectDir().wait();
+				var bootstrapJsFile = path.join(projectDir, "app", "bootstrap.js");
+				assert.isTrue(fs.existsSync(bootstrapJsFile), "NativeScript TypeScript Blank template does not contain mandatory 'app/bootstrap.js' file. This file is required in init command. You should check if this is problem with the template or change init command to use another file.");
+
+				var tnsDir = path.join(projectDir, "tns_modules");
+				assert.isTrue(fs.existsSync(tnsDir), "NativeScript TypeScript.Blank template does not contain mandatory 'tns_modules' directory. This directory is required in init command. You should check if this is problem with the template or change init command to use another file.");
+			});
+		});
+
+		describe("Cordova project", () => {
+			it("Blank template has all mandatory files)", () => {
+				var options: any = require("./../lib/options");
+				var tempFolder = temp.mkdirSync("template");
+				var projectName = "Test";
+
+				options.path = tempFolder;
+				options.template = "Blank";
+				options.appid = "com.telerik.Test";
+
+				project.createNewProject(projectTypes.Cordova, projectName).wait();
+				var projectDir = project.getProjectDir().wait();
+
+				var cordovaMandatoryFiles = _.forEach(Object.keys(MobileHelper.platformCapabilities), platform => {
+					var cordovaFile = util.format("cordova.%s.js", platform).toLowerCase();
+					assert.isTrue(fs.existsSync(path.join(projectDir, cordovaFile)), util.format("Cordova Blank template does not contain mandatory '%s' file. This file is required in init command. You should check if this is problem with the template or change init command to use another file.", cordovaFile));
+				});
+			});
+
+			it("TypeScript.Blank template has mandatory files)", () => {
+				var options: any = require("./../lib/options");
+				var tempFolder = temp.mkdirSync("template");
+				var projectName = "Test";
+
+				options.path = tempFolder;
+				options.template = "TypeScript.Blank";
+				options.appid = "com.telerik.Test";
+
+				project.createNewProject(projectTypes.Cordova, projectName).wait();
+				var projectDir = project.getProjectDir().wait();
+
+				var cordovaMandatoryFiles = _.forEach(Object.keys(MobileHelper.platformCapabilities), platform => {
+					var cordovaFile = util.format("cordova.%s.js", platform).toLowerCase();
+					assert.isTrue(fs.existsSync(path.join(projectDir, cordovaFile)), util.format("Cordova TypeScript.Blank template does not contain mandatory '%s' file. This file is required in init command. You should check if this is problem with the template or change init command to use another file.", cordovaFile));
+				});
+			});
+
+			it("Friends template has mandatory files)", () => {
+				var options: any = require("./../lib/options");
+				var tempFolder = temp.mkdirSync("template");
+				var projectName = "Test";
+
+				options.path = tempFolder;
+				options.template = "Friends";
+				options.appid = "com.telerik.Test";
+
+				project.createNewProject(projectTypes.Cordova, projectName).wait();
+				var projectDir = project.getProjectDir().wait();
+
+				var cordovaMandatoryFiles = _.forEach(Object.keys(MobileHelper.platformCapabilities), platform => {
+					var cordovaFile = util.format("cordova.%s.js", platform).toLowerCase();
+					assert.isTrue(fs.existsSync(path.join(projectDir, cordovaFile)), util.format("Cordova Friends template does not contain mandatory '%s' file. This file is required in init command. You should check if this is problem with the template or change init command to use another file.", cordovaFile));
+				});
+			});
+
+			it("KendoUI.Drawer template has mandatory files)", () => {
+				var options: any = require("./../lib/options");
+				var tempFolder = temp.mkdirSync("template");
+				var projectName = "Test";
+
+				options.path = tempFolder;
+				options.template = "KendoUI.Drawer";
+				options.appid = "com.telerik.Test";
+
+				project.createNewProject(projectTypes.Cordova, projectName).wait();
+				var projectDir = project.getProjectDir().wait();
+
+				var cordovaMandatoryFiles = _.forEach(Object.keys(MobileHelper.platformCapabilities), platform => {
+					var cordovaFile = util.format("cordova.%s.js", platform).toLowerCase();
+					assert.isTrue(fs.existsSync(path.join(projectDir, cordovaFile)), util.format("Cordova KendoUI.Drawer template does not contain mandatory '%s' file. This file is required in init command. You should check if this is problem with the template or change init command to use another file.", cordovaFile));
+				});
+			});
+
+			it("KendoUI.Empty template has mandatory files)", () => {
+				var options: any = require("./../lib/options");
+				var tempFolder = temp.mkdirSync("template");
+				var projectName = "Test";
+
+				options.path = tempFolder;
+				options.template = "KendoUI.Empty";
+				options.appid = "com.telerik.Test";
+
+				project.createNewProject(projectTypes.Cordova, projectName).wait();
+				var projectDir = project.getProjectDir().wait();
+
+				var cordovaMandatoryFiles = _.forEach(Object.keys(MobileHelper.platformCapabilities), platform => {
+					var cordovaFile = util.format("cordova.%s.js", platform).toLowerCase();
+					assert.isTrue(fs.existsSync(path.join(projectDir, cordovaFile)), util.format("Cordova KendoUI.Empty template does not contain mandatory '%s' file. This file is required in init command. You should check if this is problem with the template or change init command to use another file.", cordovaFile));
+				});
+			});
+
+			it("KendoUI.TabStrip template has mandatory files)", () => {
+				var options: any = require("./../lib/options");
+				var tempFolder = temp.mkdirSync("template");
+				var projectName = "Test";
+
+				options.path = tempFolder;
+				options.template = "KendoUI.TabStrip";
+				options.appid = "com.telerik.Test";
+
+				project.createNewProject(projectTypes.Cordova, projectName).wait();
+				var projectDir = project.getProjectDir().wait();
+
+				var cordovaMandatoryFiles = _.forEach(Object.keys(MobileHelper.platformCapabilities), platform => {
+					var cordovaFile = util.format("cordova.%s.js", platform).toLowerCase();
+					assert.isTrue(fs.existsSync(path.join(projectDir, cordovaFile)), util.format("Cordova KendoUI.TabStrip template does not contain mandatory '%s' file. This file is required in init command. You should check if this is problem with the template or change init command to use another file.", cordovaFile));
+				});
+			});
 		});
 	});
 
@@ -157,7 +309,7 @@ describe("project integration tests", () => {
 });
 
 describe("project unit tests", () => {
-	var project: Project.IProject, projectProperties: IProjectPropertiesService,  testInjector: IInjector, propSchemaCordova: any;
+	var project: Project.IProject, projectProperties: IProjectPropertiesService, testInjector: IInjector, propSchemaCordova: any;
 	before(() => {
 		testInjector = createTestInjector();
 		testInjector.register("fs", stubs.FileSystemStub);
@@ -177,52 +329,52 @@ describe("project unit tests", () => {
 
 	describe("updateProjectProperty", () => {
 		it("sets unconstrained string property", () => {
-			var projectData = {DisplayName: "wrong"};
+			var projectData = { DisplayName: "wrong" };
 			projectProperties.updateProjectProperty(projectData, "set", "DisplayName", ["fine"], propSchemaCordova).wait();
 			assert.equal("fine", projectData.DisplayName);
 		});
 
 		it("sets string property with custom validator", () => {
-			var projectData = {ProjectName: "wrong"};
+			var projectData = { ProjectName: "wrong" };
 			projectProperties.updateProjectProperty(projectData, "set", "ProjectName", ["fine"], propSchemaCordova).wait();
 			assert.equal("fine", projectData.ProjectName);
 			assert.ok(mockProjectNameValidator.validateCalled);
 		});
 
 		it("disallows 'add' on non-flag property", () => {
-			var projectData = {ProjectName: "wrong"};
+			var projectData = { ProjectName: "wrong" };
 			assert.throws(() => projectProperties.updateProjectProperty(projectData, "add", "ProjectName", ["fine"], propSchemaCordova).wait());
 		});
 
 		it("disallows 'del' on non-flag property", () => {
-			var projectData = {ProjectName: "wrong"};
+			var projectData = { ProjectName: "wrong" };
 			assert.throws(() => projectProperties.updateProjectProperty(projectData, "del", "ProjectName", ["fine"], propSchemaCordova).wait());
 		});
 
 		it("sets bundle version when given proper input", () => {
-			var projectData = {"BundleVersion": "0"};
+			var projectData = { "BundleVersion": "0" };
 			projectProperties.updateProjectProperty(projectData, "set", "BundleVersion", ["10.20.30"], propSchemaCordova).wait();
 			assert.equal("10.20.30", projectData.BundleVersion);
 		});
 
 		it("throws on invalid bundle version string", () => {
-			var projectData = {"BundleVersion": "0"};
+			var projectData = { "BundleVersion": "0" };
 			assert.throws(() => projectProperties.updateProjectProperty(projectData, "set", "BundleVersion", ["10.20.30c"], propSchemaCordova).wait());
 		});
 
 		it("sets enumerated property", () => {
-			var projectData = {iOSStatusBarStyle: "Default"};
+			var projectData = { iOSStatusBarStyle: "Default" };
 			projectProperties.updateProjectProperty(projectData, "set", "iOSStatusBarStyle", ["Hidden"], propSchemaCordova).wait();
 			assert.equal("Hidden", projectData.iOSStatusBarStyle);
 		});
 
 		it("disallows unrecognized values for enumerated property", () => {
-			var projectData = {iOSStatusBarStyle: "Default"};
+			var projectData = { iOSStatusBarStyle: "Default" };
 			assert.throws(() => projectProperties.updateProjectProperty(projectData, "set", "iOSStatusBarStyle", ["does not exist"], propSchemaCordova).wait());
 		});
 
 		it("appends to verbatim enumerated collection property", () => {
-			var projectData: any = {DeviceOrientations: []};
+			var projectData: any = { DeviceOrientations: [] };
 			projectProperties.updateProjectProperty(projectData, "add", "DeviceOrientations", ["Portrait"], propSchemaCordova).wait();
 			assert.deepEqual(["Portrait"], projectData.DeviceOrientations);
 			projectProperties.updateProjectProperty(projectData, "add", "DeviceOrientations", ["Landscape"], propSchemaCordova).wait();
@@ -230,7 +382,7 @@ describe("project unit tests", () => {
 		});
 
 		it("appends to enumerated collection property with shorthand", () => {
-			var projectData: any = {iOSDeviceFamily: []};
+			var projectData: any = { iOSDeviceFamily: [] };
 			projectProperties.updateProjectProperty(projectData, "add", "iOSDeviceFamily", ["iPhone"], propSchemaCordova).wait();
 			assert.deepEqual(["1"], projectData.iOSDeviceFamily);
 			projectProperties.updateProjectProperty(projectData, "add", "iOSDeviceFamily", ["iPad"], propSchemaCordova).wait();
@@ -238,13 +390,13 @@ describe("project unit tests", () => {
 		});
 
 		it("appends multiple values to enumerated collection property", () => {
-			var projectData: any = {iOSDeviceFamily: []};
+			var projectData: any = { iOSDeviceFamily: [] };
 			projectProperties.updateProjectProperty(projectData, "add", "iOSDeviceFamily", ["iPhone", "iPad"], propSchemaCordova).wait();
 			assert.deepEqual(["1", "2"], projectData.iOSDeviceFamily);
 		});
 
 		it("removes from enumerated collection property", () => {
-			var projectData: any = {DeviceOrientations: ["Landscape", "Portrait"]};
+			var projectData: any = { DeviceOrientations: ["Landscape", "Portrait"] };
 			projectProperties.updateProjectProperty(projectData, "del", "DeviceOrientations", ["Portrait"], propSchemaCordova).wait();
 			assert.deepEqual(["Landscape"], projectData.DeviceOrientations);
 			projectProperties.updateProjectProperty(projectData, "del", "DeviceOrientations", ["Portrait"], propSchemaCordova).wait();
@@ -252,18 +404,18 @@ describe("project unit tests", () => {
 		});
 
 		it("disallows unrecognized values for enumerated collection property", () => {
-			var projectData: any = {DeviceOrientations: []};
+			var projectData: any = { DeviceOrientations: [] };
 			assert.throws(() => projectProperties.updateProjectProperty(projectData, "add", "DeviceOrientations", ["Landscape", "bar"], propSchemaCordova).wait());
 		});
 
 		it("makes case-insensitive comparisons of property name", () => {
-			var projectData: any = {DeviceOrientations: []};
+			var projectData: any = { DeviceOrientations: [] };
 			projectProperties.updateProjectProperty(projectData, "add", "deviceorientations", ["Landscape"], propSchemaCordova).wait();
 			assert.deepEqual(["Landscape"], projectData.DeviceOrientations);
 		});
 
 		it("makes case-insensitive comparisons of property values", () => {
-			var projectData: any = {DeviceOrientations: []};
+			var projectData: any = { DeviceOrientations: [] };
 			projectProperties.updateProjectProperty(projectData, "add", "DeviceOrientations", ["landscape"], propSchemaCordova).wait();
 			assert.deepEqual(["Landscape"], projectData.DeviceOrientations);
 		});


### PR DESCRIPTION
Add init|*unknown command which can be used to automatically determine project type.
Add logic to determine project type when executing appbuilder init based on the files in the directory:
 - NativeScript project must contain tns_modules dir and app/bootstrap.js file.
 - Hybrid project must contain cordova.ios.js, cordova.android.js and cordova.wp8.js
 - Mobile Website project must contain index.html

Additional logic:
 - NativeScript project cannot contain index.html or cordova.*.js files or index.html.
 - Hybrid project and Mobile Website projects cannot contain tns_modules dir and app\bootstrap.js file.

If we are unable to determine project type, error message is shown and command's help is printed.

http://teampulse.telerik.com/view#item/269498