### PR TITLE
Use ios-sim from master

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "filesize": "2.0.3",
     "hex": "0.0.1",
     "iconv-lite": "0.4.3",
-    "ios-sim-portable": "1.0.0",
+    "ios-sim-portable": "https://github.com/telerik/ios-sim-portable/tarball/master",
     "ip": "0.3.2",
     "lodash": "2.4.1",
     "log4js": "0.6.9",


### PR DESCRIPTION
Update package.json to use ios-sim from its master branch. This is temporary in order to be able to test latest changes of node fibers (which are merged in ios-sim master). Related to http://teampulse.telerik.com/view#item/282879