### PR TITLE
Fix usage of shorthand options

### DIFF
--- a/lib/options.ts
+++ b/lib/options.ts
@@ -45,7 +45,14 @@ if(hostInfo.isWindows()) {
 commonOptions.setProfileDir(defaultProfileDir);
 var parsed = helpers.getParsedOptions(knownOpts, shorthands, "appbuilder");
 
-Object.keys(parsed).forEach((opt) => exports[opt] = parsed[opt]);
+Object.keys(parsed).forEach(opt => {
+	var key = opt;
+	if(shorthands[opt]) {
+		key = shorthands[opt];
+	}
+
+	exports[key] = parsed[opt];
+});
 exports.knownOpts = knownOpts;
 
 declare var exports: any;


### PR DESCRIPTION
Fix usage of shorthands, so when you specify -t for example to really use specified template. Update common lib where shorthands for help command had been added.

http://teampulse.telerik.com/view#item/284030