### PR TITLE
Turn on downloading of debugging tools & simulator from the CDN.

### DIFF
--- a/config/config-release.json
+++ b/config/config-release.json
@@ -1,5 +1,6 @@
 {
 	"AB_SERVER": "platform.telerik.com",
 	"AB_SERVER_PROTO": "https",
-	"DEBUG": false
+	"DEBUG": false,
+	"USE_CDN_FOR_EXTENSION_DOWNLOAD": true
 }


### PR DESCRIPTION
Download times went from 03:26 min to 00:17 min.