### PR TITLE
Improve error when unable to pass simulator params

### DIFF
--- a/lib/services/project-simulator-service.ts
+++ b/lib/services/project-simulator-service.ts
@@ -33,7 +33,7 @@ export class CordovaSimulatorService implements IProjectSimulatorService {
 		return (() => {
 			var pluginsPath = this.prepareCordovaPlugins(simulatorPackageName).wait();
 			var projectData = this.$project.projectData;
-            var corePlugins = this.$project.getProperty("CorePlugins", "debug");
+			var corePlugins = this.$project.getProperty("CorePlugins", "debug");
 
 			return [
 				"--statusbarstyle", projectData.iOSStatusBarStyle,
@@ -41,7 +41,7 @@ export class CordovaSimulatorService implements IProjectSimulatorService {
 				"--orientations", projectData.DeviceOrientations.join(";"),
 				"--corepluginspath", pluginsPath,
 				"--supportedplatforms", this.$project.getProjectTargets().wait().join(";"),
-				"--plugins", corePlugins.join(";")
+				"--plugins", (corePlugins || []).join(";")
 			];
 		}).future<string[]>()();
 	}


### PR DESCRIPTION
Add correct set of --plugins when starting simulator, in cases when CorePlugins are not defined.

Fixes http://teampulse.telerik.com/view#item/284384