### PR TITLE
Add --validValue option to prop print command

### DIFF
--- a/lib/commands/prop/prop-add.ts
+++ b/lib/commands/prop/prop-add.ts
@@ -6,6 +6,7 @@ export class AddProjectPropertyCommand extends ProjectPropertyCommandBaseLib.Pro
 	constructor($staticConfig: IStaticConfig,
 		$injector: IInjector) {
 		super($staticConfig, $injector);
+		this.$project.ensureProject();
 	}
 
 	canExecute(args: string[]): IFuture<boolean> {

--- a/lib/commands/prop/prop-command-base.ts
+++ b/lib/commands/prop/prop-command-base.ts
@@ -10,9 +10,9 @@ export class ProjectPropertyCommandBase {
 		private $injector: IInjector) {
 		this.$staticConfig.triggerJsonSchemaValidation = false;
 		this.$project = this.$injector.resolve("project");
-
-		this.$project.ensureProject();
-		this.projectSchema = this.$project.getProjectSchema().wait();
+		if (this.$project.projectData) {
+			this.projectSchema = this.$project.getProjectSchema().wait();
+		}
 	}
 
 	public get completionData(): string[] {

--- a/lib/commands/prop/prop-print.ts
+++ b/lib/commands/prop/prop-print.ts
@@ -2,11 +2,15 @@
 "use strict";
 import helpers = require("./../../helpers");
 import projectPropertyCommandBaseLib = require("./prop-command-base");
+import options = require("../../options");
 
 export class PrintProjectCommand extends projectPropertyCommandBaseLib.ProjectPropertyCommandBase implements ICommand {
 	constructor($staticConfig: IStaticConfig,
 		$injector: IInjector) {
 		super($staticConfig, $injector);
+		if(!options.validValue) {
+			this.$project.ensureProject();
+		}
 	}
 
 	execute(args:string[]): IFuture<void> {
@@ -24,10 +28,7 @@ class PrintProjectCommandParameter implements ICommandParameter {
 
 	validate(validationValue: string): IFuture<boolean> {
 		return ((): boolean => {
-			this.$project.ensureProject();
-
 			return !!validationValue;
-
 		}).future<boolean>()();
 	}
 }

--- a/lib/commands/prop/prop-remove.ts
+++ b/lib/commands/prop/prop-remove.ts
@@ -6,6 +6,7 @@ export class RemoveProjectPropertyCommand extends projectPropertyCommandBaseLib.
 	constructor($staticConfig: IStaticConfig,
 		$injector: IInjector) {
 		super($staticConfig, $injector);
+		this.$project.ensureProject();
 	}
 
 	canExecute(args: string[]): IFuture<boolean> {

--- a/lib/commands/prop/prop-set.ts
+++ b/lib/commands/prop/prop-set.ts
@@ -6,6 +6,7 @@ export class SetProjectPropertyCommand extends projectPropertyCommandBaseLib.Pro
 	constructor($staticConfig: IStaticConfig,
 		$injector: IInjector) {
 		super($staticConfig, $injector);
+		this.$project.ensureProject();
 	}
 
 	canExecute(args: string[]): IFuture<boolean> {

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -195,6 +195,8 @@ interface IProjectPropertiesService {
 	completeProjectProperties(properties: any, frameworkProject: Project.IFrameworkProject): boolean;
 	updateProjectProperty(projectData: any, mode: string, property: string, newValue: any): IFuture<void>;
 	normalizePropertyName(property: string, projectData: IProjectData): string;
+	getValidValuesForProperty(propData: any): IFuture<string[]>;
+	getPropertiesForAllSupportedProjects(): IFuture<string>;
 }
 
 interface IServerConfigurationData {

--- a/lib/json-schema/json-schema-validator.ts
+++ b/lib/json-schema/json-schema-validator.ts
@@ -66,16 +66,17 @@ export class JsonSchemaValidator implements IJsonSchemaValidator {
 					result[key] = schema.extends.properties[key];
 				}
 			});
-			var projectPropertiesFilePath = this.$resources.resolvePath(util.format("project-properties-%s.json",framework.toLowerCase()));
-			if(this.$fs.exists(projectPropertiesFilePath).wait()) {
-				var fileContent = this.$fs.readJson(projectPropertiesFilePath).wait();
-				var additionalProperties = _.keys(fileContent);
-				_.each(additionalProperties, (propertyName: string) => {
-					_.each(_.keys(fileContent[propertyName]), (value: string) => {
-						result[propertyName][value] = fileContent[propertyName][value];
-					});
+		}
+
+		var projectPropertiesFilePath = this.$resources.resolvePath(util.format("project-properties-%s.json",framework.toLowerCase()));
+		if(this.$fs.exists(projectPropertiesFilePath).wait()) {
+			var fileContent = this.$fs.readJson(projectPropertiesFilePath).wait();
+			var additionalProperties = _.keys(fileContent);
+			_.each(additionalProperties, (propertyName: string) => {
+				_.each(_.keys(fileContent[propertyName]), (key: string) => {
+					result[propertyName][key] = fileContent[propertyName][key];
 				});
-			}
+			});
 		}
 
 		return result;

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -22,7 +22,9 @@ var knownOpts: any = {
 		"client": String,
 		"available": Boolean,
 		"release": Boolean,
-		"debug": Boolean
+		"debug": Boolean,
+		"valid-value": Boolean,
+		"validValue": Boolean
 	},
 	shorthands: IStringDictionary = {
 		"t": "template",

--- a/lib/project/project.d.ts
+++ b/lib/project/project.d.ts
@@ -44,8 +44,6 @@ declare module Project {
 		requiredAndroidApiLevel: number;
 		configFiles: IConfigurationFile[];
 		getTemplateFilename(name: string): string;
-		projectTemplatesString(): IFuture<string>;
-		alterPropertiesForNewProject(properties: any, projectName: string): void;
 		getValidationSchemaId(): string;
 		getProjectFileSchema(): IDictionary<any>;
 		getProjectTargets(projectDir: string): IFuture<string[]>;

--- a/lib/services/project-properties-service.ts
+++ b/lib/services/project-properties-service.ts
@@ -107,7 +107,7 @@ export class ProjectPropertiesService implements IProjectPropertiesService {
 		return normalizedPropertyName;
 	}
 
-	public getProjectSchemaHelp(): IFuture<string> {
+	public getPropertiesForAllSupportedProjects(): IFuture<string> {
 		return (() => {
 			var result: string[] = [];
 			var schemas: IDictionary<IDictionary<any>> = Object.create(null);
@@ -136,7 +136,7 @@ export class ProjectPropertiesService implements IProjectPropertiesService {
 			});
 
 			var commonProperties: IDictionary<string> = Object.create(null);
-			 _.each(commonPropertyNames, (propertyName: string) => commonProperties[propertyName] = firstArray[propertyName]);
+			_.each(commonPropertyNames, (propertyName: string) => commonProperties[propertyName] = firstArray[propertyName]);
 			result.push(this.getProjectSchemaPartHelp(commonProperties, "Common properties for all projects"));
 
 			return result.join(os.EOL + os.EOL);
@@ -161,6 +161,19 @@ export class ProjectPropertiesService implements IProjectPropertiesService {
 				}
 			}
 			return propData.range;
+		}).future<string[]>()();
+	}
+
+	public getValidValuesForProperty(propData: any): IFuture<string[]> {
+		return ((): string[] => {
+			var range = this.getPropRange(propData).wait();
+			if(range) {
+				return _.sortBy(_.values(range), (val: string) => {
+					return val.toUpperCase();
+				});
+			}
+
+			return null;
 		}).future<string[]>()();
 	}
 

--- a/resources/help.txt
+++ b/resources/help.txt
@@ -1020,11 +1020,12 @@ You must run the prop command with a related command.
 
 --[prop|print]--
 Usage:
-    $ appbuilder prop print <PropertyName>
+    $ appbuilder prop print <PropertyName> [--validValue]
 
-Shows the value for the selected project property.
+Shows the value for the selected project property. When executed without <Property Name> command prints all project properties and their values.
 
-#{projectPropertiesService.getProjectSchemaHelp}
+  --validValue - If set, prints valid values for the selected property. In case <Property Name> is not specified, command will print all valid values 
+for all project properties.
 --[/]--
 
 --[prop|add]--
@@ -1032,12 +1033,11 @@ Usage:
     $ appbuilder prop add <Property Name> <Value> [Value]*
 
 Enables more options for the selected project property, if the property accepts multiple values.
+Use $ appbuilder prop print <Property Name> --validValue to print values of the property.
 
 <Property Name> is the name of the project property as listed by $ appbuilder prop print.
 
 IMPORTANT: Do not modify the CorePlugins property with this command. Instead, use the $ appbuilder plugin commands.
-
-#{projectPropertiesService.getProjectSchemaHelp}
 --[/]--
 
 --[prop|set]--
@@ -1045,12 +1045,11 @@ Usage:
     $ appbuilder prop set <Property Name> <Value> [Value]*
 
 Sets the selected project property and overwrites its current value.
+Use $ appbuilder prop print <Property Name> --validValue to print values of the property.
 
 <Property Name> is the name of the project property as listed by $ appbuilder prop print.
 
 IMPORTANT: Do not modify the CorePlugins property with this command. Instead, use the $ appbuilder plugin commands.
-
-#{projectPropertiesService.getProjectSchemaHelp}
 --[/]--
 
 --[prop|remove]--
@@ -1061,8 +1060,6 @@ Disables options for the selected project property, if the property accepts mult
 <Property Name> is the name of the project property as listed by $ appbuilder prop print.
 
 IMPORTANT: Do not modify the CorePlugins property with this command. Instead, use the $ appbuilder plugin commands.
-
-#{projectPropertiesService.getProjectSchemaHelp}
 --[/]--
 
 --[feature-usage-tracking]--


### PR DESCRIPTION
Add validValue to options. When it is specified, all valid values of the requested property will be printed. Improve prop print command to work in the following way:
I. inside project dir:
     1. $ appbuilder prop print -> prints all properties of current project and their current values
     2. $ appbuilder prop print --validValue -> prints all properties valid for the current project and all valid values for each of them.
     3. $ appbuilder prop print <PropName> -> prints the value of the property for the current project
     4. $ appbuilder prop print <PropName> --validValue -> prints all valid values for the selected property, applicable to the current project type.

II. Outside of project dir:
     1. $ appbuilder prop print -> leads to error, that no project is found
     2. $ appbuilder prop print --validValue -> prints all properties for all projects and all valid values for each of them.
     3. $ appbuilder prop print <PropName> -> leads to error, that no project is found
     4. $ appbuilder prop print <PropName> --validValue -> prints all valid values for the selected property

Remove dynamic call from help.txt in order to make the output more readable. Remove calls to ensureProject when working with prop print command.

http://teampulse.telerik.com/view#item/284655