### PR TITLE
Allow only Cordova projects to be published in the appstore

### DIFF
--- a/lib/commands/itunes-connect.ts
+++ b/lib/commands/itunes-connect.ts
@@ -13,8 +13,8 @@ export class AppstoreApplicationCommandBase implements ICommand {
 		public $errors: IErrors) { }
 
 	execute(args: string[]): IFuture<void> {
-		return (() => {
-		}).future<void>()();
+		this.$errors.fail("This function should never execute.");
+		return null;
 	}
 
 	allowedParameters: ICommandParameter[] = [];
@@ -104,7 +104,7 @@ export class UploadApplicationCommand extends AppstoreApplicationCommandBase {
         
 	execute(args:string[]): IFuture<void> {
 		return (() => {
-			this.$project.ensureProject();
+			this.$project.ensureCordovaProject();
 			this.$loginManager.ensureLoggedIn().wait();
 
 			var application = args[0];

--- a/lib/project.ts
+++ b/lib/project.ts
@@ -260,7 +260,7 @@ export class Project implements Project.IProject {
 		this.ensureProject();
 
 		if(this.projectData.Framework !== this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova) {
-			this.$errors.fail("This is not a valid Cordova project.");
+			this.$errors.fail("This command is applicable only to Cordova projects.");
 		}
 	}
 


### PR DESCRIPTION
Improve the error message when non-Corodova project is used.

Fixes http://teampulse.telerik.com/view#item/283182