### PR TITLE
Windows Phone SDK updates

### DIFF
--- a/lib/services/project-properties-service.ts
+++ b/lib/services/project-properties-service.ts
@@ -82,12 +82,18 @@ export class ProjectPropertiesService implements IProjectPropertiesService {
 				this.$errors.fail("Unknown property update mode '%s'", mode);
 			}
 
-			if(normalizedProperty === "Framework") {
-				var projectSchema = this.$jsonSchemaValidator.tryResolveValidationSchema(projectData.Framework);
-				var propData = projectSchema[normalizedProperty];
-				if(propData && propData.onChanging) {
-					this.$injector.dynamicCall(propData.onChanging, [propertyValue]).wait();
+            var projectSchema = this.$jsonSchemaValidator.tryResolveValidationSchema(projectData.Framework);
+
+			// HACK - yargs parses double values (8.0) as integers (8)
+			if(normalizedProperty === "WPSdk") {
+				if(propertyValue.indexOf(".") === -1) {
+					propertyValue += ".0";
 				}
+			}
+
+			var propData = projectSchema[normalizedProperty];
+			if(propData && propData.onChanging) {
+				this.$injector.dynamicCall(propData.onChanging, [propertyValue]).wait();
 			}
 
 			projectData[normalizedProperty] = propertyValue;

--- a/resources/json-schemas/WP.json
+++ b/resources/json-schemas/WP.json
@@ -88,6 +88,14 @@
 					"ID_RESOLUTION_HD720P"
 				]
 			}
+		},
+		"WPSdk": {
+			"type": "string",
+			"description": "List of supported Windows Phone 8 SDKs.",
+			"enum": [
+				"8.0",
+				"8.1"
+			]
 		}
 	}
 }

--- a/resources/project-properties-cordova.json
+++ b/resources/project-properties-cordova.json
@@ -5,5 +5,8 @@
 	},
 	"CorePlugins": {
 		"dynamicRange": "#{project.getSupportedPlugins}"
+	},
+	"WPSdk": {
+		"onChanging": "#{project.onWPSdkVersionChanging}"
 	}
 }

--- a/test/commands-service.ts
+++ b/test/commands-service.ts
@@ -14,7 +14,10 @@ class ErrorsNoFailStub implements IErrors {
 	fail(formatStr: string, ...args: any[]): void;
 	fail(opts: { formatStr?: string; errorCode?: number; suppressCommandHelp?: boolean }, ...args: any[]): void;
 
-	fail(...args: any[]) { throw new Error();}
+	fail(...args: any[]) { throw new Error(); }
+	failWithoutHelp(message: string, ...args: any[]): void {
+		throw new Error();
+	}
 
 	beginCommand(action: () => IFuture<boolean>, printHelpCommand: () => IFuture<boolean>): IFuture<boolean> {
 		return (() => {

--- a/test/hash-service.ts
+++ b/test/hash-service.ts
@@ -48,6 +48,9 @@ class ErrorsNoFailStub implements IErrors {
 	fail(opts: { formatStr?: string; errorCode?: number; suppressCommandHelp?: boolean }, ...args: any[]): void;
 
 	fail(...args: any[]) { failed = true; throw new Error(args[0]); }
+	failWithoutHelp(message: string, ...args: any[]): void {
+		throw new Error();
+	}
 
 	beginCommand(action: () => IFuture<boolean>, printHelpCommand: () => IFuture<boolean>): IFuture<boolean> {
 		return (() => {

--- a/test/project.ts
+++ b/test/project.ts
@@ -57,6 +57,7 @@ function createTestInjector(): IInjector {
 	testInjector.register("cordovaMigrationService", require("../lib/services/cordova-migration-service").CordovaMigrationService);
 	testInjector.register("resources", $injector.resolve("resources"));
 	testInjector.register("pathFilteringService", stubs.PathFilteringServiceStub);
+	testInjector.register("prompter", {});
 	testInjector.register("jsonSchemaLoader", jsonSchemaLoaderLib.JsonSchemaLoader);
 	testInjector.register("jsonSchemaResolver", jsonSchemaResolverLib.JsonSchemaResolver);
 	testInjector.register("jsonSchemaValidator", jsonSchemaValidatorLib.JsonSchemaValidator),

--- a/test/resources/blank-cordova.abproject
+++ b/test/resources/blank-cordova.abproject
@@ -25,6 +25,7 @@
     ]
     ,"AndroidHardwareAcceleration": "false"
     ,"iOSStatusBarStyle": "Default"
+	,"WPSdk": "8.0"
     ,"WP8SupportedResolutions": [
       "ID_RESOLUTION_WVGA",
       "ID_RESOLUTION_WXGA",

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -152,6 +152,10 @@ export class ErrorsStub implements IErrors {
 		this.impl.fail.apply(this.impl, args);
 	}
 
+	failWithoutHelp(message: string, ...args: any[]): void {
+		throw new Error();
+	}
+
 	beginCommand(action:() => IFuture<boolean>, printHelpCommand: () => IFuture<boolean>): IFuture<boolean> {
 		return action();
 	}


### PR DESCRIPTION
Add check for current Windows Phone SDK in .abproject (WPSdk) and when migrating it (using prop set) check if the new value is supported in the current Cordova version. As WP 8.1 SDK is supported in Cordova 3.7.0 and above, if the project is trying to use WP 8.1 SDK and its version is 3.5.0 or below, a prompt message suggests to use newer Cordova version. In case user is migrating his Framework version to a lower than 3.7.0 we check WPSdk value and if it is 8.1, we prompt the user to use 8.0.

http://teampulse.telerik.com/view#item/284537