### PR TITLE
Fix error when trying to show the help for the create website command

### DIFF
--- a/resources/help.txt
+++ b/resources/help.txt
@@ -148,7 +148,7 @@ Creates a new project from a Telerik Mobile Website-based template.
 
 Options:
     --template <Template> - Sets the source template for the project. You can use the following templates:
-        #{mobileWebSiteProject.projectTemplatesString}. The default value is KendoUI.TabStrip.
+        #{mobileWebsiteProject.projectTemplatesString}. The default value is KendoUI.TabStrip.
     --path - Specifies the path where you want to create the project, if different from the current directory.
         The directory must be empty.
 


### PR DESCRIPTION
The bug is the wrong case of a single symbol, which prevents dynamic calls from working