### PR TITLE
Fix WPSdk setting

### DIFF
--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -187,6 +187,7 @@ interface IProjectData extends IDictionary<any> {
 	WP8Capabilities: string[];
 	WP8Requirements: string[];
 	WP8SupportedResolutions: string[];
+	WPSdk?: string;
 	CordovaPluginVariables?: any;
 }
 

--- a/lib/services/build.ts
+++ b/lib/services/build.ts
@@ -422,6 +422,10 @@ export class BuildService implements Project.IBuildService {
 
 			this.$loginManager.ensureLoggedIn().wait();
 
+			if(this.$project.projectData.WPSdk && this.$project.projectData.WPSdk === "8.0" && helpers.versionCompare(this.$project.projectData.FrameworkVersion,"3.7.0") >= 0) {
+				this.$logger.warn("Your project targets Apache Cordova %s which lets you use the Windows Phone 8.1 SDK when building your apps. You can change your target Windows Phone SDK by running $ appbuilder prop set WPSdk 8.1", this.$project.projectData.FrameworkVersion);
+			}
+
 			if(options.companion) {
 				this.deployToIon(platform).wait();
 			} else {


### PR DESCRIPTION
Fix issue that migrated framework value is not saved in .abproject (when using $appbuilder prop set WPSdk 8.1). Fixed issue that migrated WPSdk version is not saved in .abproject(when using $appbuilder prop set FrameworkVersion 3.5.0). Fixed typo when checking for Experimental version.