### PR TITLE
Update TAM Publishing

### DIFF
--- a/lib/commands/appmanager.ts
+++ b/lib/commands/appmanager.ts
@@ -29,8 +29,9 @@ class AppManagerUploadCommand implements ICommand {
 			var buildResult = this.$buildService.build({
 				platform: platform,
 				configuration: "Release",
-				provisionTypes: [constants.ProvisionType.AppStore],
-				showWp8SigningMessage: false
+				provisionTypes: [constants.ProvisionType.Development, constants.ProvisionType.Enterprise, constants.ProvisionType.AdHoc],
+				showWp8SigningMessage: false,
+				buildForTAM: true
 			}).wait();
 
 			if (!buildResult[0] || !buildResult[0].solutionPath) {

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -138,6 +138,7 @@ declare module Project {
 
 		buildForiOSSimulator?: boolean;
 		showWp8SigningMessage?: boolean;
+		buildForTAM?: boolean;
 	}
 
 	interface IPlatformMigrator {

--- a/lib/services/build.ts
+++ b/lib/services/build.ts
@@ -152,7 +152,10 @@ export class BuildService implements Project.IBuildService {
 				var certificateData: ICryptographicIdentity;
 				if(options.certificate) {
 					certificateData = this.$identityManager.findCertificate(options.certificate).wait();
-				} else if(settings.configuration === "Release") {
+				} else if(settings.buildForTAM) {
+					this.$logger.warn("You have not specified certificate to code sign this app. We'll use default debug certificate. " +
+						"Use --certificate option to specify your own certificate. You can check available certificates with '$ appbuilder certificate' command.");
+				} else if(settings.configuration === "Release" ) {
 					certificateData = this.$identityManager.findReleaseCertificate().wait();
 
 					if(!certificateData) {
@@ -183,6 +186,10 @@ export class BuildService implements Project.IBuildService {
 				var provisionData: IProvision;
 				if(options.provision) {
 					provisionData = this.$identityManager.findProvision(options.provision).wait();
+					if(settings.buildForTAM && provisionData.ProvisionType === Server.ProvisionType.AppStore.toString()) {
+						this.$errors.failWithoutHelp("You cannot use AppStore provision for upload in AppManager. Please use Development, AdHoc or Enterprise provision." +
+							"You can check availalbe provisioning profiles by using '$ appbuilder provision' command.");
+					}
 				} else if(!settings.buildForiOSSimulator) {
 					var deviceIdentifier = settings.device ? settings.device.getIdentifier() : undefined;
 					provisionData = this.$identityManager.autoselectProvision(

--- a/lib/validators/cryptographic-identity-validators.ts
+++ b/lib/validators/cryptographic-identity-validators.ts
@@ -93,8 +93,8 @@ export class SelfSignedIdentityValidator extends BaseValidators.BaseValidator<IS
 		if (commonHelpers.isNullOrWhitespace(forGooglePlayPublishing)) {
 			return new ValidationResult.ValidationResult(util.format(SelfSignedIdentityValidator.EMPTY_FIELD_ERROR_MESSAGE_PATTERN, "For Google Play Publishing"));
 		}
-		if ("true".equals(forGooglePlayPublishing, false) ||
-			"false".equals(forGooglePlayPublishing, false)) {
+		if(forGooglePlayPublishing.equals("true", false) ||
+			forGooglePlayPublishing.equals("false", false)) {
 			return ValidationResult.ValidationResult.Successful;
 		}
 		return new ValidationResult.ValidationResult(util.format(SelfSignedIdentityValidator.INVALID_FIELD_ERROR_MESSAGE_PATTERN, "For Google Play Publishing"));
@@ -134,7 +134,7 @@ export class SelfSignedIdentityValidator extends BaseValidators.BaseValidator<IS
 			return new ValidationResult.ValidationResult(SelfSignedIdentityValidator.NEGATIVE_EXPIRATION_ERROR_MESSAGE);
 		}
 
-		if ("true".equals(forGooglePlayPublishing, false) &&
+		if(forGooglePlayPublishing.equals("true", false) &&
 			endDate < SelfSignedIdentityValidator.GOOGLE_PLAY_IDENTITY_MIN_EXPIRATION_DATE) {
 			return new ValidationResult.ValidationResult(SelfSignedIdentityValidator.INVALID_GOOGLE_PLAY_IDENTITY_EXPIRATION_DATE_ERROR_MESSAGE);
 		}


### PR DESCRIPTION
Uploading application in AppManager now uses the following rules for certificates/provisions:
 - android upload should work no matter of the certificate. If user had not specified certificate, we'll print warning and we'll use server's debug certificate
 - ios upload cannot use AppStore provisioning (Development, AdHoc and Enterprise are allowed)

http://teampulse.telerik.com/view#item/284661