### PR TITLE
Fix using of properties from configuration specific .abproject

### DIFF
--- a/lib/project/framework-project-base.ts
+++ b/lib/project/framework-project-base.ts
@@ -61,7 +61,7 @@ export class FrameworkProjectBase implements Project.IFrameworkProjectBase {
 		var propertyValue: any = null;
 
 		var configData = projectInformation.configurationSpecificData[configuration];
-		if(configData) {
+		if(configData && configData[propertyName]) {
 			propertyValue = configData[propertyName];
 		} else {
 			propertyValue = projectInformation.projectData[propertyName];


### PR DESCRIPTION
In case you have CorePlugins defined in .abproject only (not in .debug.abproject and .release.abproject) you cannot build your project. Add check if the property is defined in the configuration specific files and if not - check for it in .abproject.

Fixes http://teampulse.telerik.com/view#item/284955