### PR TITLE
Add check if 7za can be executed on Linux

### DIFF
--- a/lib/commands/debug.ts
+++ b/lib/commands/debug.ts
@@ -8,6 +8,7 @@ import helpers = require("../helpers");
 import watchr = require("watchr");
 import MobileHelper = require("./../common/mobile/mobile-helper");
 import hostInfo = require("../host-info");
+import commonHostInfo = require("../common/host-info");
 
 export class DebugCommand implements ICommand {
 	private debuggerPath: string;
@@ -175,9 +176,9 @@ class DarwinDebuggerPlatformServices extends BaseDebuggerPlatformServices implem
 	}
 }
 
-if (hostInfo.isWindows()) {
+if(commonHostInfo.isWindows()) {
 	$injector.register("debuggerPlatformServices", WinDebuggerPlatformServices);
-} else if (hostInfo.isDarwin()) {
+} else if(commonHostInfo.isDarwin()) {
 	$injector.register("debuggerPlatformServices", DarwinDebuggerPlatformServices);
 } else {
 	$injector.register("debuggerPlatformServices", {}); // for unsupported OSes

--- a/lib/commands/edit-configuration.ts
+++ b/lib/commands/edit-configuration.ts
@@ -5,7 +5,7 @@
 import util = require("util");
 import path = require("path");
 import helpers = require("../helpers");
-import hostInfo = require("../host-info");
+import hostInfo = require("../common/host-info");
 
 export class EditConfigurationCommandParameter implements ICommandParameter {
 	constructor(private $errors: IErrors,

--- a/lib/commands/simulate.ts
+++ b/lib/commands/simulate.ts
@@ -5,6 +5,7 @@ import os = require("os");
 import path = require("path");
 import Future = require("fibers/future");
 import hostInfo = require("../host-info");
+import commonHostInfo = require("../common/host-info");
 
 export class SimulateCommand implements ICommand {
 	private static PLUGINS_PACKAGE_IDENTIFIER: string = "Plugins";
@@ -135,9 +136,9 @@ class MacSimulatorPlatformServices implements IExtensionPlatformServices {
 	}
 }
 
-if (hostInfo.isWindows()) {
+if(commonHostInfo.isWindows()) {
 	$injector.register("simulatorPlatformServices", WinSimulatorPlatformServices);
-} else if (hostInfo.isDarwin()) {
+} else if(commonHostInfo.isDarwin()) {
 	$injector.register("simulatorPlatformServices", MacSimulatorPlatformServices);
 } else {
 	$injector.register("simulatorPlatformServices", {});

--- a/lib/host-info.ts
+++ b/lib/host-info.ts
@@ -2,26 +2,6 @@
 "use strict";
 import Future = require("fibers/future");
 
-export function isWindows() {
-	return process.platform === "win32";
-}
-
-export function isWindows64() {
-	return isWindows() && (process.arch === "x64" || process.env.hasOwnProperty("PROCESSOR_ARCHITEW6432"));
-}
-
-export function isWindows32() {
-	return isWindows() && !isWindows64();
-}
-
-export function isDarwin() {
-	return process.platform.toUpperCase() === "DARWIN";
-}
-
-export function isLinux() {
-	return process.platform === "linux";
-}
-
 export function isDotNet40Installed(message: string) : IFuture<boolean> {
 	var result = new Future<boolean>();
 	var Winreg = require("winreg");
@@ -38,8 +18,8 @@ export function isDotNet40Installed(message: string) : IFuture<boolean> {
 	return result;
 }
 
-export var hostCapabilities: { [key:string]: IHostCapabilities } = {
-	"win32": { 
+export var hostCapabilities: { [key: string]: IHostCapabilities } = {
+	"win32": {
 		debugToolsSupported: true
 	},
 	"darwin": {
@@ -48,4 +28,4 @@ export var hostCapabilities: { [key:string]: IHostCapabilities } = {
 	"linux": {
 		debugToolsSupported: false
 	}
-};
+}

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -6,7 +6,7 @@ import _ = require("lodash");
 import path = require("path");
 import osenv = require("osenv");
 import commonOptions = require("./common/options");
-import hostInfo = require("./host-info");
+import hostInfo = require("./common/host-info");
 
 var knownOpts: any = {
 		"companion": Boolean,


### PR DESCRIPTION
If user is on x64 Linux and 32 bit libraries, describe in our documentation, are not installed, user will not be able to use 7zip. This means - unable to create projects, unable to build etc. So on post-install we check if we are able to execute the 7za file and if ENOENT is return we show the user where he can find system requirements.

Fix host-info paths in some files and remove host-info reference from some other files.

Remove duplicated methods from host-info files (they exist on two places - in common lib and here).

http://teampulse.telerik.com/view#item/285027