### PR TITLE
Improve .abproject prop completion

### DIFF
--- a/lib/project.ts
+++ b/lib/project.ts
@@ -588,9 +588,20 @@ export class Project implements Project.IProject {
 						this.$errors.fail("FUTURE_PROJECT_VER");
 					}
 
+					if(!_.has(data, "Framework")) {
+						if(_.has(data, "projectType")) {
+							data["Framework"] = data["projectType"];
+							delete data["projectType"];
+						} else {
+							data["Framework"] = this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova;
+						}
+
+						shouldSaveProject = true;
+					}
+
 					this.projectData = data;
 					this.frameworkProject = this.$frameworkProjectResolver.resolve(this.projectData.Framework);
-					shouldSaveProject = this.$projectPropertiesService.completeProjectProperties(this.projectData, this.frameworkProject) && this.$config.AUTO_UPGRADE_PROJECT_FILE;
+					shouldSaveProject = this.$projectPropertiesService.completeProjectProperties(this.projectData, this.frameworkProject) || shouldSaveProject;
 					
 					if(this.$staticConfig.triggerJsonSchemaValidation) {
 						this.$jsonSchemaValidator.validate(this.projectData);
@@ -626,7 +637,7 @@ export class Project implements Project.IProject {
 						projectFilePath, err.toString());
 				}
 
-				if(shouldSaveProject) {
+				if(shouldSaveProject && this.$config.AUTO_UPGRADE_PROJECT_FILE) {
 					this.saveProject(projectDir).wait();
 				}
 			}

--- a/lib/project.ts
+++ b/lib/project.ts
@@ -583,7 +583,6 @@ export class Project implements Project.IProject {
 				var projectFilePath = path.join(projectDir, this.$staticConfig.PROJECT_FILE_NAME);
 				try {
 					var data = this.$fs.readJson(projectFilePath).wait();
-				
 					if(data.projectVersion && data.projectVersion !== 1) {
 						this.$errors.fail("FUTURE_PROJECT_VER");
 					}

--- a/lib/services/project-properties-service.ts
+++ b/lib/services/project-properties-service.ts
@@ -15,7 +15,8 @@ export class ProjectPropertiesService implements IProjectPropertiesService {
 		private $injector: IInjector,
 		private $jsonSchemaValidator: IJsonSchemaValidator,
 		private $projectConstants: Project.IProjectConstants,
-		private $resources: IResourceLoader)  { }
+		private $resources: IResourceLoader,
+		private $logger: ILogger) { }
 
 	public getProjectProperties(projectFile: string, isJsonProjectFile: boolean, frameworkProject: Project.IFrameworkProject): IFuture<IProjectData> {
 		return ((): any => {
@@ -33,8 +34,9 @@ export class ProjectPropertiesService implements IProjectPropertiesService {
 	public completeProjectProperties(properties: any, frameworkProject: Project.IFrameworkProject): boolean {
 		var updated = false;
 
-		if(!_.has(properties, "Framework")) {
-			properties["Framework"] = this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova;
+		if(!_.has(properties, "projectVersion")) {
+			this.$logger.warn("Missing 'projectVersion' property in .abproject. Default value '1' will be used.");
+			properties["projectVersion"] = "1";
 			updated = true;
 		}
 

--- a/test/project.ts
+++ b/test/project.ts
@@ -484,7 +484,8 @@ describe("project unit tests (canonical paths)", () => {
 		testInjector.register("fs", stubs.FileSystemStub);
 		testInjector.resolve("staticConfig").PROJECT_FILE_NAME = "";
 		testInjector.register("projectPropertiesService", projectPropertiesLib.ProjectPropertiesService);
-
+		var staticConfig = testInjector.resolve("staticConfig");
+		staticConfig.triggerJsonSchemaValidation = false;
 		project = testInjector.resolve("project");
 
 		oldPath = options.path;

--- a/test/resources/blank-NativeScript.abproject
+++ b/test/resources/blank-NativeScript.abproject
@@ -12,7 +12,7 @@
         "2"
     ]
     ,"iOSBackgroundMode": []
-    ,"FrameworkVersion": "0.5.0"
+    ,"FrameworkVersion": "0.4.2"
     ,"AndroidPermissions": [ ]
     ,"DeviceOrientations": [
       "Portrait",


### PR DESCRIPTION
Move completion of properties before validation of the project in order to have correct WP8 props.

If .abproject is missing projectVersion we print warning and add it.

In old project instead of Framework, we had projectType - in case we find projectType in .abproject, replace it with Framework.

http://teampulse.telerik.com/view#item/285225