### PR TITLE
Show plugin url for marketplace plugins

### DIFF
--- a/lib/services/marketplace-plugins-service.ts
+++ b/lib/services/marketplace-plugins-service.ts
@@ -19,6 +19,9 @@ export class MarketplacePluginsService implements ICordovaPluginsService {
 	public createPluginData(plugin: any): IFuture<IMarketplacePlugin> {
 		return (() => {
 			var rowPluginData = this.$server.cordova.getMarketplacePluginData(plugin.uniqueId, plugin.pluginVersion).wait();
+			if(!rowPluginData.Url) {
+				rowPluginData.Url = plugin.repositoryUrl;
+			}
 			return new PluginsDataLib.MarketplacePluginData(rowPluginData, plugin.downloadsCount, plugin.demoAppRepositoryLink);
 		}).future<IMarketplacePlugin>()();
 	}


### PR DESCRIPTION
Fixes http://teampulse.telerik.com/view#item/281518
Sometimes server returns empty url address but we actually have the url from the response from `telerik.plugins.com`. This is only temporaly fix. After integrating the feature for marketplace plugin versioning we should delete this code.