### PR TITLE
Add verified publisher for marketplace plugins

### DIFF
--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -346,6 +346,11 @@ interface IPluginsService {
 	isPluginInstalled(pluginName: string): boolean;
 }
 
+interface IPublisher {
+	name: string;
+	url: string;
+}
+
 interface IPlugin {
 	data: Server.CordovaPluginData;
 	type: any;

--- a/lib/plugins-data.ts
+++ b/lib/plugins-data.ts
@@ -42,9 +42,13 @@ export class CordovaPluginData implements IPlugin {
 }
 
 export class MarketplacePluginData extends CordovaPluginData {
+	private static TELERIK_PUBLISHER_NAME = "Telerik plugins";
+	private static TELERIK_PARTNER_PUBLISHER_NAME = "Telerik partner plugins";
+
 	constructor(public data: Server.CordovaPluginData,
 		public downloads: number,
-		public demoAppRepositoryUrl: string) {
+		public demoAppRepositoryUrl: string,
+		public publisher: IPublisher) {
 		super(data, PluginType.MarketplacePlugin);
 	}
 
@@ -55,8 +59,13 @@ export class MarketplacePluginData extends CordovaPluginData {
 		var urlRow = util.format("    Url: %s", this.data.Url);
 		var demoAppRepositoryUrlRow = util.format("    Demo app repository url: %s", this.demoAppRepositoryUrl);
 		var downloadsCountRow = util.format("    Downloads count: %s", this.downloads);
+		var publisherName = this.getPublisherName(this.publisher);
 
 		var result = [nameRow, identifierRow, versionRow, urlRow, demoAppRepositoryUrlRow, downloadsCountRow];
+
+		if(publisherName) {
+			result.push(util.format("    Publisher: %s", publisherName));
+		}
 
 		if(this.data.Variables && this.data.Variables.length > 0) {
 			result.push(util.format("    Variables: %s", this.data.Variables.join(", ")));
@@ -67,5 +76,19 @@ export class MarketplacePluginData extends CordovaPluginData {
 
 	public toProjectDataRecord(): string {
 		return util.format("%s@%s", this.data.Identifier, this.data.Version);
+	}
+
+	private getPublisherName(publisher: IPublisher): string {
+		if(publisher && publisher.name) {
+			if(publisher.name === MarketplacePluginData.TELERIK_PUBLISHER_NAME) {
+				return "Telerik";
+			}
+
+			if(publisher.name === MarketplacePluginData.TELERIK_PARTNER_PUBLISHER_NAME) {
+				return "Telerik Partner";
+			}
+		}
+
+		return "";
 	}
 }

--- a/lib/services/marketplace-plugins-service.ts
+++ b/lib/services/marketplace-plugins-service.ts
@@ -22,7 +22,7 @@ export class MarketplacePluginsService implements ICordovaPluginsService {
 			if(!rowPluginData.Url) {
 				rowPluginData.Url = plugin.repositoryUrl;
 			}
-			return new PluginsDataLib.MarketplacePluginData(rowPluginData, plugin.downloadsCount, plugin.demoAppRepositoryLink);
+			return new PluginsDataLib.MarketplacePluginData(rowPluginData, plugin.downloadsCount, plugin.demoAppRepositoryLink, plugin.publisher);
 		}).future<IMarketplacePlugin>()();
 	}
 }


### PR DESCRIPTION
If plugin is verified its publisher is Telerik or Telerik Partner. When showing info for plugins, if it is verified we show Telerik, or Telerik Partner.  Add IPublisher interface and modify MarketplacePluginData to handle verified plugins.

Fixes http://teampulse.telerik.com/view#item/280939