### PR TITLE
Add --download option to appmanager upload

### DIFF
--- a/lib/commands/appmanager.ts
+++ b/lib/commands/appmanager.ts
@@ -4,6 +4,7 @@
 import MobileHelper = require("../common/mobile/mobile-helper");
 import constants = require("../common/mobile/constants");
 import util = require("util");
+import options = require("../options");
 
 class AppManagerUploadCommand implements ICommand {
 	constructor(
@@ -31,7 +32,8 @@ class AppManagerUploadCommand implements ICommand {
 				configuration: "Release",
 				provisionTypes: [constants.ProvisionType.Development, constants.ProvisionType.Enterprise, constants.ProvisionType.AdHoc],
 				showWp8SigningMessage: false,
-				buildForTAM: true
+				buildForTAM: true,
+				downloadFiles: options.download
 			}).wait();
 
 			if (!buildResult[0] || !buildResult[0].solutionPath) {

--- a/lib/services/build.ts
+++ b/lib/services/build.ts
@@ -320,7 +320,7 @@ export class BuildService implements Project.IBuildService {
 			var buildResult = this.requestCloudBuild(settings).wait();
 			var packageDefs = buildResult.packageDefs;
 
-			if(buildResult.provisionType === constants.ProvisionType.Development && !settings.downloadFiles) {
+			if(buildResult.provisionType === constants.ProvisionType.Development && !settings.downloadFiles && !settings.buildForTAM) {
 				this.$logger.info("Package built with 'Development' provision type. Downloading package, instead of generating QR code.");
 				this.$logger.info("Deploy manually to your device using iTunes.");
 				settings.showQrCodes = false;

--- a/resources/help.txt
+++ b/resources/help.txt
@@ -974,7 +974,7 @@ This command is not applicable to Mobile Website projects.
 
 --[appmanager|upload]--
 Usage:
-    $ appbuilder appmanager upload <Platform> [--certificate <Certificate ID>] [--provision <Provision ID>]
+    $ appbuilder appmanager upload <Platform> [--certificate <Certificate ID>] [--provision <Provision ID>] [--download]
 
 Platform-specific usage:
     $ appbuilder appmanager upload android --certificate <Certificate ID>
@@ -997,6 +997,7 @@ Options:
     --provision - Sets the provisioning profile that you want to use for code signing your iOS app. You can set
         a provisioning profile by index or name.
         To list available provisioning profiles, run $ appbuilder provision
+    --download - If set, downloads the application package to the root of the project
 --[/]--
 
 --[certificate-request]--


### PR DESCRIPTION
If you are using Development provision and you execute $appbuilder appmanager upload ios, the .ipa is downloaded. But if your provision is any other type or you upload for any other platform, the project is not downloaded. Change build code to download project with development certificate only if it is not build for appmanager. Use --download option with appmanger upload command in order to download the file.

http://teampulse.telerik.com/view#item/285204