### PR TITLE
Fix emulate of NativeScript projects

### DIFF
--- a/lib/commands/emulate.ts
+++ b/lib/commands/emulate.ts
@@ -9,7 +9,6 @@ import iconv = require("iconv-lite");
 import osenv = require("osenv");
 import helpers = require("../helpers");
 import MobileHelper = require("../common/mobile/mobile-helper");
-import AppIdentifier = require("../common/mobile/app-identifier");
 import options = require("../options");
 
 export class EmulateAndroidCommand implements ICommand {
@@ -33,8 +32,7 @@ export class EmulateAndroidCommand implements ICommand {
 				downloadedFilePath: packageFilePath
 			}).wait();
 
-			var appId = AppIdentifier.createAppIdentifier(MobileHelper.DevicePlatforms[MobileHelper.DevicePlatforms.Android], this.$project.projectData.AppIdentifier, options.companion);
-			this.$androidEmulatorServices.startEmulator(packageFilePath, <Mobile.IEmulatorOptions>{appId:appId.appIdentifier }).wait();
+			this.$androidEmulatorServices.startEmulator(packageFilePath, <Mobile.IEmulatorOptions>{ appId: this.$project.projectData.AppIdentifier }).wait();
 		}).future<void>()();
 	}
 }

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -160,6 +160,7 @@ interface IProjectCapabilities {
 	livesync: boolean;
 	livesyncCompanion: boolean;
 	updateKendo: boolean;
+	emulate: boolean;
 }
 
 interface IProjectData extends IDictionary<any> {

--- a/lib/project.ts
+++ b/lib/project.ts
@@ -390,15 +390,6 @@ export class Project implements Project.IProject {
 		}).future<string[]>()();
 	}
 
-	public get projectTargets(): IFuture<string[]> {
-		return (() => {
-			var projectDir = this.getProjectDir().wait();
-			var projectTargets = this.frameworkProject.getProjectTargets(projectDir).wait();
-
-			return projectTargets;
-		}).future<string[]>()();
-	}
-
 	public getTempDir(extraSubdir?: string): IFuture<string> {
 		return (() => {
 			var dir = path.join(this.getProjectDir().wait(), ".ab");

--- a/lib/project/cordova-project.ts
+++ b/lib/project/cordova-project.ts
@@ -35,7 +35,8 @@ export class CordovaProject extends frameworkProjectBaseLib.FrameworkProjectBase
 			simulate: true,
 			livesync: true,
 			livesyncCompanion: true,
-			updateKendo: true
+			updateKendo: true,
+			emulate: true
 		};
 	}
 

--- a/lib/project/nativescript-project.ts
+++ b/lib/project/nativescript-project.ts
@@ -3,6 +3,7 @@
 
 import path = require("path");
 import util = require("util");
+import Future = require("fibers/future");
 
 import frameworkProjectBaseLib = require("./framework-project-base");
 import helpers = require("./../common/helpers");
@@ -34,7 +35,8 @@ export class NativeScriptProject extends frameworkProjectBaseLib.FrameworkProjec
 			simulate: false,
 			livesync: false,
 			livesyncCompanion: true,
-			updateKendo: false
+			updateKendo: false,
+			emulate: true
 		};
 	}
 
@@ -79,10 +81,7 @@ export class NativeScriptProject extends frameworkProjectBaseLib.FrameworkProjec
 	}
 
 	public getProjectTargets(projectDir: string): IFuture<string[]> {
-		var dir = path.join(projectDir, "app");
-		var fileMask = /^bootstrap\.(\w*)\.js$/i;
-
-		return this.getProjectTargetsBase(dir, fileMask);
+		return Future.fromResult(["android", "ios"]);
 	}
 
 	public adjustBuildProperties(buildProperties: any, projectInformation?: Project.IProjectInformation): any {

--- a/lib/project/project.d.ts
+++ b/lib/project/project.d.ts
@@ -2,7 +2,6 @@ declare module Project {
 	interface IProject {
 		projectData: IProjectData;
 		capabilities: IProjectCapabilities;
-		projectTargets: IFuture<string[]>;
 		configurationSpecificData: IDictionary<IDictionary<any>>;
 		configurations: string[];
 		requiredAndroidApiLevel: number;

--- a/lib/project/web-site-project.ts
+++ b/lib/project/web-site-project.ts
@@ -31,7 +31,8 @@ export class MobileWebSiteProject extends frameworkProjectBaseLib.FrameworkProje
 			simulate: true,
 			livesync: false,
 			livesyncCompanion: false,
-			updateKendo: false
+			updateKendo: false,
+			emulate: false
 		};
 	}
 

--- a/lib/services/emulator-settings-service.ts
+++ b/lib/services/emulator-settings-service.ts
@@ -2,12 +2,18 @@
 "use strict";
 
 export class EmulatorSettingsService implements Mobile.IEmulatorSettingsService {
-	constructor(private $project: Project.IProject) { }
+	constructor(private $project: Project.IProject,
+		private $errors: IErrors) { }
 
 	public canStart(platform: string): IFuture<boolean> {
 		return (() => {
 			this.$project.ensureProject();
-			return _.contains(this.$project.projectTargets.wait(), platform.toLowerCase());
+
+			if(this.$project.capabilities.emulate) {
+				return _.contains(this.$project.getProjectTargets().wait(), platform.toLowerCase());
+			}
+
+			this.$errors.fail("The operation is not supported for %s projects.", this.$project.projectData.Framework);
 		}).future<boolean>()();
 	}
 


### PR DESCRIPTION
Fix getProjectTargets of nativescript-project to be "android" and "ios" (remove code which was checking for bootstrap.android.js and bootstrap.ios.js). Fix emulate command to use appIdentifier directly (without using AppIdentifier class and passing incorrect options.companion option to it). Remove projectTargets property of project, as there is getProjectTargets method, which is used almost everywhere when we need project targets (fixed the only place where the projectTargets property was used).  Add emulate option to project capabilities in order to forbid emulate of mobile-website projects. EmulatorSettingsService checks for emulate capability and fails in case the project cannot be emulated.

NOTE: This PR allows to deploy nativescript projects to native emulator. For Android, the application is installed, but it is not started. It has to be started manually. Graphite is doing the same, I'll research the issue and if I find a fix, I'll include it in another PR.

Fixes http://teampulse.telerik.com/view#item/285409