### PR TITLE
Fix projectVersion completion

### DIFF
--- a/lib/services/project-properties-service.ts
+++ b/lib/services/project-properties-service.ts
@@ -36,7 +36,7 @@ export class ProjectPropertiesService implements IProjectPropertiesService {
 
 		if(!_.has(properties, "projectVersion")) {
 			this.$logger.warn("Missing 'projectVersion' property in .abproject. Default value '1' will be used.");
-			properties["projectVersion"] = "1";
+			properties["projectVersion"] = 1;
 			updated = true;
 		}
 


### PR DESCRIPTION
If projectVersion is missing from .abproject, we should set it to 1. Fix the code to set it to number 1, not string 1.

http://teampulse.telerik.com/view#item/285484