### PR TITLE
Print configuration specific properties

### DIFF
--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -212,3 +212,12 @@ export function block(operation: () => void): void {
 	}
 }
 
+// Remove when node incorporates ES6 array.fill
+export function fill(value: string, times: number): string[]{
+	var repeatedValues: string[] = [];
+	for(var repeat = 0; repeat < times; repeat++) {
+		repeatedValues.push(value);
+	}
+
+	return repeatedValues;
+}


### PR DESCRIPTION
"$ appbuilder prop print" and "$ appbuilder prop print CorePlugins" do not print the values of the configuration specific properties. Use cli-table to print the values of all configuration specific properties for all configurations (it will work no matter how much configurations we add in the future).

Fixes http://teampulse.telerik.com/view#item/285533