### PR TITLE
Fix starting of nativescript projects on device

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -89,7 +89,10 @@ export class StaticConfig extends staticConfigBaseLib.StaticConfigBase implement
 	public TRACK_FEATURE_USAGE_SETTING_NAME = "AnalyticsSettings.TrackFeatureUsage";
 	public ANALYTICS_INSTALLATION_ID_SETTING_NAME = "AnalyticsInstallationID";
 
-	public START_PACKAGE_ACTIVITY_NAME = ".TelerikCallbackActivity";
+	public get START_PACKAGE_ACTIVITY_NAME(): string {
+		var project: Project.IProject = $injector.resolve("project");
+		return project.startPackageActivity;
+	}
 
 	public SOLUTION_SPACE_NAME = "Private_Build_Folder";
 	public QR_SIZE = 300;

--- a/lib/project.ts
+++ b/lib/project.ts
@@ -67,6 +67,10 @@ export class Project implements Project.IProject {
 		return this.frameworkProject.configFiles;
 	}
 
+	public get startPackageActivity(): string {
+		return this.frameworkProject.startPackageActivity;
+	}
+
 	public getProjectTargets(): IFuture<string[]> {
 		return (() => {
 			var projectDir = this.getProjectDir().wait();

--- a/lib/project/cordova-project.ts
+++ b/lib/project/cordova-project.ts
@@ -57,6 +57,10 @@ export class CordovaProject extends frameworkProjectBaseLib.FrameworkProjectBase
 		return _.values(allConfigFiles);
 	}
 
+	public get startPackageActivity(): string {
+		return ".TelerikCallbackActivity";
+	}
+
 	public getValidationSchemaId(): string {
 		return this.$jsonSchemaConstants.CORDOVA_VERSION_3_SCHEMA_ID;
 	}

--- a/lib/project/nativescript-project.ts
+++ b/lib/project/nativescript-project.ts
@@ -60,6 +60,10 @@ export class NativeScriptProject extends frameworkProjectBaseLib.FrameworkProjec
 		]
 	}
 
+	public get startPackageActivity(): string {
+		return "com.tns.NativeScriptActivity";
+	}
+
 	public getValidationSchemaId(): string {
 		return this.$jsonSchemaConstants.NATIVESCRIPT_SCHEMA_ID;
 	}

--- a/lib/project/project.d.ts
+++ b/lib/project/project.d.ts
@@ -6,6 +6,7 @@ declare module Project {
 		configurations: string[];
 		requiredAndroidApiLevel: number;
 		projectConfigFiles: Project.IConfigurationFile[];
+		startPackageActivity: string;
 
 		createNewProject(projectName: string, framework: string): IFuture<void>;
 		initializeProjectFromExistingFiles(framework: string): IFuture<void>;
@@ -42,6 +43,7 @@ declare module Project {
 		liveSyncUrl: string;
 		requiredAndroidApiLevel: number;
 		configFiles: IConfigurationFile[];
+		startPackageActivity: string;
 		getTemplateFilename(name: string): string;
 		getValidationSchemaId(): string;
 		getProjectFileSchema(): IDictionary<any>;

--- a/lib/project/web-site-project.ts
+++ b/lib/project/web-site-project.ts
@@ -52,6 +52,10 @@ export class MobileWebSiteProject extends frameworkProjectBaseLib.FrameworkProje
 		return [];
 	}
 
+	public get startPackageActivity(): string {
+		throw new Error("Not applicable.");
+	}
+
 	public getValidationSchemaId(): string {
 		return null;
 	}

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -265,7 +265,9 @@ class FrameworkProjectStub implements Project.IFrameworkProject {
 
 	public get requiredAndroidApiLevel(): number { return 0; }
 
-	public get configFiles(): Project.IConfigurationFile[] { return undefined; }
+	public get configFiles(): Project.IConfigurationFile[]{ return undefined; }
+
+	public get startPackageActivity(): string { return ""; }
 
 	public getValidationSchemaId(): string { return ""; }
 


### PR DESCRIPTION
NativeScript projects are successfully installed on emulators and devices, but they are not started. The reason is incorrect startPackageActivity - it is project dependant. Add startPackageActivity for each projectType and set staticConfig's START_PACKAGE_ACTIVITY to it when emulate or deploy command is executed.

Fixes http://teampulse.telerik.com/view#item/285489