### PR TITLE
Forbid ports below 1024

### DIFF
--- a/lib/commands/remote.ts
+++ b/lib/commands/remote.ts
@@ -55,10 +55,9 @@ export class RemoteCommand implements ICommand {
 				this.$errors.fail("You must specify a valid port number. Valid values are between 1 and 65535.");
 			}
 
-			if (!hostInfo.isWindows() && (parsedPortNumber < 1024) && process.getuid() != 0) {
-				this.$logger.warn("Port %s is a system port and requires superuser privileges." + os.EOL +
-				"To use this port, re-run the command using sudo." + os.EOL +
-				"To use a non-system port, re-run the command with a port above 1024.", parsedPortNumber.toString());
+			if (!hostInfo.isWindows() && (parsedPortNumber < 1024) && process.getuid() !== 0) {
+				this.$errors.fail("Port %s is a system port and cannot be used." + os.EOL +
+				"To use a non-system port, re-run the command with a port number greater than 1023.", parsedPortNumber.toString());
 			}
 
 			this.$fs.ensureDirectoryExists(this.appBuilderDir).wait();

--- a/resources/help.txt
+++ b/resources/help.txt
@@ -1154,9 +1154,7 @@ Starts a remote server to let you run your app in the iOS Simulator from a Windo
 
 This operation is applicable only to OS X systems.
 
-IMPORTANT: If you want to listen on a port in the range of 0 through 1023, run the command using sudo. For example: $ sudo appbuilder remote 443 
-
-<Port> is a non-negative integer that specifies a port on your OS X system. 
+<Port> is an integer greater than 1023 that specifies a port on your OS X system. 
        Make sure that the port is open and that your firewall allows traffic on it, if configured. 
        Make sure that your Windows system can reach and send traffic to the OS X system on the specified port. 
 <Device Name> is the name of the iOS Simulator device on which you want to run your app as listed by $ appbuilder emulate ios --availableDevices


### PR DESCRIPTION
With latest XCode, when you try starting simulator with sudo, the application is not started. Currently we are using sudo when user wants to use port below 1024. Even if they use $ sudo appbuilder remote 444, the application will not start because of the bug in XCode. So using ports below 1024 is useless. That's why we forbid using them.
Fixes http://teampulse.telerik.com/view#item/285912