### PR TITLE
Preuninstall script should use correct adb path

### DIFF
--- a/preuninstall.js
+++ b/preuninstall.js
@@ -5,8 +5,12 @@ var fs = require("fs");
 var options = require("./lib/options");
 
 var adbPath = util.format("resources/platform-tools/android/%s/adb", process.platform);
-var killAdbServerCommand = util.format("\"%s\" %s", adbPath, " kill-server");
+var executableAdbPath = process.platform === "win32" ? adbPath + ".exe" : adbPath;
+if(!fs.existsSync(executableAdbPath)) {
+	adbPath = "lib/common/" + adbPath;
+}
 
+var killAdbServerCommand = util.format("\"%s\" %s", adbPath, " kill-server");
 child_process.exec(killAdbServerCommand, function(error) {
 	if(error) {
 		console.log(error.toString());


### PR DESCRIPTION
Preuninstall script tries to execute adb from resource/platform-tools... but we have moved the adb file in lib/common/platform-tools... so the script should check the path to adb.