### PR TITLE
Update configs according to latest changes

### DIFF
--- a/config/config-dev.json
+++ b/config/config-dev.json
@@ -1,5 +1,5 @@
 {
-	"AB_SERVER": "icedev.icenium.com",
+	"AB_SERVER": "mocktap.telerik.com",
 	"AB_SERVER_PROTO": "https",
 	"DEBUG": false
 }

--- a/config/config-dev1.json
+++ b/config/config-dev1.json
@@ -1,5 +1,0 @@
-{
-	"AB_SERVER": "icedev1.icenium.com",
-	"AB_SERVER_PROTO": "https",
-	"DEBUG": false
-}

--- a/config/config-dev2.json
+++ b/config/config-dev2.json
@@ -1,5 +1,0 @@
-{
-	"AB_SERVER": "icedev2.icenium.com",
-	"AB_SERVER_PROTO": "https",
-	"DEBUG": false
-}

--- a/config/config-local.json
+++ b/config/config-local.json
@@ -1,5 +1,5 @@
 {
-	"AB_SERVER": "integrationtap.telerik.com",
+	"AB_SERVER": "sit-platform.telerik.rocks",
 	"AB_SERVER_PROTO": "https",
 	"DEBUG": false
 }

--- a/config/config-sit.json
+++ b/config/config-sit.json
@@ -1,5 +1,0 @@
-{
-	"AB_SERVER": "sit-platform.telerik.rocks",
-	"AB_SERVER_PROTO": "https",
-	"DEBUG": false
-}

--- a/config/config-sttap.json
+++ b/config/config-sttap.json
@@ -1,5 +1,5 @@
 {
-	"AB_SERVER": "uat-tap.telerik.rocks",
+	"AB_SERVER": "sttap.telerik.com",
 	"AB_SERVER_PROTO": "https",
 	"DEBUG": false
 }

--- a/config/config-test.json
+++ b/config/config-test.json
@@ -1,5 +1,5 @@
 {
-	"AB_SERVER": "taptestapp.icenium.com",
+	"AB_SERVER": "testtap.telerik.com",
 	"AB_SERVER_PROTO": "https",
 	"DEBUG": false
 }


### PR DESCRIPTION
 - Change local to point to sit-platform. That's why I've removed sit config.
 - Remove dev1 and dev2 as they do not seem to work (also we've used them only once).
 - Remove uat as it does not exist anymore.
 - Change test to point to testtap.telerik.com (old address is redirected to this one).
 - Change dev to point to mocktap.telerik.com NOTE: AppBuilder's deployment configuration on mocktap will be from release. This is local live environment.
 - Add dev3 configuration - NOTE: AppBuilder's deployment configuration is Test.