### PR TITLE
Allow projectVersion to be string

### DIFF
--- a/lib/project.ts
+++ b/lib/project.ts
@@ -647,7 +647,7 @@ export class Project implements Project.IProject {
 				var projectFilePath = path.join(projectDir, this.$staticConfig.PROJECT_FILE_NAME);
 				try {
 					var data = this.$fs.readJson(projectFilePath).wait();
-					if(data.projectVersion && data.projectVersion !== 1) {
+					if(data.projectVersion && data.projectVersion.toString() !== "1") {
 						this.$errors.fail("FUTURE_PROJECT_VER");
 					}
 


### PR DESCRIPTION
In some of our samples projectVersion is set to "1". Our code expects number, so the validation fails. Other clients (VSE, Graphite) allow using string for project version, so we use toString in order to allow "1". Json schemas allow both integer and string for projectVersion.

Fixes http://teampulse.telerik.com/view#item/286619