### PR TITLE
Show context specific help

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -59,7 +59,9 @@ $injector.requireCommand("login", "./commands/authentication");
 $injector.requireCommand("logout", "./commands/authentication");
 
 $injector.require("buildService", "./services/build");
-$injector.requireCommand("build", "./commands/build");
+$injector.requireCommand("build|android", "./commands/build");
+$injector.requireCommand("build|ios", "./commands/build");
+$injector.requireCommand("build|wp8", "./commands/build");
 
 $injector.require("multipartUploadService", "./services/multipart-upload");
 $injector.require("hashService", "./services/hash-service");
@@ -96,10 +98,17 @@ $injector.requireCommand("prop|print", "./commands/prop/prop-print");
 $injector.requireCommand("cloud|*list", "./commands/cloud-projects");
 $injector.requireCommand("cloud|export", "./commands/cloud-projects");
 
-$injector.requireCommand("deploy", "./commands/deploy");
+$injector.requireCommand("deployHelper", "./commands/deploy");
+$injector.requireCommand("deploy|*devices", "./commands/deploy");
+$injector.requireCommand("deploy|android", "./commands/deploy");
+$injector.requireCommand("deploy|ios", "./commands/deploy");
+$injector.requireCommand("deploy|wp8", "./commands/deploy");
 
 $injector.requireCommand(["livesync|*devices", "live-sync|*devices"], "./commands/live-sync");
 $injector.requireCommand(["livesync|cloud", "live-sync|cloud"], "./commands/livesync-cloud");
+$injector.requireCommand(["livesync|android", "live-sync|android"], "./commands/livesync-cloud");
+$injector.requireCommand(["livesync|ios", "live-sync|ios"], "./commands/livesync-cloud");
+$injector.requireCommand(["livesync|wp8", "live-sync|wp8"], "./commands/livesync-cloud");
 
 $injector.require("identityManager", "./commands/cryptographic-identities");
 $injector.requireCommand("provision|*list", "./commands/cryptographic-identities");
@@ -119,7 +128,9 @@ $injector.requireCommand("certificate-request|download", "./commands/cryptograph
 $injector.requireCommand("user", "./commands/user-status");
 $injector.requireCommand("appstore|list", "./commands/itunes-connect");
 $injector.requireCommand("appstore|upload", "./commands/itunes-connect");
-$injector.requireCommand("appmanager|upload", "./commands/appmanager");
+$injector.requireCommand("appmanager|upload|android", "./commands/appmanager");
+$injector.requireCommand("appmanager|upload|ios", "./commands/appmanager");
+$injector.requireCommand("appmanager|upload|wp8", "./commands/appmanager");
 
 $injector.requireCommand("update-kendoui", "./commands/update-kendoui");
 
@@ -146,3 +157,7 @@ $injector.require("jsonSchemaLoader", "./json-schema/json-schema-loader");
 $injector.require("jsonSchemaResolver", "./json-schema/json-schema-resolver");
 $injector.require("jsonSchemaValidator", "./json-schema/json-schema-validator");
 $injector.require("jsonSchemaConstants", "./json-schema/json-schema-constants");
+
+$injector.require("liveSyncService", "./services/livesync-service");
+$injector.require("appManagerService", "./services/appmanager-service");
+$injector.require("dynamicHelpProvider", "./dynamic-help-provider");

--- a/lib/commands/appmanager.ts
+++ b/lib/commands/appmanager.ts
@@ -2,69 +2,36 @@
 "use strict";
 
 import MobileHelper = require("../common/mobile/mobile-helper");
-import constants = require("../common/mobile/constants");
-import util = require("util");
-import options = require("../options");
 
-class AppManagerUploadCommand implements ICommand {
-	constructor(
-		private $config: IConfiguration,
-		private $server: Server.IServer,
-		private $errors: IErrors,
-		private $logger: ILogger,
-		private $project: Project.IProject,
-		private $loginManager: ILoginManager,
-		private $opener: IOpener,
-		private $buildService: Project.IBuildService) {}
+class AppManagerUploadAndroidCommand implements ICommand {
+	constructor(private $appManagerService: IAppManagerService) { }
 
 	execute(args: string[]): IFuture<void> {
-		return (() => {
-			var platform = MobileHelper.validatePlatformName(args[0], this.$errors);
-			this.$project.ensureProject();
-			this.$loginManager.ensureLoggedIn().wait();
-
-			this.$logger.info("Accessing Telerik AppManager store.");
-			this.$server.tam.verifyStoreCreated().wait();
-
-			this.$logger.info("Building release package.");
-			var buildResult = this.$buildService.build({
-				platform: platform,
-				configuration: "Release",
-				provisionTypes: [constants.ProvisionType.Development, constants.ProvisionType.Enterprise, constants.ProvisionType.AdHoc],
-				showWp8SigningMessage: false,
-				buildForTAM: true,
-				downloadFiles: options.download
-			}).wait();
-
-			if (!buildResult[0] || !buildResult[0].solutionPath) {
-				this.$errors.fail({formatStr: "Build failed.", suppressCommandHelp: true});
-			}
-
-			this.$logger.info("Uploading package to Telerik AppManager.");
-			var projectName = this.$project.projectData.ProjectName;
-			var solutionPath = buildResult[0].solutionPath;
-			var projectPath = solutionPath.substr(solutionPath.indexOf("/") + 1);
-			this.$server.tam.uploadApplication(projectName, projectName, projectPath).wait();
-
-			this.$logger.info("Successfully uploaded package.");
-
-			var tamUrl = util.format("%s://%s/appbuilder/Services/tam", this.$config.AB_SERVER_PROTO, this.$config.AB_SERVER);
-			this.$logger.info("Go to %s to manage your apps.", tamUrl);
-			this.$opener.open(tamUrl);
-		}).future<void>()();
+		return this.$appManagerService.upload(MobileHelper.DevicePlatforms[MobileHelper.DevicePlatforms.Android].toLowerCase());
 	}
 
-	allowedParameters : ICommandParameter[] = [new PlatformNameCommandParameter(this.$errors)];
+	allowedParameters: ICommandParameter[] = [];
 }
-$injector.registerCommand("appmanager|upload", AppManagerUploadCommand);
+$injector.registerCommand("appmanager|upload|android", AppManagerUploadAndroidCommand);
 
-class PlatformNameCommandParameter implements ICommandParameter {
-	constructor(private $errors: IErrors) { }
-	mandatory = true;
-	validate(value: string, errorMessage?: string): IFuture<boolean> {
-		return ((): boolean => {
-			MobileHelper.validatePlatformName(value, this.$errors);
-			return true;
-		}).future<boolean>()();
+class AppManagerUploadIosCommand implements ICommand {
+	constructor(private $appManagerService: IAppManagerService) { }
+
+	execute(args: string[]): IFuture<void> {
+		return this.$appManagerService.upload(MobileHelper.DevicePlatforms[MobileHelper.DevicePlatforms.iOS]);
 	}
+
+	allowedParameters: ICommandParameter[] = [];
 }
+$injector.registerCommand("appmanager|upload|ios", AppManagerUploadIosCommand);
+
+class AppManagerUploadWP8Command implements ICommand {
+	constructor(private $appManagerService: IAppManagerService) { }
+
+	execute(args: string[]): IFuture<void> {
+		return this.$appManagerService.upload(MobileHelper.DevicePlatforms[MobileHelper.DevicePlatforms.WP8]);
+	}
+
+	allowedParameters: ICommandParameter[] = [];
+}
+$injector.registerCommand("appmanager|upload|wp8", AppManagerUploadWP8Command);

--- a/lib/commands/build.ts
+++ b/lib/commands/build.ts
@@ -1,46 +1,37 @@
 ///<reference path="../.d.ts"/>
 "use strict";
-import MobileHelper = require("./../common/mobile/mobile-helper");
-import options = require("../common/options");
 
-export class BuildCommand implements ICommand {
-	constructor(private $buildService: Project.IBuildService,
-		private $project: Project.IProject,
-		private $errors: IErrors) { }
+import MobileHelper = require("../common/mobile/mobile-helper");
 
-	allowedParameters: ICommandParameter[] = [new PlatformCommandParameter(this.$project, this.$errors)];
+export class BuildAndroidCommand implements ICommand {
+	constructor(private $buildService: Project.IBuildService) { }
 
-	get completionData(): string[] {
-		return _.map(MobileHelper.PlatformNames, (platformName: string) => platformName.toLowerCase());
-	}
+	allowedParameters: ICommandParameter[] = [];
 
 	execute(args: string[]): IFuture<void> {
-		return	this.$buildService.executeBuild(args[0]);
+		return this.$buildService.executeBuild(MobileHelper.DevicePlatforms[MobileHelper.DevicePlatforms.Android]);
 	}
 }
-$injector.registerCommand("build", BuildCommand);
+$injector.registerCommand("build|android", BuildAndroidCommand);
 
-class PlatformCommandParameter implements ICommandParameter {
-	constructor(private $project: Project.IProject,
-		private $errors: IErrors) { }
+export class BuildIosCommand implements ICommand {
+	constructor(private $buildService: Project.IBuildService) { }
 
-	mandatory = true;
+	allowedParameters: ICommandParameter[] = [];
 
-	validate(validationValue: string): IFuture<boolean> {
-		return (() => {
-			if(!validationValue) {
-				return false;
-			}
-
-			this.$project.ensureProject();
-
-			if(!this.$project.capabilities.build && !options.companion) {
-				this.$errors.fail("You will be able to build %s based applications in a future release of the Telerik AppBuilder CLI.", this.$project.projectData.Framework);
-			}
-
-			MobileHelper.validatePlatformName(validationValue, this.$errors);
-
-			return true;
-		}).future<boolean>()();
+	execute(args: string[]): IFuture<void> {
+		return this.$buildService.executeBuild(MobileHelper.DevicePlatforms[MobileHelper.DevicePlatforms.iOS]);
 	}
 }
+$injector.registerCommand("build|ios", BuildAndroidCommand);
+
+export class BuildWP8Command implements ICommand {
+	constructor(private $buildService: Project.IBuildService) { }
+
+	allowedParameters: ICommandParameter[] = [];
+
+	execute(args: string[]): IFuture<void> {
+		return this.$buildService.executeBuild(MobileHelper.DevicePlatforms[MobileHelper.DevicePlatforms.WP8]);
+	}
+}
+$injector.registerCommand("build|wp8", BuildAndroidCommand);

--- a/lib/commands/live-sync.ts
+++ b/lib/commands/live-sync.ts
@@ -16,164 +16,42 @@ interface IProjectFileInfo {
 	shouldIncludeFile: boolean;
 }
 
-export class LiveSyncCommand implements ICommand {
-	private excludedProjectDirsAndFiles = [
-		"app_resources"
-		, "plugins"
-		, ".*.tmp"
-	];
-
-	constructor(private $devicesServices: Mobile.IDevicesServices,
-		private $logger: ILogger,
-		private $fs: IFileSystem,
-		private $errors: IErrors,
-		private $project: Project.IProject,
-		private $projectFilesManager: Project.IProjectFilesManager,
-		private $dispatcher: IFutureDispatcher,
-		private $stringParameter: ICommandParameter) { }
-
-	public allowedParameters = [this.$stringParameter];
-
-	public execute(args: string[]): IFuture<void> {
-		return (() => {
-			this.$project.ensureProject();
-
-			this.$devicesServices.initialize({platform: args[0], deviceId: options.device}).wait();
-			var platform = this.$devicesServices.platform;
-
-			if (!MobileHelper.platformCapabilities[platform].companion && options.companion) {
-				this.$errors.fail("The AppBuilder Companion app is not available on %s devices.", platform);
-			}
-
-			if (!this.$devicesServices.hasDevices) {
-				this.$errors.fail({formatStr: constants.ERROR_NO_DEVICES, suppressCommandHelp: true});
-			}
-
-			if (!this.$project.capabilities.livesync && !options.companion) {
-				this.$errors.fail("Use $ appbuilder livesync cloud to sync your application to Telerik Nativescript Companion App. You will be able to LiveSync %s based applications in a future release of the Telerik AppBuilder CLI.", this.$project.projectData.Framework);
-			}
-
-			if (!this.$project.capabilities.livesyncCompanion && options.companion) {
-				this.$errors.fail("You will be able to LiveSync %s based applications to the Companion app in a future release of the Telerik AppBuilder CLI.", this.$project.projectData.Framework);
-			}
-
-			var projectDir = this.$project.getProjectDir().wait();
-
-			var appIdentifier = AppIdentifier.createAppIdentifier(platform,
-				this.$project.projectData.AppIdentifier, options.companion);
-
-			if (options.file) {
-				var isExistFile = this.$fs.exists(options.file).wait();
-				if (isExistFile) {
-					this.sync(appIdentifier, projectDir, [path.resolve(options.file)]).wait();
-				} else {
-					this.$errors.fail("The file %s does not exist.", options.file);
-				}
-			} else {
-				var projectFiles = this.$project.enumerateProjectFiles(this.excludedProjectDirsAndFiles).wait();
-
-				this.sync(appIdentifier, projectDir, projectFiles).wait();
-
-				if (options.watch) {
-					this.liveSyncDevices(platform, projectDir, appIdentifier);
-					helpers.exitOnStdinEnd();
-					this.$dispatcher.run();
-				}
-			}
-		}).future<void>()();
+class LiveSyncDevicesCommand implements ICommand {
+	constructor(private $liveSyncService: ILiveSyncService) { }
+	execute(args: string[]): IFuture<void> {
+		return this.$liveSyncService.livesync();
 	}
 
-	private getProjectFileInfo(fileName: string): IProjectFileInfo {
-		var platforms = _.map(MobileHelper.PlatformNames, (platformName: string) => MobileHelper.normalizePlatformName(platformName));
-		var parsed = this.parseFile(fileName, platforms, this.$devicesServices.platform);
-		if(!parsed) {
-			parsed = this.parseFile(fileName, ["debug", "release"], "debug");
-		}
-
-		return parsed || {
-			fileName: fileName,
-			onDeviceName: fileName,
-			shouldIncludeFile: true
-		};
-	}
-
-	private parseFile(fileName: string, validValues: string[], value: string): any {
-		var regex = util.format("^(.+?)[.](%s)([.].+?)$", validValues.join("|"));
-		var parsed = fileName.match(new RegExp(regex, "i"));
-		if (parsed) {
-			return {
-				fileName: fileName,
-				onDeviceName: parsed[1] + parsed[3],
-				shouldIncludeFile: parsed[2].toLowerCase() === value.toLowerCase()
-			};
-		}
-
-		return undefined;
-	}
-
-	private sync(appIdentifier: Mobile.IAppIdentifier, projectDir: string, projectFiles: string[]): IFuture<void> {
-		var projectFilesInfo: IProjectFileInfo[] = [];
-
-		_.each(projectFiles, (projectFile: string) => {
-			var projectFileInfo = this.getProjectFileInfo(projectFile);
-			if(projectFileInfo.shouldIncludeFile) {
-				projectFilesInfo.push(projectFileInfo);
-			}
-		});
-
-		return this.syncCore(appIdentifier, projectDir, projectFilesInfo);
-	}
-
-	private syncCore(appIdentifier: Mobile.IAppIdentifier, projectDir: string, projectFiles: IProjectFileInfo[]): IFuture<void> {
-		return(() => {
-			var action = (device: Mobile.IDevice): IFuture<void> => {
-				return (() => {
-					var platformSpecificProjectPath = appIdentifier.deviceProjectPath;
-					var localDevicePaths = this.getLocalToDevicePaths(projectDir, projectFiles, platformSpecificProjectPath);
-					device.sync(localDevicePaths, appIdentifier, this.$project.getLiveSyncUrl()).wait();
-				}).future<void>()();
-			};
-
-			this.$devicesServices.execute(action).wait();
-		}).future<void>()();
-	}
-
-	private getLocalToDevicePaths(localProjectPath: string, projectFiles: IProjectFileInfo[], deviceProjectPath: string): MobileHelper.LocalToDevicePathData[] {
-		var localToDevicePaths = _.map(projectFiles, (projectFileInfo: IProjectFileInfo) => {
-			var relativeToProjectBasePath = helpers.getRelativeToRootPath(localProjectPath, projectFileInfo.onDeviceName);
-			var devicePath = path.join(deviceProjectPath, relativeToProjectBasePath);
-			return new MobileHelper.LocalToDevicePathData(projectFileInfo.fileName, helpers.fromWindowsRelativePathToUnix(devicePath), relativeToProjectBasePath);
-		});
-
-		return localToDevicePaths;
-	}
-
-	private liveSyncDevices(platform: string, projectDir: string, appIdentifier: Mobile.IAppIdentifier): void {
-		var _this = this;
-
-		gaze(projectDir + "/**/*", function(err: any, watcher: any) {
-			this.on('changed', (filePath: string) => {
-				if (!_this.$projectFilesManager.isProjectFileExcluded(projectDir, filePath, _this.excludedProjectDirsAndFiles)) {
-					_this.batchLiveSync(filePath, projectDir, appIdentifier);
-				}
-			});
-		});
-	}
-
-	private timer: Timer = null;
-	private syncQueue: string[] = [];
-	private batchLiveSync(filePath: string, projectDir: string, appIdentifier: Mobile.IAppIdentifier): void {
-		if (!this.timer) {
-			this.timer = setInterval(() => {
-				var filesToSync = this.syncQueue;
-				if (filesToSync.length > 0) {
-					this.syncQueue = [];
-					this.$logger.trace("Syncing %s", filesToSync.join(", "));
-					this.$dispatcher.dispatch(() => this.sync(appIdentifier, projectDir, filesToSync));
-				}
-			}, 500);
-		}
-		this.syncQueue.push(filePath);
-	}
+	allowedParameters: ICommandParameter[] = [];
 }
-$injector.registerCommand(["livesync|*devices", "live-sync|*devices"], LiveSyncCommand);
+$injector.registerCommand(["livesync|*devices", "live-sync|*devices"], LiveSyncDevicesCommand);
+
+class LiveSyncAndroidCommand implements ICommand {
+	constructor(private $liveSyncService: ILiveSyncService) { }
+	execute(args: string[]): IFuture<void> {
+		return this.$liveSyncService.livesync(MobileHelper.DevicePlatforms[MobileHelper.DevicePlatforms.Android]);
+	}
+
+	allowedParameters: ICommandParameter[] = [];
+}
+$injector.registerCommand(["livesync|android", "live-sync|android"], LiveSyncAndroidCommand);
+
+class LiveSyncIosCommand implements ICommand {
+	constructor(private $liveSyncService: ILiveSyncService) { }
+	execute(args: string[]): IFuture<void> {
+		return this.$liveSyncService.livesync(MobileHelper.DevicePlatforms[MobileHelper.DevicePlatforms.iOS]);
+	}
+
+	allowedParameters: ICommandParameter[] = [];
+}
+$injector.registerCommand(["livesync|ios", "live-sync|ios"], LiveSyncIosCommand);
+
+class LiveSyncWP8Command implements ICommand {
+	constructor(private $liveSyncService: ILiveSyncService) { }
+	execute(args: string[]): IFuture<void> {
+		return this.$liveSyncService.livesync(MobileHelper.DevicePlatforms[MobileHelper.DevicePlatforms.WP8]);
+	}
+
+	allowedParameters: ICommandParameter[] = [];
+}
+$injector.registerCommand(["livesync|wp8", "live-sync|wp8"], LiveSyncWP8Command);

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -399,3 +399,15 @@ interface IRemoteProjectService {
 interface IProjectSimulatorService {
 	getSimulatorParams(simulatorPackageName: string): IFuture<string[]>;
 }
+
+interface IDeployHelper {
+	deploy(platform?: string): IFuture<void>;
+}
+
+interface ILiveSyncService {
+	livesync(platform?: string): IFuture<void>;
+}
+
+interface IAppManagerService {
+	upload(platform: string): IFuture<void>;
+}

--- a/lib/dynamic-help-provider.ts
+++ b/lib/dynamic-help-provider.ts
@@ -1,0 +1,30 @@
+///<reference path=".d.ts"/>
+
+"use strict";
+
+export class DynamicHelpProvider implements IDynamicHelpProvider {
+	constructor(private $project: Project.IProject,
+		private $projectConstants: Project.IProjectConstants) { }
+
+	public isProjectType(args: string[]): IFuture<boolean> {
+		return ((): boolean => {
+			if(this.$project.getProjectDir().wait()) {
+				var framework = this.$project.projectData.Framework.toLowerCase();
+				return _.any(args, arg => arg.toLowerCase() === framework);
+			}
+
+			return true;
+		}).future<boolean>()();
+	}
+
+	public getLocalVariables(): IFuture<IDictionary<any>> {
+		return ((): IDictionary<any> => {
+			var localVariables:IDictionary<any> = {};
+			localVariables["isMobileWebsite"] = this.isProjectType([this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.MobileWebsite]).wait();
+			localVariables["isCordova"] = this.isProjectType([this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova]).wait();
+			localVariables["isNativeScript"] = this.isProjectType([this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript]).wait();
+			return localVariables;
+		}).future<IDictionary<any>>()();
+	}
+}
+$injector.register("dynamicHelpProvider", DynamicHelpProvider);

--- a/lib/services/appmanager-service.ts
+++ b/lib/services/appmanager-service.ts
@@ -1,0 +1,57 @@
+///<reference path="../.d.ts"/>
+"use strict";
+
+import MobileHelper = require("../common/mobile/mobile-helper");
+import constants = require("../common/mobile/constants");
+import util = require("util");
+import options = require("../options");
+
+class AppManagerService implements IAppManagerService {
+	constructor(
+		private $config: IConfiguration,
+		private $server: Server.IServer,
+		private $errors: IErrors,
+		private $logger: ILogger,
+		private $project: Project.IProject,
+		private $loginManager: ILoginManager,
+		private $opener: IOpener,
+		private $buildService: Project.IBuildService) { }
+
+	upload(platform: string): IFuture<void> {
+		return (() => {
+			var mobilePlatform = MobileHelper.validatePlatformName(platform, this.$errors);
+			this.$project.ensureProject();
+			this.$loginManager.ensureLoggedIn().wait();
+
+			this.$logger.info("Accessing Telerik AppManager store.");
+			this.$server.tam.verifyStoreCreated().wait();
+
+			this.$logger.info("Building release package.");
+			var buildResult = this.$buildService.build({
+				platform: mobilePlatform,
+				configuration: "Release",
+				provisionTypes: [constants.ProvisionType.Development, constants.ProvisionType.Enterprise, constants.ProvisionType.AdHoc],
+				showWp8SigningMessage: false,
+				buildForTAM: true,
+				downloadFiles: options.download
+			}).wait();
+
+			if(!buildResult[0] || !buildResult[0].solutionPath) {
+				this.$errors.fail({ formatStr: "Build failed.", suppressCommandHelp: true });
+			}
+
+			this.$logger.info("Uploading package to Telerik AppManager.");
+			var projectName = this.$project.projectData.ProjectName;
+			var solutionPath = buildResult[0].solutionPath;
+			var projectPath = solutionPath.substr(solutionPath.indexOf("/") + 1);
+			this.$server.tam.uploadApplication(projectName, projectName, projectPath).wait();
+
+			this.$logger.info("Successfully uploaded package.");
+
+			var tamUrl = util.format("%s://%s/appbuilder/Services/tam", this.$config.AB_SERVER_PROTO, this.$config.AB_SERVER);
+			this.$logger.info("Go to %s to manage your apps.", tamUrl);
+			this.$opener.open(tamUrl);
+		}).future<void>()();
+	}
+}
+$injector.register("appManagerService", AppManagerService);

--- a/lib/services/livesync-service.ts
+++ b/lib/services/livesync-service.ts
@@ -1,0 +1,176 @@
+///<reference path="../.d.ts"/>
+"use strict";
+
+import util = require("util");
+import path = require("path");
+var options: any = require("../common/options");
+var gaze = require("gaze");
+import helpers = require("./../helpers");
+import MobileHelper = require("./../common/mobile/mobile-helper");
+import AppIdentifier = require("../common/mobile/app-identifier");
+import constants = require("../common/mobile/constants");
+
+interface IProjectFileInfo {
+	fileName: string;
+	onDeviceName: string;
+	shouldIncludeFile: boolean;
+}
+
+export class LiveSyncService implements ILiveSyncService {
+	private excludedProjectDirsAndFiles = [
+		"app_resources",
+		"plugins",
+		".*.tmp"
+	];
+
+	constructor(private $devicesServices: Mobile.IDevicesServices,
+		private $logger: ILogger,
+		private $fs: IFileSystem,
+		private $errors: IErrors,
+		private $project: Project.IProject,
+		private $projectFilesManager: Project.IProjectFilesManager,
+		private $dispatcher: IFutureDispatcher) { }
+
+	public livesync(platform: string): IFuture<void> {
+		return (() => {
+			this.$project.ensureProject();
+
+			this.$devicesServices.initialize({ platform: platform, deviceId: options.device }).wait();
+			var platform = this.$devicesServices.platform;
+
+			if(!MobileHelper.platformCapabilities[platform].companion && options.companion) {
+				this.$errors.fail("The AppBuilder Companion app is not available on %s devices.", platform);
+			}
+
+			if(!this.$devicesServices.hasDevices) {
+				this.$errors.fail({ formatStr: constants.ERROR_NO_DEVICES, suppressCommandHelp: true });
+			}
+
+			if(!this.$project.capabilities.livesync && !options.companion) {
+				this.$errors.fail("Use $ appbuilder livesync cloud to sync your application to Telerik Nativescript Companion App. You will be able to LiveSync %s based applications in a future release of the Telerik AppBuilder CLI.", this.$project.projectData.Framework);
+			}
+
+			if(!this.$project.capabilities.livesyncCompanion && options.companion) {
+				this.$errors.fail("You will be able to LiveSync %s based applications to the Companion app in a future release of the Telerik AppBuilder CLI.", this.$project.projectData.Framework);
+			}
+
+			var projectDir = this.$project.getProjectDir().wait();
+
+			var appIdentifier = AppIdentifier.createAppIdentifier(platform,
+				this.$project.projectData.AppIdentifier, options.companion);
+
+			if(options.file) {
+				try {
+					this.sync(appIdentifier, projectDir, [path.resolve(options.file)]).wait();
+				} catch(e) {
+					var message: string = (e.code === "ENOENT") ? util.format("The file %s does not exist.", options.file) : e.message;
+					this.$errors.failWithoutHelp(message);
+				}
+			} else {
+				var projectFiles = this.$project.enumerateProjectFiles(this.excludedProjectDirsAndFiles).wait();
+
+				this.sync(appIdentifier, projectDir, projectFiles).wait();
+
+				if(options.watch) {
+					this.liveSyncDevices(platform, projectDir, appIdentifier);
+					helpers.exitOnStdinEnd();
+					this.$dispatcher.run();
+				}
+			}
+		}).future<void>()();
+	}
+
+	private getProjectFileInfo(fileName: string): IProjectFileInfo {
+		var platforms = _.map(MobileHelper.PlatformNames,(platformName: string) => MobileHelper.normalizePlatformName(platformName));
+		var parsed = this.parseFile(fileName, platforms, this.$devicesServices.platform);
+		if(!parsed) {
+			parsed = this.parseFile(fileName, ["debug", "release"], "debug");
+		}
+
+		return parsed || {
+			fileName: fileName,
+			onDeviceName: fileName,
+			shouldIncludeFile: true
+		};
+	}
+
+	private parseFile(fileName: string, validValues: string[], value: string): any {
+		var regex = util.format("^(.+?)[.](%s)([.].+?)$", validValues.join("|"));
+		var parsed = fileName.match(new RegExp(regex, "i"));
+		if(parsed) {
+			return {
+				fileName: fileName,
+				onDeviceName: parsed[1] + parsed[3],
+				shouldIncludeFile: parsed[2].toLowerCase() === value.toLowerCase()
+			};
+		}
+
+		return undefined;
+	}
+
+	private sync(appIdentifier: Mobile.IAppIdentifier, projectDir: string, projectFiles: string[]): IFuture<void> {
+		var projectFilesInfo: IProjectFileInfo[] = [];
+
+		_.each(projectFiles,(projectFile: string) => {
+			var projectFileInfo = this.getProjectFileInfo(projectFile);
+			if(projectFileInfo.shouldIncludeFile) {
+				projectFilesInfo.push(projectFileInfo);
+			}
+		});
+
+		return this.syncCore(appIdentifier, projectDir, projectFilesInfo);
+	}
+
+	private syncCore(appIdentifier: Mobile.IAppIdentifier, projectDir: string, projectFiles: IProjectFileInfo[]): IFuture<void> {
+		return (() => {
+			var action = (device: Mobile.IDevice): IFuture<void> => {
+				return (() => {
+					var platformSpecificProjectPath = appIdentifier.deviceProjectPath;
+					var localDevicePaths = this.getLocalToDevicePaths(projectDir, projectFiles, platformSpecificProjectPath);
+					device.sync(localDevicePaths, appIdentifier, this.$project.getLiveSyncUrl()).wait();
+				}).future<void>()();
+			};
+
+			this.$devicesServices.execute(action).wait();
+		}).future<void>()();
+	}
+
+	private getLocalToDevicePaths(localProjectPath: string, projectFiles: IProjectFileInfo[], deviceProjectPath: string): MobileHelper.LocalToDevicePathData[] {
+		var localToDevicePaths = _.map(projectFiles,(projectFileInfo: IProjectFileInfo) => {
+			var relativeToProjectBasePath = helpers.getRelativeToRootPath(localProjectPath, projectFileInfo.onDeviceName);
+			var devicePath = path.join(deviceProjectPath, relativeToProjectBasePath);
+			return new MobileHelper.LocalToDevicePathData(projectFileInfo.fileName, helpers.fromWindowsRelativePathToUnix(devicePath), relativeToProjectBasePath);
+		});
+
+		return localToDevicePaths;
+	}
+
+	private liveSyncDevices(platform: string, projectDir: string, appIdentifier: Mobile.IAppIdentifier): void {
+		var _this = this;
+
+		gaze(projectDir + "/**/*", function(err: any, watcher: any) {
+			this.on('changed',(filePath: string) => {
+				if(!_this.$projectFilesManager.isProjectFileExcluded(projectDir, filePath, _this.excludedProjectDirsAndFiles)) {
+					_this.batchLiveSync(filePath, projectDir, appIdentifier);
+				}
+			});
+		});
+	}
+
+	private timer: Timer = null;
+	private syncQueue: string[] = [];
+	private batchLiveSync(filePath: string, projectDir: string, appIdentifier: Mobile.IAppIdentifier): void {
+		if(!this.timer) {
+			this.timer = setInterval(() => {
+				var filesToSync = this.syncQueue;
+				if(filesToSync.length > 0) {
+					this.syncQueue = [];
+					this.$logger.trace("Syncing %s", filesToSync.join(", "));
+					this.$dispatcher.dispatch(() => this.sync(appIdentifier, projectDir, filesToSync));
+				}
+			}, 500);
+		}
+		this.syncQueue.push(filePath);
+	}
+}
+$injector.register("liveSyncService", LiveSyncService);

--- a/resources/help.txt
+++ b/resources/help.txt
@@ -119,7 +119,6 @@ Creates a project for hybrid or native development. You must run the create comm
 --[/]--
 
 --[create|hybrid]--
-
 Usage:
     $ appbuilder create hybrid <App name> [--template <Template>] [--path <Directory>] [--appid <App ID>]
 
@@ -129,7 +128,7 @@ Creates a new project from an Apache Cordova-based template.
 
 Options:
     --template <Template> - Sets the source template for the project. You can use the following templates:
-        #{cordovaProject.projectTemplatesString}. The default value is KendoUI.TabStrip.
+        <%=#{cordovaProject.projectTemplatesString}%>. The default value is KendoUI.TabStrip.
     --path - Specifies the directory where you want to create the project, if different from the current directory. 
         The directory must be empty.
     --appid - Sets the application identifier for your app. The application identifier must consist of at least three
@@ -150,7 +149,7 @@ Creates a new project from a Mobile Website-based template.
 
 Options:
     --template <Template> - Sets the source template for the project. You can use the following templates:
-        #{mobileWebsiteProject.projectTemplatesString}. The default value is KendoUI.TabStrip.
+        <%=#{mobileWebsiteProject.projectTemplatesString}%>. The default value is KendoUI.TabStrip.
     --path - Specifies the path where you want to create the project, if different from the current directory.
         The directory must be empty.
 
@@ -167,7 +166,7 @@ Creates a new project from a NativeScript-based template.
 
 Options:
     --template <Template> - Sets the source template for the project. You can use the following templates:
-        #{nativeScriptProject.projectTemplatesString}. The default value is Blank.
+        <%=#{nativeScriptProject.projectTemplatesString}%>. The default value is Blank.
     --path - Specifies the path where you want to create the project, if different from the current directory.
         The directory must be empty.
 
@@ -210,7 +209,7 @@ Options:
     The directory must be empty.
     If not specified, the Telerik AppBuilder CLI attempts to clone the sample in the current directory.
 
-#{samplesService.getSamplesInformation}
+<%=#{samplesService.getSamplesInformation}%>
 --[/]--
 
 --[init]--
@@ -427,6 +426,107 @@ package on device only via QR code or by opening the link in the device browser.
 You cannot install the app package manually via cable connection.
 --[/]--
 
+--[build|android]--
+Usage:
+    $ appbuilder build android [--download] [--companion] [--certificate <Certificate ID>][--save-to <File Path>] [--debug] [--release]
+
+Builds the project for the target platform and produces an application package or a QR code for deployment.
+<Certificate ID> is the index or name of the certificate as listed by $ appbuilder certificate.
+
+You can choose which files from your project to exclude or include in your application package by maintaining an .abignore file.
+For more information about .abignore, see https://github.com/Icenium/icenium-cli/blob/release/ABIGNORE.md.
+
+Options:
+    --debug - If set, applies the Debug build configuration. For more information about build configurations,
+        see http://docs.telerik.com/platform/appbuilder/build-configurations/overview
+    --release - If set, applies the Release build configuration. For more information about build configurations,
+        see http://docs.telerik.com/platform/appbuilder/build-configurations/overview
+    --download - If set, downloads the application package to the root of the project, instead
+        of producing a QR code. Set this option if you want to manually deploy the app package later.
+        You cannot set both the --companion and --download switches.
+        If you want to download the application package to a specified file path, use the --save-to option instead.
+    --companion - Produces a QR code for deployment in the Telerik AppBuilder companion app. When deploying to the
+        companion app, you do not need to set a certificate or provision.
+    --certificate - Sets the certificate that you want to use for code signing your Android app. You can set
+        a certificate by index or name.
+        To list available certificates, run $ appbuilder certificate.
+    --save-to - If set, downloads the application package and saves it to the specified file path,
+        instead of the project root. The file path must be complete with file name and extension.
+        You do not need to set the --download switch.
+--[/]--
+
+--[build|ios]--
+Usage:
+    $ appbuilder build ios [--download] [--companion] [--certificate <Certificate ID>] [--provision <Provision ID>] [--save-to <File Path>] [--debug] [--release]
+
+Builds the project for the target platform and produces an application package or a QR code for deployment.
+<Certificate ID> is the index or name of the certificate as listed by $ appbuilder certificate.
+<Provision ID> is the index or name of the provisioning profile as listed by $ appbuilder provision.
+
+You can choose which files from your project to exclude or include in your application package by maintaining an .abignore file.
+For more information about .abignore, see https://github.com/Icenium/icenium-cli/blob/release/ABIGNORE.md.
+
+Options:
+    --debug - If set, applies the Debug build configuration. For more information about build configurations,
+        see http://docs.telerik.com/platform/appbuilder/build-configurations/overview
+    --release - If set, applies the Release build configuration. For more information about build configurations,
+        see http://docs.telerik.com/platform/appbuilder/build-configurations/overview
+    --download - If set, downloads the application package to the root of the project, instead
+        of producing a QR code. Set this option if you want to manually deploy the app package later.
+        You cannot set both the --companion and --download switches.
+        If you want to download the application package to a specified file path, use the --save-to option instead.
+    --companion - Produces a QR code for deployment in the Telerik AppBuilder companion app. When deploying to the
+        companion app, you do not need to set a certificate or provision.
+    --certificate - Sets the certificate that you want to use for code signing your iOS app. You can set
+        a certificate by index or name.
+        Unless the --companion switch is set, you must specify a certificate. The certificate
+        must match the provisioning profile.
+        To list available certificates, run $ appbuilder certificate.
+    --provision - Sets the provisioning profile that you want to use for code signing your iOS app. You can set
+        a provisioning profile by index or name.
+        Unless the --companion switch is set, you must specify a provisioning profile. The 
+        provisioning profile must match the certificate. 
+        To list available provisioning profiles, run $ appbuilder provision.
+    --save-to - If set, downloads the application package and saves it to the specified file path,
+        instead of the project root. The file path must be complete with file name and extension.
+        You do not need to set the --download switch.
+--[/]--
+
+--[build|wp8]--
+Usage:
+    $ appbuilder build wp8 [--download] [--companion] [--save-to <File Path>] [--debug] [--release]
+
+Builds the project for the target platform and produces an application package or a QR code for deployment.
+
+You can choose which files from your project to exclude or include in your application package by maintaining an .abignore file.
+For more information about .abignore, see https://github.com/Icenium/icenium-cli/blob/release/ABIGNORE.md.
+
+Options:
+    --debug - If set, applies the Debug build configuration. For more information about build configurations,
+        see http://docs.telerik.com/platform/appbuilder/build-configurations/overview
+    --release - If set, applies the Release build configuration. For more information about build configurations,
+        see http://docs.telerik.com/platform/appbuilder/build-configurations/overview
+    --download - If set, downloads the application package to the root of the project, instead
+        of producing a QR code. Set this option if you want to manually deploy the app package later.
+        You cannot set both the --companion and --download switches.
+        If you want to download the application package to a specified file path, use the --save-to option instead.
+    --companion - Produces a QR code for deployment in the Telerik AppBuilder companion app. When deploying to the
+        companion app, you do not need to set a certificate or provision.
+    --save-to - If set, downloads the application package and saves it to the specified file path,
+        instead of the project root. The file path must be complete with file name and extension.
+        You do not need to set the --download switch.
+
+When you build without the --download switch, the Telerik AppBuilder CLI lets you download and install
+the Telerik Application Enrollment Token (AET) on your device via QR code. Always make sure that you have
+installed the Telerik AET on the device before attempting to scan the QR code for your Windows Phone app package.
+If the Telerik AET is not installed on the device, the following error message will appear when you attempt
+to install your app: "Before you install this app, you need to add Telerik AD company account".
+
+When you build without the --download switch, you can deploy the app
+package on device only via QR code or by opening the link in the device browser.
+You cannot install the app package manually via cable connection.
+--[/]--
+
 --[provision]--
 Usage:
     $ appbuilder provision [<Provision ID> -v]
@@ -485,6 +585,36 @@ Options:
             hold gesture).
 --[/]--
 
+--[livesync|android]--
+Usage:
+    $ appbuilder livesync android [--device <Device ID>] [--companion] [--watch]
+
+<Device ID> is the device index or identifier as listed by run $ appbuilder device.
+
+Options:
+    --watch - If set, when you save changes to the project, changes are automatically synchronized
+        to the connected device.
+    --device - Specifies the serial number or the index of the connected device to which you want to synchronize changes. 
+        To list all connected devices, grouped by platform, run $ appbuilder device.
+    --companion - If set, when you save changes to the project, changes are automatically synchronized
+        to the Telerik AppBuilder companion app.
+--[/]--
+
+--[livesync|ios]--
+Usage:
+    $ appbuilder livesync ios [--device <Device ID>] [--companion] [--watch]
+
+<Device ID> is the device index or identifier as listed by run $ appbuilder device.
+
+Options:
+    --watch - If set, when you save changes to the project, changes are automatically synchronized
+        to the connected device.
+    --device - Specifies the serial number or the index of the connected device to which you want to synchronize changes. 
+        To list all connected devices, grouped by platform, run $ appbuilder device.
+    --companion - If set, when you save changes to the project, changes are automatically synchronized
+        to the Telerik AppBuilder companion app.
+--[/]--
+
 --[livesync|cloud]--
 Usage:
     $ appbuilder livesync cloud
@@ -507,7 +637,7 @@ Platform-specific usages:
 Builds the project for the selected platform and deploys it to connected physical devices. When you build for Android,
 deploys the project on all connected physical devices and running Android virtual devices. 
 
-In this version of the Telerik AppBuilder CLI, you cannot build and deploy to Windows Phone connected devices. 
+In this version of the Telerik AppBuilder CLI, you cannot build and deploy to Windows Phone connected devices.
 
 In this version of the Telerik AppBuilder CLI, you cannot build and deploy to iOS connected devices on Linux systems.
 
@@ -532,6 +662,66 @@ Options:
     --provision - Sets the provisioning profile that you want to use for code signing your iOS app. You can set a 
         provisioning profile by index or name.
         If you build for iOS, you must specify a provisioning profile. The provisioning profile must match the certificate. 
+        To list available provisioning profiles, run $ appbuilder provision.
+--[/]--
+
+--[deploy|android]--
+Usage:
+    $ appbuilder deploy android [--device <Device ID>] [--certificate <Certificate ID>] [--debug] [--release]
+
+Builds the project for android platform and deploys it to connected physical devices. 
+Deploys the project on all connected physical devices and running Android virtual devices. 
+<% if (isLinux) { %>
+In this version of the Telerik AppBuilder CLI, you cannot build and deploy to iOS connected devices on Linux systems.
+<% } %>
+<Device ID> is the device index or identifier as listed by run $ appbuilder device.
+<Certificate ID> is the index or name of the certificate as listed by $ appbuilder certificate.
+<Provision ID> is the index or name of the provisioning profile as listed by $ appbuilder provision.
+
+You can choose which files from your project to exclude or include in your application package by maintaining an .abignore file.
+For more information about .abignore, see https://github.com/Icenium/icenium-cli/blob/release/ABIGNORE.md.
+
+Options:
+    --debug - If set, applies the Debug build configuration. For more information about build configurations,
+        see http://docs.telerik.com/platform/appbuilder/build-configurations/overview
+    --release - If set, applies the Release build configuration. For more information about build configurations,
+        see http://docs.telerik.com/platform/appbuilder/build-configurations/overview
+    --device - Specifies the serial number or the index of the connected device on which you want to deploy the app.
+        To list all connected devices, grouped by platform, run $ appbuilder device.
+    --certificate - Sets the certificate that you want to use for code signing your Android app. You can set 
+        a certificate by index or name.
+        To list available certificates, run $ appbuilder certificate.
+--[/]--
+
+--[deploy|ios]--
+Usage:
+    $ appbuilder deploy ios [--device <Device ID>] --certificate <Certificate ID> --provision <Provision ID> [--debug] [--release]
+
+Builds the project for ios platform and deploys it to connected physical devices.
+<% if (isLinux) { %>
+In this version of the Telerik AppBuilder CLI, you cannot build and deploy to iOS connected devices on Linux systems.
+<% } %>
+<Device ID> is the device index or identifier as listed by run $ appbuilder device.
+<Certificate ID> is the index or name of the certificate as listed by $ appbuilder certificate.
+<Provision ID> is the index or name of the provisioning profile as listed by $ appbuilder provision.
+
+You can choose which files from your project to exclude or include in your application package by maintaining an .abignore file.
+For more information about .abignore, see https://github.com/Icenium/icenium-cli/blob/release/ABIGNORE.md.
+
+Options:
+    --debug - If set, applies the Debug build configuration. For more information about build configurations,
+        see http://docs.telerik.com/platform/appbuilder/build-configurations/overview
+    --release - If set, applies the Release build configuration. For more information about build configurations,
+        see http://docs.telerik.com/platform/appbuilder/build-configurations/overview
+    --device - Specifies the serial number or the index of the connected device on which you want to deploy the app.
+        To list all connected devices, grouped by platform, run $ appbuilder device.
+    --certificate - Sets the certificate that you want to use for code signing your iOS app. You can set 
+        a certificate by index or name.
+        You must specify a certificate. The certificate must match the provisioning profile.
+        To list available certificates, run $ appbuilder certificate.
+    --provision - Sets the provisioning profile that you want to use for code signing your iOS app. You can set a 
+        provisioning profile by index or name.
+        You must specify a provisioning profile. The provisioning profile must match the certificate. 
         To list available provisioning profiles, run $ appbuilder provision.
 --[/]--
 
@@ -853,7 +1043,7 @@ Usage:
 
 <ConfigurationFile> is the configuration file that you want to open. You can select a configuration file
     for editing by setting any of the following values.
-#{project.configurationFilesString}
+<%=#{project.configurationFilesString}%>
 
 --[/]--
 
@@ -989,28 +1179,44 @@ This command is not applicable to Mobile Website projects.
 
 <Command> is a related command that extends the appmanager command. You can run the following related commands:
     upload - Builds the project and uploads the binary to Telerik AppManager.
---[/]--
-
---[appmanager|upload]--
-Usage:
-    $ appbuilder appmanager upload <Platform> [--certificate <Certificate ID>] [--provision <Provision ID>] [--download]
-
-Platform-specific usage:
+    Platform-specific usage:
     $ appbuilder appmanager upload android --certificate <Certificate ID>
     $ appbuilder appmanager upload ios --certificate <Certificate ID> --provision <Provision ID>
     $ appbuilder appmanager upload wp8
+--[/]--
+
+--[appmanager|upload|android]--
+Usage:
+    $ appbuilder appmanager upload android [--certificate <Certificate ID>] [--download]
+    
+Builds the project and uploads the application to Telerik AppManager.
+After the upload completes, you need to go to your app in Telerik AppManager, manually configure it for distribution and publish it.
+<% if (isMobileWebsite) {%>
+This command is not applicable to Mobile Website projects.
+<% } %>
+<Certificate ID> is the index or name of the certificate as listed by $ appbuilder certificate
+
+Options:
+    --certificate - Sets the certificate that you want to use for code signing your Android app. You can set 
+        a certificate by index or name.
+        To list available certificates, run $ appbuilder certificate
+    --download - If set, downloads the application package to the root of the project.
+--[/]--
+
+--[appmanager|upload|ios]--
+Usage:
+    $ appbuilder appmanager upload ios [--certificate <Certificate ID>] [--provision <Provision ID>] [--download]
 
 Builds the project and uploads the application to Telerik AppManager.
 After the upload completes, you need to go to your app in Telerik AppManager, manually configure it for distribution and publish it.
-
+<% if (isMobileWebsite) { %>
 This command is not applicable to Mobile Website projects.
-
-<Platform> is the target distribution platform. You can set ios, android or wp8.
+<% } %>
 <Certificate ID> is the index or name of the certificate as listed by $ appbuilder certificate
 <Provision ID> is the index or name of the provisioning profile as listed by $ appbuilder provision
 
 Options:
-    --certificate - Sets the certificate that you want to use for code signing your iOS or Android app. You can set 
+    --certificate - Sets the certificate that you want to use for code signing your iOS app. You can set 
         a certificate by index or name.
         To list available certificates, run $ appbuilder certificate
     --provision - Sets the provisioning profile that you want to use for code signing your iOS app. You can set

--- a/test/help.ts
+++ b/test/help.ts
@@ -6,29 +6,293 @@ import yok = require("../lib/common/yok");
 import helpCommand = require("../lib/common/commands/help");
 import stubs = require("./stubs");
 import Future = require("fibers/future");
+import microTemplateServiceLib = require("../lib/common/services/micro-templating-service");
+import dynamicHelpServiceLib = require("../lib/common/services/dynamic-help-service");
+import dynamicHelpProviderLib = require("../lib/dynamic-help-provider");
 
 var assert = require("chai").assert;
 
+var createTestInjector = (options?: { isProjectTypeResult: boolean; isPlatformResult: boolean }): IInjector => {
+	var injector = new yok.Yok();
+	var logger = new stubs.LoggerStub();
+	injector.register("logger", logger);
+	injector.register("errors", stubs.ErrorsStub);
+	options = options || { isPlatformResult: true, isProjectTypeResult: true };
+	injector.register("dynamicHelpProvider", dynamicHelpProviderLib.DynamicHelpProvider);
+	injector.register("dynamicHelpService", {
+		isProjectType: (...args: string[]): IFuture<boolean> => { return Future.fromResult(options.isProjectTypeResult); },
+		isPlatform: (...args: string[]): boolean => { return options.isPlatformResult; },
+		getLocalVariables: (): IFuture<IDictionary<any>> => {
+			return (() => {
+				var localVariables: IDictionary<any> = {};
+				localVariables["isMobileWebsite"] = options.isProjectTypeResult;
+				localVariables["isCordova"] = options.isProjectTypeResult;
+				localVariables["isNativeScript"] = options.isProjectTypeResult;
+				localVariables["isLinux"] = options.isPlatformResult;
+				localVariables["isWindows"] = options.isPlatformResult;
+				localVariables["isMacOS"] = options.isPlatformResult;
+				return localVariables;
+			}).future<IDictionary<any>>()();
+		}
+	});
+	injector.register("microTemplateService", microTemplateServiceLib.MicroTemplateService);
+	
+	injector.register("staticConfig", {
+		helpTextPath: path.join(__dirname, "../resources/help.txt")
+	});
+
+	return injector;
+}
+
 describe("help", () => {
-	it("processes substitution points", () => {
-		var injector = new yok.Yok();
-		var logger = new stubs.LoggerStub();
-		injector.register("logger", logger);
-		injector.register("errors", stubs.ErrorsStub);
-		injector.register("fs", {
-			readText: () => Future.fromResult("--[foo]-- bla #{module.command} bla --[/]--")
-		});
+	it("processes substitution points",() => {
+		var injector = createTestInjector();
 		injector.register("module", {
 			command: () => "woot"
 		});
-		injector.register("staticConfig", {
-			helpTextPath: path.join(__dirname, "../resources/help.txt")
+
+		injector.register("fs", {
+			readText: () => Future.fromResult("--[foo]-- bla <%= #{module.command} %> bla --[/]--")
 		});
 
 		var help = injector.resolve(helpCommand.HelpCommand);
-
 		help.execute(["foo"]).wait();
 
-		assert.equal(logger.output, "bla woot bla\n");
+		assert.equal(injector.resolve("logger").output, "bla woot bla\n");
+	});
+
+	it("process correctly if construction with dynamicCall returning false",() => {
+		var injector = createTestInjector();
+		injector.register("module", {
+			command: () => false
+		});
+
+		injector.register("fs", {
+			readText: () => Future.fromResult("--[foo]-- bla <% if (#{module.command}) { %> bla <% } %>--[/]--")
+		});
+
+		var help = injector.resolve(helpCommand.HelpCommand);
+		help.execute(["foo"]).wait();
+
+		assert.equal(injector.resolve("logger").output, "bla \n");
+	});
+
+	it("process correctly if construction with dynamicCall returning true",() => {
+		var injector = createTestInjector();
+		injector.register("module", {
+			command: () => true
+		});
+
+		injector.register("fs", {
+			readText: () => Future.fromResult("--[foo]-- bla <% if (#{module.command}) { %>bla<% } %>--[/]--")
+		});
+
+		var help = injector.resolve(helpCommand.HelpCommand);
+		help.execute(["foo"]).wait();
+
+		assert.equal(injector.resolve("logger").output, "bla bla\n");
+	});
+
+	it("process correctly if construction returning false",() => {
+		var injector = createTestInjector();
+		injector.register("fs", {
+			readText: () => Future.fromResult("--[foo]-- bla <% if (false) { %> bla <% } %>--[/]--")
+		});
+
+		var help = injector.resolve(helpCommand.HelpCommand);
+		help.execute(["foo"]).wait();
+
+		assert.equal(injector.resolve("logger").output, "bla \n");
+	});
+
+	it("process correctly if construction returning true",() => {
+		var injector = createTestInjector();
+		injector.register("fs", {
+			readText: () => Future.fromResult("--[foo]-- bla <% if (true) { %>bla<% } %>--[/]--")
+		});
+
+		var help = injector.resolve(helpCommand.HelpCommand);
+		help.execute(["foo"]).wait();
+
+		assert.equal(injector.resolve("logger").output, "bla bla\n");
+	});
+
+	it("process correctly is* projectType variables when they are true",() => {
+		var injector = createTestInjector();
+		injector.register("fs", {
+			readText: () => Future.fromResult("--[foo]-- bla <% if (isCordova) { %>isCordova<% } %> <% if(isNativeScript) { %>isNativeScript<%}%> <%if(isMobileWebsite) {%>isMobileWebsite<%}%>--[/]--")
+		});
+
+		var help = injector.resolve(helpCommand.HelpCommand);
+		help.execute(["foo"]).wait();
+
+		assert.equal(injector.resolve("logger").output, "bla isCordova isNativeScript isMobileWebsite\n");
+	});
+
+	it("process correctly is* projectType variables when they are false",() => {
+		var injector = createTestInjector({ isProjectTypeResult: false, isPlatformResult: false });
+		injector.register("fs", {
+			readText: () => Future.fromResult("--[foo]-- bla <% if (isCordova) { %>isCordova<% } %> <% if(isNativeScript) { %>isNativeScript<%}%> <%if(isMobileWebsite) {%>isMobileWebsite<%}%>--[/]--")
+		});
+
+		var help = injector.resolve(helpCommand.HelpCommand);
+		help.execute(["foo"]).wait();
+
+		assert.equal(injector.resolve("logger").output, "bla   \n");
+	});
+
+	it("process correctly is* platform variables when they are true",() => {
+		var injector = createTestInjector();
+		injector.register("fs", {
+			readText: () => Future.fromResult("--[foo]-- bla <% if (isLinux) { %>isLinux<% } %> <% if(isWindows) { %>isWindows<%}%> <%if(isMacOS) {%>isMacOS<%}%>--[/]--")
+		});
+
+		var help = injector.resolve(helpCommand.HelpCommand);
+		help.execute(["foo"]).wait();
+
+		assert.equal(injector.resolve("logger").output, "bla isLinux isWindows isMacOS\n");
+	});
+
+	it("process correctly is* platform variables when they are false",() => {
+		var injector = createTestInjector({ isProjectTypeResult: false, isPlatformResult: false });
+		injector.register("fs", {
+			readText: () => Future.fromResult("--[foo]-- bla <% if (isLinux) { %>isLinux<% } %> <% if(isWindows) { %>isWindows<%}%> <%if(isMacOS) {%>isMacOS<%}%>--[/]--")
+		});
+
+		var help = injector.resolve(helpCommand.HelpCommand);
+		help.execute(["foo"]).wait();
+
+		assert.equal(injector.resolve("logger").output, "bla   \n");
+	});
+
+	it("process correctly is* platform variables when they are false",() => {
+		var injector = createTestInjector({ isProjectTypeResult: false, isPlatformResult: false });
+		injector.register("fs", {
+			readText: () => Future.fromResult("--[foo]-- bla <% if (isLinux) { %>isLinux<% } %> <% if(isWindows) { %>isWindows<%}%> <%if(isMacOS) {%>isMacOS<%}%>--[/]--")
+		});
+
+		var help = injector.resolve(helpCommand.HelpCommand);
+		help.execute(["foo"]).wait();
+
+		assert.equal(injector.resolve("logger").output, "bla   \n");
+	});
+
+	it("process correctly multiple if statements with local variables (all are true)",() => {
+		var injector = createTestInjector();
+		injector.register("fs", {
+			// all variables must be true
+			readText: () => Future.fromResult("--[foo]-- bla <% if (isLinux) { %><% if(isCordova) {%>isLinux and isCordova <% } %><% } %>end--[/]--")
+		});
+
+		var help = injector.resolve(helpCommand.HelpCommand);
+		help.execute(["foo"]).wait();
+
+		assert.equal(injector.resolve("logger").output, "bla isLinux and isCordova end\n");
+	});
+
+	it("process correctly multiple if statements with local variables (all are false)",() => {
+		var injector = createTestInjector({ isProjectTypeResult: false, isPlatformResult: false });
+		injector.register("fs", {
+			// all variables must be false
+			readText: () => Future.fromResult("--[foo]-- bla <% if (isLinux) { %><% if(isCordova) {%>isLinux and isCordova <% } %><% } %>end--[/]--")
+		});
+
+		var help = injector.resolve(helpCommand.HelpCommand);
+		help.execute(["foo"]).wait();
+
+		assert.equal(injector.resolve("logger").output, "bla end\n");
+	});
+
+	it("process correctly multiple if statements with local variables (isProjectType is false, isPlatform is true)",() => {
+		var injector = createTestInjector({ isProjectTypeResult: false, isPlatformResult: true });
+		injector.register("fs", {
+			readText: () => Future.fromResult("--[foo]-- bla <% if (isLinux) { %>isLinux <% if(isCordova) {%>isCordova <% } %><% } %>end--[/]--")
+		});
+
+		var help = injector.resolve(helpCommand.HelpCommand);
+		help.execute(["foo"]).wait();
+
+		assert.equal(injector.resolve("logger").output, "bla isLinux end\n");
+	});
+
+	it("process correctly multiple if statements with dynamicCalls (all are true)",() => {
+		var injector = createTestInjector();
+		injector.register("module", {
+			command1: () => true,
+			command2: () => true
+		});
+		injector.register("fs", {
+			readText: () => Future.fromResult("--[foo]-- bla <% if (#{module.command1}) { %>command1<% if(#{module.command2}) {%> and command2 <% } %><% } %>end--[/]--")
+		});
+
+		var help = injector.resolve(helpCommand.HelpCommand);
+		help.execute(["foo"]).wait();
+
+		assert.equal(injector.resolve("logger").output, "bla command1 and command2 end\n");
+	});
+
+	it("process correctly multiple if statements with dynamicCalls (all are false)",() => {
+		var injector = createTestInjector();
+		injector.register("module", {
+			command1: () => false,
+			command2: () => false
+		});
+		injector.register("fs", {
+			readText: () => Future.fromResult("--[foo]-- bla <% if (#{module.command1}) { %>command1<% if(#{module.command2}) {%> and command2 <% } %><% } %>end--[/]--")
+		});
+
+		var help = injector.resolve(helpCommand.HelpCommand);
+		help.execute(["foo"]).wait();
+
+		assert.equal(injector.resolve("logger").output, "bla end\n");
+	});
+
+	it("process correctly multiple if statements with dynamicCalls (different result)",() => {
+		var injector = createTestInjector();
+		injector.register("module", {
+			command1: () => true,
+			command2: () => false,
+			command3: () => false
+		});
+		injector.register("fs", {
+			readText: () => Future.fromResult("--[foo]-- bla <% if (#{module.command1}) { %>command1 <% if(#{module.command2}) {%> and command2 <% if(#{module.command3}) { %>and command3 <% } %> <% } %><% } %>end--[/]--")
+		});
+
+		var help = injector.resolve(helpCommand.HelpCommand);
+		help.execute(["foo"]).wait();
+
+		assert.equal(injector.resolve("logger").output, "bla command1 end\n");
+	});
+
+	it("process correctly multiple dynamicCalls",() => {
+		var injector = createTestInjector();
+		injector.register("module", {
+			command1: () => "command1",
+			command2: () => "command2",
+			command3: () => "command3"
+		});
+		injector.register("fs", {
+			readText: () => Future.fromResult("--[foo]-- bla <%= #{module.command1}%> <%= #{module.command2} %> <%= #{module.command3} %> end--[/]--")
+		});
+
+		var help = injector.resolve(helpCommand.HelpCommand);
+		help.execute(["foo"]).wait();
+
+		assert.equal(injector.resolve("logger").output, "bla command1 command2 command3 end\n");
+	});
+
+	it("process correctly dynamicCalls with parameters",() => {
+		var injector = createTestInjector();
+		injector.register("module", {
+			command1: (...args:string[]) => args.join(" ")
+		});
+		injector.register("fs", {
+			readText: () => Future.fromResult("--[foo]-- bla <%= #{module.command1(param1, param2)}%> end--[/]--")
+		});
+
+		var help = injector.resolve(helpCommand.HelpCommand);
+		help.execute(["foo"]).wait();
+
+		assert.equal(injector.resolve("logger").output, "bla param1 param2 end\n");
 	});
 });


### PR DESCRIPTION
Refactor several commands in order to be mobile platform specific - deploy, build, livesync, appmanager upload.
Update help.txt to support boolean conditions in order to understand if part of the help.txt should be included in the output.
Use lodash _.template in order to allow using of javascript code directly in help.txt file.
In case you want to call some method that returns string and you need the string in help.txt just write:
Some text... <%= this.$injector.resolve("project").myMethod() %> or even simpler:
Some text... <%= #{project.myMethod} %>
The code between <%= and %> will be executed (it's pure javascript, but you are able to use our $injector and $dynamicHelpService) and the returned string will be placed in the help file.

In case you want to limit some text only for specific case, just write:
<% if (this.$dynamicHelpService.isPlatform("linux")) { %>
In this version of the Telerik AppBuilder CLI, you cannot build and deploy to iOS connected devices on Linux systems.
<% } %>
This way the code in if statement will be shown only in case command is run on linux.

Add localVariables that allow easy call for default scenarios (isLinux, isMacOS, is Windows, isCordova, isNativeScript, isMobileWebsite). In order to use it, just call:
\<% if (isCordova) %\>

Add replace of all entries, which match our dynamicCallRegex with this.$injector.dynamicCall($1).wait()
This way you can call dynamic methods, by just using:
\<%= #{cordovaProject.projectTemplatesString} %\>

Add dynamicHelpProvider.

Add unit tests.

http://teampulse.telerik.com/view#item/283188