### PR TITLE
Allow publishing with WPSdk 8.1

### DIFF
--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -190,6 +190,8 @@ interface IProjectData extends IDictionary<any> {
 	WP8Requirements: string[];
 	WP8SupportedResolutions: string[];
 	WPSdk?: string;
+	WP8PackageIdentityName?: string;
+	WP8WindowsPublisherName?: string;
 	CordovaPluginVariables?: any;
 }
 

--- a/lib/project/cordova-project.ts
+++ b/lib/project/cordova-project.ts
@@ -10,6 +10,9 @@ import MobileHelper = require("../common/mobile/mobile-helper");
 import options = require("../options");
 
 export class CordovaProject extends frameworkProjectBaseLib.FrameworkProjectBase implements Project.IFrameworkProject {
+	private static WP8_DEFAULT_PACKAGE_IDENTITY_NAME_PREFIX = "1234Telerik";
+	private static WP8_DEFAULT_WP8_WINDOWS_PUBLISHER_NAME = "CN=Telerik";
+
 	constructor(private $config: IConfiguration,
 		$fs: IFileSystem,
 		$errors: IErrors,
@@ -79,6 +82,7 @@ export class CordovaProject extends frameworkProjectBaseLib.FrameworkProjectBase
 
 		properties.WP8ProductID = helpers.createGUID();
 		properties.WP8PublisherID = helpers.createGUID();
+		properties.WP8PackageIdentityName = CordovaProject.WP8_DEFAULT_PACKAGE_IDENTITY_NAME_PREFIX + properties.AppIdentifier;
 	}
 
 	public projectTemplatesString(): IFuture<string> {
@@ -102,6 +106,8 @@ export class CordovaProject extends frameworkProjectBaseLib.FrameworkProjectBase
 			buildProperties.WP8Capabilities = projectData.WP8Capabilities;
 			buildProperties.WP8Requirements = projectData.WP8Requirements;
 			buildProperties.WP8SupportedResolutions = projectData.WP8SupportedResolutions;
+			buildProperties.WP8PackageIdentityName = projectData.WP8PackageIdentityName;
+			buildProperties.WP8WindowsPublisherName = projectData.WP8WindowsPublisherName;
 		}
 
 		return buildProperties;
@@ -164,6 +170,21 @@ export class CordovaProject extends frameworkProjectBaseLib.FrameworkProjectBase
 				updated = true;
 			}
 		});
+
+		if(!_.has(properties, "WP8PackageIdentityName")) {
+			var wp8PackageIdentityName = CordovaProject.WP8_DEFAULT_PACKAGE_IDENTITY_NAME_PREFIX + properties.AppIdentifier;
+			this.$logger.warn("Missing 'WP8PackageIdentityName' property in .abproject. Default value '%s' will be used.", wp8PackageIdentityName);
+			properties.WP8PackageIdentityName = wp8PackageIdentityName;
+			updated = true;
+		}
+
+		if(!_.has(properties, "WP8WindowsPublisherName")) {
+			var wp8WindowsPublisherName = CordovaProject.WP8_DEFAULT_WP8_WINDOWS_PUBLISHER_NAME;
+			this.$logger.warn("Missing 'WP8WindowsPublisherName' property in .abproject. Default value '%s' will be used.", wp8WindowsPublisherName);
+			properties.WP8WindowsPublisherName = wp8WindowsPublisherName;
+			updated = true;
+		}
+
 
 		return updated;
 	}

--- a/lib/services/build.ts
+++ b/lib/services/build.ts
@@ -228,6 +228,12 @@ export class BuildService implements Project.IBuildService {
 				return buildResult;
 			} else if(settings.platform === "WP8") {
 				var buildCompanyHubApp = !settings.downloadFiles;
+				if(this.$project.projectData.WPSdk === "8.1" && ((options.release && settings.downloadFiles) || settings.buildForTAM)) {
+					this.$logger.warn("Verify that you have configured your project for publishing in the Windows Phone Store. For more information see: %s",
+						settings.buildForTAM ? "http://docs.telerik.com/platform/appbuilder/publishing-your-app/publish-appmanager#prerequisites" :
+						"http://docs.telerik.com/platform/appbuilder/publishing-your-app/distribute-production/publish-wp8#prerequisites");
+				}
+
 				if(buildCompanyHubApp) {
 					buildProperties.WP8CompanyHubApp = true;
 					if(settings.showWp8SigningMessage === undefined) {

--- a/lib/services/project-properties-service.ts
+++ b/lib/services/project-properties-service.ts
@@ -9,6 +9,8 @@ import helpers = require("../helpers");
 import MobileHelper = require("../common/mobile/mobile-helper");
 
 export class ProjectPropertiesService implements IProjectPropertiesService {
+	private static PROJECT_VERSION_DEFAULT_VALUE = 1;
+	
 	constructor(private $frameworkProjectResolver: Project.IFrameworkProjectResolver,
 		private $fs: IFileSystem,
 		private $errors: IErrors,
@@ -36,7 +38,7 @@ export class ProjectPropertiesService implements IProjectPropertiesService {
 
 		if(!_.has(properties, "projectVersion")) {
 			this.$logger.warn("Missing 'projectVersion' property in .abproject. Default value '1' will be used.");
-			properties["projectVersion"] = 1;
+			properties.projectVersion = ProjectPropertiesService.PROJECT_VERSION_DEFAULT_VALUE;
 			updated = true;
 		}
 

--- a/resources/json-schemas/WP.json
+++ b/resources/json-schemas/WP.json
@@ -16,6 +16,18 @@
 			"pattern": "(\\{)?[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}(\\})?",
 			"errorMessage": "The publisher ID must be a GUID string enclosed in curly braces."
 		},
+		"WP8PackageIdentityName": {
+			"type": "string",
+			"description": "Describes the contents of the package. The Name attribute is case-sensitive.",
+			"pattern": "^[a-zA-Z0-9.-]{3,50}$",
+			"errorMessage": "A string between 3 and 50 characters in length that consists of alpha-numeric, period, and dash characters."
+		},
+		"WP8WindowsPublisherName": {
+			"type": "string",
+			"description": "Windows publisher name of the account that will be used to publish the application in the store.",
+			"pattern": "(CN|L|O|OU|E|C|S|STREET|T|G|I|SN|DC|SERIALNUMBER|(OID\\.(0|[1-9][0-9]*)(\\.(0|[1-9][0-9]*))+))=(([^,+=\"&lt;&gt;#;])+|\".*\")(, ((CN|L|O|OU|E|C|S|STREET|T|G|I|SN|DC|SERIALNUMBER|(OID\\.(0|[1-9][0-9]*)(\\.(0|[1-9][0-9]*))+))=(([^,+=\"&lt;&gt;#;])+|\".*\")))*",
+			"errorMessage": "The Windows publisher name must be compliant with CertNameToStr Windows API implementation of X.500 rules."
+		},
 		"WP8Capabilities": {
 			"type": "array",
 			"description": "List of Windows Phone 8 application capabilities",

--- a/test/resources/blank-Cordova.abproject
+++ b/test/resources/blank-Cordova.abproject
@@ -25,12 +25,14 @@
     ]
     ,"AndroidHardwareAcceleration": "false"
     ,"iOSStatusBarStyle": "Default"
-	,"WPSdk": "8.0"
+    ,"WPSdk": "8.0"
     ,"WP8SupportedResolutions": [
       "ID_RESOLUTION_WVGA",
       "ID_RESOLUTION_WXGA",
       "ID_RESOLUTION_HD720P"
     ]
+    ,"WP8PackageIdentityName": "1234Telerikcom.telerik.Test"
+    ,"WP8WindowsPublisherName": "CN=Telerik"
     ,"Framework": "Cordova"
     ,"ProjectTypeGuids": "{070BCB52-5A75-4F8C-A973-144AF0EAFCC9}"
 }


### PR DESCRIPTION
Add required properties in order to be able to publish apps that target WPSdk 8.1. Add warning when calling $ appbuilder build wp8 --release --download (this is the common way to publish app to WP Store - build in release configuration and download the xap) and when calling $appbuilder appmanager upload wp8. Add code to complete these properties if they do not exist in current abproject.

http://teampulse.telerik.com/view#item/286652