### PR TITLE
Fix edit-configuration command

### DIFF
--- a/lib/project/cordova-project.ts
+++ b/lib/project/cordova-project.ts
@@ -54,7 +54,14 @@ export class CordovaProject extends frameworkProjectBaseLib.FrameworkProjectBase
 
 	public get configFiles(): Project.IConfigurationFile[] {
 		var allConfigFiles = this.$projectFilesManager.availableConfigFiles;
-		return _.values(allConfigFiles);
+		return [
+			allConfigFiles["cordova-android-manifest"],
+			allConfigFiles["android-config"],
+			allConfigFiles["ios-info"],
+			allConfigFiles["ios-config"],
+			allConfigFiles["wp8-manifest"],
+			allConfigFiles["wp8-config"]
+		]
 	}
 
 	public get startPackageActivity(): string {

--- a/lib/project/nativescript-project.ts
+++ b/lib/project/nativescript-project.ts
@@ -56,7 +56,7 @@ export class NativeScriptProject extends frameworkProjectBaseLib.FrameworkProjec
 		var allConfigFiles = this.$projectFilesManager.availableConfigFiles;
 		return [
 			allConfigFiles["ios-info"],
-			allConfigFiles["android-manifest"]
+			allConfigFiles["nativescript-android-manifest"]
 		]
 	}
 

--- a/lib/project/project-files-manager.ts
+++ b/lib/project/project-files-manager.ts
@@ -27,10 +27,16 @@ export class ProjectFilesManager implements Project.IProjectFilesManager {
 
 	public get availableConfigFiles(): IDictionary<Project.IConfigurationFile> {
 		return {
-			"android-manifest": new ConfigurationFile(
+			"cordova-android-manifest": new ConfigurationFile(
 				"android-manifest",
 				"App_Resources/Android/AndroidManifest.xml",
-				"Mobile.Android.ManifestXml.zip",
+				"Mobile.Cordova.Android.ManifestXml.zip",
+				"Opens AndroidManifest.xml for editing and creates it, if needed."
+			),
+			"nativescript-android-manifest": new ConfigurationFile(
+				"android-manifest",
+				"App_Resources/Android/AndroidManifest.xml",
+				"Mobile.NativeScript.Android.ManifestXml.zip",
 				"Opens AndroidManifest.xml for editing and creates it, if needed."
 			),
 			"android-config": new ConfigurationFile(

--- a/test/edit-configuration.ts
+++ b/test/edit-configuration.ts
@@ -26,7 +26,7 @@ testInjector.register("project", {
 	ensureProject: () => {},
 	projectConfigFiles: [{ template: "android-manifest",
 		filepath: "App_Resources/Android/AndroidManifest.xml",
-		templateFilepath: "Mobile.Android.ManifestXml.zip",
+		templateFilepath: "Mobile.Cordova.Android.ManifestXml.zip",
 		helpText: "" }]
 });
 testInjector.register("errors", stubs.ErrorsStub);


### PR DESCRIPTION
Mobile.Android.ManifestXml.zip on the server had been renamed to Mobile.Cordova.Android.ManifestXml.zip  Also there's additional file - Mobile.NativeScript.Android.ManifestXml.zip  which is used now. This breaks our unit tests and $ appbuilder edit-configuration android-manifest calls.

Add cordova-android-manifest and nativescript-android-manifest configs in order to fix the issue.