### PR TITLE
Fix WP8PackageIdentityName setting

### DIFF
--- a/lib/project/cordova-project.ts
+++ b/lib/project/cordova-project.ts
@@ -89,7 +89,7 @@ export class CordovaProject extends frameworkProjectBaseLib.FrameworkProjectBase
 
 		properties.WP8ProductID = helpers.createGUID();
 		properties.WP8PublisherID = helpers.createGUID();
-		properties.WP8PackageIdentityName = CordovaProject.WP8_DEFAULT_PACKAGE_IDENTITY_NAME_PREFIX + properties.AppIdentifier;
+		properties.WP8PackageIdentityName = util.format("%s.%s", CordovaProject.WP8_DEFAULT_PACKAGE_IDENTITY_NAME_PREFIX, properties.ProjectName);
 	}
 
 	public projectTemplatesString(): IFuture<string> {
@@ -179,7 +179,7 @@ export class CordovaProject extends frameworkProjectBaseLib.FrameworkProjectBase
 		});
 
 		if(!_.has(properties, "WP8PackageIdentityName")) {
-			var wp8PackageIdentityName = CordovaProject.WP8_DEFAULT_PACKAGE_IDENTITY_NAME_PREFIX + properties.AppIdentifier;
+			var wp8PackageIdentityName = util.format("%s.%s", CordovaProject.WP8_DEFAULT_PACKAGE_IDENTITY_NAME_PREFIX, properties.ProjectName);
 			this.$logger.warn("Missing 'WP8PackageIdentityName' property in .abproject. Default value '%s' will be used.", wp8PackageIdentityName);
 			properties.WP8PackageIdentityName = wp8PackageIdentityName;
 			updated = true;


### PR DESCRIPTION
Use the following format as default "1234Telerik.<ProjectName>" so you can use project names with the max length 30 symbols.

Fixes http://teampulse.telerik.com/view#item/286977