### PR TITLE
Fix WP8PackageIdentityName setting

### DIFF
--- a/lib/project/cordova-project.ts
+++ b/lib/project/cordova-project.ts
@@ -89,7 +89,12 @@ export class CordovaProject extends frameworkProjectBaseLib.FrameworkProjectBase
 
 		properties.WP8ProductID = helpers.createGUID();
 		properties.WP8PublisherID = helpers.createGUID();
-		properties.WP8PackageIdentityName = CordovaProject.WP8_DEFAULT_PACKAGE_IDENTITY_NAME_PREFIX + properties.AppIdentifier;
+		properties.WP8PackageIdentityName = this.getCorrectWP8PackageIdentityName(properties.ProjectName);
+	}
+
+	private getCorrectWP8PackageIdentityName(projectName: string) {
+		var sanitizedName = projectName ? _.filter(projectName.split(""),(c) => /[a-zA-Z0-9.-]/.test(c)).join("") : "";
+		return util.format("%s.%s", CordovaProject.WP8_DEFAULT_PACKAGE_IDENTITY_NAME_PREFIX, sanitizedName); 
 	}
 
 	public projectTemplatesString(): IFuture<string> {
@@ -179,7 +184,7 @@ export class CordovaProject extends frameworkProjectBaseLib.FrameworkProjectBase
 		});
 
 		if(!_.has(properties, "WP8PackageIdentityName")) {
-			var wp8PackageIdentityName = CordovaProject.WP8_DEFAULT_PACKAGE_IDENTITY_NAME_PREFIX + properties.AppIdentifier;
+			var wp8PackageIdentityName = this.getCorrectWP8PackageIdentityName(properties.ProjectName);
 			this.$logger.warn("Missing 'WP8PackageIdentityName' property in .abproject. Default value '%s' will be used.", wp8PackageIdentityName);
 			properties.WP8PackageIdentityName = wp8PackageIdentityName;
 			updated = true;

--- a/test/resources/blank-Cordova.abproject
+++ b/test/resources/blank-Cordova.abproject
@@ -31,7 +31,7 @@
       "ID_RESOLUTION_WXGA",
       "ID_RESOLUTION_HD720P"
     ]
-    ,"WP8PackageIdentityName": "1234Telerikcom.telerik.Test"
+    ,"WP8PackageIdentityName": "1234Telerik.Test"
     ,"WP8WindowsPublisherName": "CN=Telerik"
     ,"Framework": "Cordova"
     ,"ProjectTypeGuids": "{070BCB52-5A75-4F8C-A973-144AF0EAFCC9}"


### PR DESCRIPTION
Use the following format as default "1234Telerik." so you can use project names with the max length 30 symbols.

Fixes http://teampulse.telerik.com/view#item/286977