### PR TITLE
Respect configuration passed to build method

### DIFF
--- a/lib/services/build.ts
+++ b/lib/services/build.ts
@@ -331,7 +331,7 @@ export class BuildService implements Project.IBuildService {
 
 			this.$jsonSchemaValidator.validate(this.$project.projectData);
 
-			settings.configuration = options.release ? "Release" : "Debug";
+			settings.configuration = settings.configuration || (options.release ? "Release" : "Debug");
 			this.$logger.info("Building project for platform '%s', configuration '%s'", settings.platform, settings.configuration);
 
 			this.$platformMigrator.ensureAllPlatformAssets().wait();


### PR DESCRIPTION
Build method has BuildSettings passed as parameter. Respect the configuration passed in these settings (if it has such). This fixes the problem that calling $ appbuilder appstore upload <app_name> builds the app in Debug configuration and it is rejected by iTunes. The command correctly sets BuildSettings configuration to release, but build method does not respect it.

Fixes http://teampulse.telerik.com/view#item/287256