### PR TITLE
Use AppIdentifier when setting WP8PackageIdentityName

### DIFF
--- a/lib/project/cordova-project.ts
+++ b/lib/project/cordova-project.ts
@@ -89,12 +89,11 @@ export class CordovaProject extends frameworkProjectBaseLib.FrameworkProjectBase
 
 		properties.WP8ProductID = helpers.createGUID();
 		properties.WP8PublisherID = helpers.createGUID();
-		properties.WP8PackageIdentityName = this.getCorrectWP8PackageIdentityName(properties.ProjectName);
+		properties.WP8PackageIdentityName = this.getCorrectWP8PackageIdentityName(properties.AppIdentifier);
 	}
 
-	private getCorrectWP8PackageIdentityName(projectName: string) {
-		var sanitizedName = projectName ? _.filter(projectName.split(""),(c) => /[a-zA-Z0-9.-]/.test(c)).join("") : "";
-		return util.format("%s.%s", CordovaProject.WP8_DEFAULT_PACKAGE_IDENTITY_NAME_PREFIX, sanitizedName); 
+	private getCorrectWP8PackageIdentityName(appIdentifier: string) {
+		return util.format("%s.%s", CordovaProject.WP8_DEFAULT_PACKAGE_IDENTITY_NAME_PREFIX, appIdentifier).substr(0, 50);
 	}
 
 	public projectTemplatesString(): IFuture<string> {
@@ -184,7 +183,7 @@ export class CordovaProject extends frameworkProjectBaseLib.FrameworkProjectBase
 		});
 
 		if(!_.has(properties, "WP8PackageIdentityName")) {
-			var wp8PackageIdentityName = this.getCorrectWP8PackageIdentityName(properties.ProjectName);
+			var wp8PackageIdentityName = this.getCorrectWP8PackageIdentityName(properties.AppIdentifier);
 			this.$logger.warn("Missing 'WP8PackageIdentityName' property in .abproject. Default value '%s' will be used.", wp8PackageIdentityName);
 			properties.WP8PackageIdentityName = wp8PackageIdentityName;
 			updated = true;

--- a/test/project.ts
+++ b/test/project.ts
@@ -519,3 +519,52 @@ describe("project unit tests (canonical paths)", () => {
 	});
 });
 
+describe("cordovaProject unit tests",() => {
+	var projectProperties: IProjectPropertiesService, testInjector: IInjector;
+
+	beforeEach(() => {
+		testInjector = createTestInjector();
+		testInjector.register("fs", fslib.FileSystem);
+
+		testInjector.register("config", require("../lib/config").Configuration);
+		testInjector.register("staticConfig", require("../lib/config").StaticConfig);
+		var config = testInjector.resolve("config");
+		var staticConfig = testInjector.resolve("staticConfig");
+		staticConfig.PROJECT_FILE_NAME = "";
+		config.AUTO_UPGRADE_PROJECT_FILE = false;
+
+		projectProperties = testInjector.resolve(projectPropertiesLib.ProjectPropertiesService);
+	});
+
+	describe("alterPropertiesForNewProject",() => {
+		it("sets correct WP8PackageIdentityName when appid is short",() => {
+			var cordovaProject: Project.IFrameworkProject = testInjector.resolve("cordovaProject");
+			var props: any = {};
+			options.appid = "appId";
+			cordovaProject.alterPropertiesForNewProject(props, "name");
+			assert.equal(props["WP8PackageIdentityName"], "1234Telerik.appId");
+		});
+
+		it("sets correct WP8PackageIdentityName when appid combined with default prefix has 50 symbols length",() => {
+			var cordovaProject: Project.IFrameworkProject = testInjector.resolve("cordovaProject");
+			var props: any = {};
+			var defaultPrefix = "1234Telerik.";
+			var value = _.range(0, 50 - defaultPrefix.length).map(num => "a").join("");
+			options.appid = value;
+
+			cordovaProject.alterPropertiesForNewProject(props, "name");
+			assert.equal(props["WP8PackageIdentityName"], defaultPrefix + value);
+		});
+
+		it("sets correct WP8PackageIdentityName when appid combined with default prefix has more than 50 symbols length",() => {
+			var cordovaProject: Project.IFrameworkProject = testInjector.resolve("cordovaProject");
+			var props: any = {};
+			var defaultPrefix = "1234Telerik.";
+			var value = _.range(0, 50 - defaultPrefix.length).map(num => "a").join("");
+			options.appid = value + "another long value that should be omitted at the end";
+
+			cordovaProject.alterPropertiesForNewProject(props, "name");
+			assert.equal(props["WP8PackageIdentityName"], defaultPrefix + value);
+		});
+	});
+});

--- a/test/resources/blank-Cordova.abproject
+++ b/test/resources/blank-Cordova.abproject
@@ -31,7 +31,7 @@
       "ID_RESOLUTION_WXGA",
       "ID_RESOLUTION_HD720P"
     ]
-    ,"WP8PackageIdentityName": "1234Telerik.Test"
+    ,"WP8PackageIdentityName": "1234Telerik.com.telerik.Test"
     ,"WP8WindowsPublisherName": "CN=Telerik"
     ,"Framework": "Cordova"
     ,"ProjectTypeGuids": "{070BCB52-5A75-4F8C-A973-144AF0EAFCC9}"


### PR DESCRIPTION
As we've decided to use same default value for WP8PackageIdentityName, which is 1234Telerik.\<appid\>, I've changed the getCorrectWP8PackageIdentityName to use AppIdentifier property. In case the value is longer than 50 symbols, only the first 50 are taken.
Add unit tests.

http://teampulse.telerik.com/view#item/287429