### PR TITLE
Fix hierarchical commands

### DIFF
--- a/resources/help.txt
+++ b/resources/help.txt
@@ -295,17 +295,26 @@ the project retains any existing project configuration.
 
 --[device]--
 Usage:
-    $ appbuilder device [<Platform>] [--timeout  <Milliseconds>]
     $ appbuilder device [<Command>]
 
-Platform-specific usage:
-    $ appbuilder device android
-    $ appbuilder device ios
 
 Lists all recognized connected devices with serial number and index, grouped by platform. In this version of the Telerik AppBuilder CLI,
 you can connect only iOS and Android devices.
 
-When the target platform is Android, the Telerik AppBuilder CLI lists all connected physical and running Android virtual devices.
+<Command> is a related command that extends the device command. You can run the following related commands:
+    android - Lists all recognized connected Android physical and running Android virtual devices.
+    ios - Lists all recognized connected iOS devices.
+    log - Opens the device log stream for a selected connected device.
+    list-applications - Lists the installed applications on all connected Android <% if(isWindows || isMacOS) { %>or iOS <%}%>devices.
+    run - Runs the selected application on a connected Android <% if(isMacOS) { %>or iOS <%}%>device.
+
+--[/]--
+
+--[device|android]--
+Usage:
+    $ appbuilder device android [--timeout <Milliseconds>]
+
+Lists all recognized connected physical and running virtual devices with serial number and index.
 
 If a connected Android device is not shown in the list, make sure that you have installed the required Android USB drivers on your system
 and that USB debugging is enabled on the device.
@@ -314,11 +323,18 @@ Options:
    --timeout - Sets the time in milliseconds for the operation to search for connected devices before completing.
       The operation will continue to wait and listen for newly connected devices and will list them
       after the specified time expires. If not set, the default value is 4000.
+--[/]--
 
-<Command> is a related command that extends the device command. You can run the following related commands:
-    log - Opens the device log stream for a selected connected device.
-    list-applications - Lists the installed applications on all connected Android or iOS devices.
-    run - Runs the selected application on a connected Android or iOS device.
+--[device|ios]--
+Usage:
+    $ appbuilder device ios [--timeout <Milliseconds>]
+
+Lists all recognized connected iOS devices with serial number and index.
+
+Options:
+   --timeout - Sets the time in milliseconds for the operation to search for connected devices before completing.
+      The operation will continue to wait and listen for newly connected devices and will list them
+      after the specified time expires. If not set, the default value is 4000.
 
 --[/]--
 


### PR DESCRIPTION
Update common lib where a fix for hierarchical commands had been applied. Add help for new commands - '$ appbuilder device android' and '$ appbuilder device ios'

Fix is part of http://teampulse.telerik.com/view#item/283188