### PR TITLE
Replace  appbuilder strings with CLIENT_NAME

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -161,3 +161,4 @@ $injector.require("jsonSchemaConstants", "./json-schema/json-schema-constants");
 $injector.require("liveSyncService", "./services/livesync-service");
 $injector.require("appManagerService", "./services/appmanager-service");
 $injector.require("dynamicHelpProvider", "./dynamic-help-provider");
+$injector.require("mobilePlatformsCapabilities", "./mobile-platforms-capabilities");

--- a/lib/commands/appmanager.ts
+++ b/lib/commands/appmanager.ts
@@ -1,13 +1,12 @@
 ///<reference path="../.d.ts"/>
 "use strict";
 
-import MobileHelper = require("../common/mobile/mobile-helper");
-
 class AppManagerUploadAndroidCommand implements ICommand {
-	constructor(private $appManagerService: IAppManagerService) { }
+	constructor(private $appManagerService: IAppManagerService,
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) { }
 
 	execute(args: string[]): IFuture<void> {
-		return this.$appManagerService.upload(MobileHelper.DevicePlatforms[MobileHelper.DevicePlatforms.Android].toLowerCase());
+		return this.$appManagerService.upload(this.$devicePlatformsConstants.Android.toLowerCase());
 	}
 
 	allowedParameters: ICommandParameter[] = [];
@@ -15,10 +14,11 @@ class AppManagerUploadAndroidCommand implements ICommand {
 $injector.registerCommand("appmanager|upload|android", AppManagerUploadAndroidCommand);
 
 class AppManagerUploadIosCommand implements ICommand {
-	constructor(private $appManagerService: IAppManagerService) { }
+	constructor(private $appManagerService: IAppManagerService,
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) { }
 
 	execute(args: string[]): IFuture<void> {
-		return this.$appManagerService.upload(MobileHelper.DevicePlatforms[MobileHelper.DevicePlatforms.iOS]);
+		return this.$appManagerService.upload(this.$devicePlatformsConstants.iOS.toLowerCase());
 	}
 
 	allowedParameters: ICommandParameter[] = [];
@@ -26,10 +26,11 @@ class AppManagerUploadIosCommand implements ICommand {
 $injector.registerCommand("appmanager|upload|ios", AppManagerUploadIosCommand);
 
 class AppManagerUploadWP8Command implements ICommand {
-	constructor(private $appManagerService: IAppManagerService) { }
+	constructor(private $appManagerService: IAppManagerService,
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) { }
 
 	execute(args: string[]): IFuture<void> {
-		return this.$appManagerService.upload(MobileHelper.DevicePlatforms[MobileHelper.DevicePlatforms.WP8]);
+		return this.$appManagerService.upload(this.$devicePlatformsConstants.WP8.toLowerCase());
 	}
 
 	allowedParameters: ICommandParameter[] = [];

--- a/lib/commands/build.ts
+++ b/lib/commands/build.ts
@@ -1,37 +1,38 @@
 ///<reference path="../.d.ts"/>
 "use strict";
 
-import MobileHelper = require("../common/mobile/mobile-helper");
-
 export class BuildAndroidCommand implements ICommand {
-	constructor(private $buildService: Project.IBuildService) { }
+	constructor(private $buildService: Project.IBuildService,
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) { }
 
 	allowedParameters: ICommandParameter[] = [];
 
 	execute(args: string[]): IFuture<void> {
-		return this.$buildService.executeBuild(MobileHelper.DevicePlatforms[MobileHelper.DevicePlatforms.Android]);
+		return this.$buildService.executeBuild(this.$devicePlatformsConstants.Android);
 	}
 }
 $injector.registerCommand("build|android", BuildAndroidCommand);
 
 export class BuildIosCommand implements ICommand {
-	constructor(private $buildService: Project.IBuildService) { }
+	constructor(private $buildService: Project.IBuildService,
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) { }
 
 	allowedParameters: ICommandParameter[] = [];
 
 	execute(args: string[]): IFuture<void> {
-		return this.$buildService.executeBuild(MobileHelper.DevicePlatforms[MobileHelper.DevicePlatforms.iOS]);
+		return this.$buildService.executeBuild(this.$devicePlatformsConstants.iOS);
 	}
 }
-$injector.registerCommand("build|ios", BuildAndroidCommand);
+$injector.registerCommand("build|ios", BuildIosCommand);
 
 export class BuildWP8Command implements ICommand {
-	constructor(private $buildService: Project.IBuildService) { }
+	constructor(private $buildService: Project.IBuildService,
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) { }
 
 	allowedParameters: ICommandParameter[] = [];
 
 	execute(args: string[]): IFuture<void> {
-		return this.$buildService.executeBuild(MobileHelper.DevicePlatforms[MobileHelper.DevicePlatforms.WP8]);
+		return this.$buildService.executeBuild(this.$devicePlatformsConstants.WP8);
 	}
 }
-$injector.registerCommand("build|wp8", BuildAndroidCommand);
+$injector.registerCommand("build|wp8", BuildWP8Command);

--- a/lib/commands/debug.ts
+++ b/lib/commands/debug.ts
@@ -5,7 +5,6 @@ import child_process = require("child_process");
 import path = require("path");
 import Future = require("fibers/future");
 import helpers = require("../helpers");
-import MobileHelper = require("./../common/mobile/mobile-helper");
 import hostInfo = require("../host-info");
 import commonHostInfo = require("../common/host-info");
 var gaze = require("gaze");

--- a/lib/commands/deploy.ts
+++ b/lib/commands/deploy.ts
@@ -3,7 +3,6 @@
 
 import options = require("../common/options");
 import util = require("util");
-import MobileHelper = require("./../common/mobile/mobile-helper");
 import Future = require("fibers/future");
 import commandParams = require("../common/command-params");
 
@@ -14,16 +13,17 @@ export class DeployHelper implements IDeployHelper {
 		protected $project: Project.IProject,
 		protected $buildService: Project.IBuildService,
 		protected $liveSyncService: ILiveSyncService,
-		protected $errors: IErrors) { }
+		protected $errors: IErrors,
+		private $mobileHelper: Mobile.IMobileHelper) { }
 
 	public deploy(platform?: string): IFuture<void> {
 		this.$project.ensureProject();
 
 		if (!this.$project.capabilities.deploy) {
-			this.$errors.fail("You will be able to deploy %s based applications in a future release of the Telerik AppBuilder CLI.", this.$project.projectData.Framework);
+			this.$errors.failWithoutHelp("You will be able to deploy %s based applications in a future release of the Telerik AppBuilder CLI.", this.$project.projectData.Framework);
 		}
-		if(platform && !MobileHelper.isPlatformSupported(platform)) {
-			this.$errors.fail("On your current OS, you cannot deploy apps on connected %s devices.", MobileHelper.normalizePlatformName(platform));
+		if(platform && !this.$mobileHelper.isPlatformSupported(platform)) {
+			this.$errors.failWithoutHelp("On your current OS, you cannot deploy apps on connected %s devices.", this.$mobileHelper.normalizePlatformName(platform));
 		}
 
 		return this.deployCore(platform);
@@ -69,35 +69,38 @@ export class DeployCommand implements ICommand {
 $injector.registerCommand("deploy|*devices", DeployCommand);
 
 export class DeployAndroidCommand implements ICommand {
-	constructor(private $deployHelper: IDeployHelper) { }
+	constructor(private $deployHelper: IDeployHelper,
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) { }
 
 	public allowedParameters: ICommandParameter[] = [];
 
 	public execute(args: string[]): IFuture<void> {
-		return this.$deployHelper.deploy(MobileHelper.DevicePlatforms[MobileHelper.DevicePlatforms.Android]);
+		return this.$deployHelper.deploy(this.$devicePlatformsConstants.Android);
 	}
 }
 $injector.registerCommand("deploy|android", DeployAndroidCommand);
 
 export class DeployIosCommand implements ICommand {
-	constructor(private $deployHelper: IDeployHelper) {	}
+	constructor(private $deployHelper: IDeployHelper,
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) {	}
 
 	public allowedParameters: ICommandParameter[] = [];
 
 	public execute(args: string[]): IFuture<void> {
-		return this.$deployHelper.deploy(MobileHelper.DevicePlatforms[MobileHelper.DevicePlatforms.iOS]);
+		return this.$deployHelper.deploy(this.$devicePlatformsConstants.iOS);
 	}
 }
 $injector.registerCommand("deploy|ios", DeployIosCommand);
 
 
 export class DeployWP8Command implements ICommand {
-	constructor(private $deployHelper: IDeployHelper) { }
+	constructor(private $deployHelper: IDeployHelper,
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) { }
 
 	public allowedParameters: ICommandParameter[] = [];
 
 	public execute(args: string[]): IFuture<void> {
-		return this.$deployHelper.deploy(MobileHelper.DevicePlatforms[MobileHelper.DevicePlatforms.WP8]);
+		return this.$deployHelper.deploy(this.$devicePlatformsConstants.WP8);
 	}
 }
 $injector.registerCommand("deploy|wp8", DeployWP8Command);

--- a/lib/commands/emulate.ts
+++ b/lib/commands/emulate.ts
@@ -8,13 +8,13 @@ import minimatch = require("minimatch");
 import iconv = require("iconv-lite");
 import osenv = require("osenv");
 import helpers = require("../helpers");
-import MobileHelper = require("../common/mobile/mobile-helper");
 import options = require("../common/options");
 
 export class EmulateAndroidCommand implements ICommand {
 	constructor(private $project: Project.IProject,
 				private $buildService: Project.IBuildService,
-				private $androidEmulatorServices: Mobile.IEmulatorPlatformServices) { }
+				private $androidEmulatorServices: Mobile.IEmulatorPlatformServices,
+				private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) { }
 
 	public allowedParameters: ICommandParameter[] = [];
 
@@ -26,7 +26,7 @@ export class EmulateAndroidCommand implements ICommand {
 			var tempDir = this.$project.getTempDir("emulatorfiles").wait();
 			var packageFilePath = path.join(tempDir, "package.apk");
 			var packageDefs = this.$buildService.build(<Project.IBuildSettings>{
-				platform: MobileHelper.DevicePlatforms[MobileHelper.DevicePlatforms.Android],
+				platform: this.$devicePlatformsConstants.Android,
 				showQrCodes: false,
 				downloadFiles: true,
 				downloadedFilePath: packageFilePath
@@ -42,7 +42,8 @@ export class EmulateIosCommand implements ICommand {
 	constructor(private $fs: IFileSystem,
 				private $project: Project.IProject,
 				private $buildService: Project.IBuildService,
-				private $iOSEmulatorServices: Mobile.IEmulatorPlatformServices) {
+				private $iOSEmulatorServices: Mobile.IEmulatorPlatformServices,
+				private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) {
 		this.$project.ensureProject();
 	}
 
@@ -57,7 +58,7 @@ export class EmulateIosCommand implements ICommand {
 			if(!options.availableDevices) {
 				var tempDir = this.$project.getTempDir("emulatorfiles").wait();
 				var packageDefs = this.$buildService.build(<Project.IBuildSettings>{
-					platform: MobileHelper.DevicePlatforms[MobileHelper.DevicePlatforms.iOS],
+					platform: this.$devicePlatformsConstants.iOS,
 					configuration: "Debug",
 					showQrCodes: false,
 					downloadFiles: true,
@@ -76,9 +77,10 @@ export class EmulateIosCommand implements ICommand {
 $injector.registerCommand("emulate|ios", EmulateIosCommand);
 
 export class EmulateWp8Command implements ICommand {
-	constructor(private $project: Project.IProject
-		,private $buildService: Project.IBuildService
-		,private $wp8EmulatorServices: Mobile.IEmulatorPlatformServices) {
+	constructor(private $project: Project.IProject,
+		private $buildService: Project.IBuildService,
+		private $wp8EmulatorServices: Mobile.IEmulatorPlatformServices,
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) {
 		this.$project.ensureProject();
 	}
 
@@ -92,7 +94,7 @@ export class EmulateWp8Command implements ICommand {
 			var tempDir = this.$project.getTempDir("emulatorfiles").wait();
 			var packageFilePath = path.join(tempDir, "package.xap");
 			var packageDefs = this.$buildService.build(<Project.IBuildSettings>{
-				platform: MobileHelper.DevicePlatforms[MobileHelper.DevicePlatforms.WP8],
+				platform: this.$devicePlatformsConstants.WP8,
 				configuration: "Debug",
 				showQrCodes: false,
 				downloadFiles: true,

--- a/lib/commands/live-sync.ts
+++ b/lib/commands/live-sync.ts
@@ -5,7 +5,6 @@ import path = require("path");
 var options: any = require("../common/options");
 var gaze = require("gaze");
 import helpers = require("./../helpers");
-import MobileHelper = require("./../common/mobile/mobile-helper");
 import AppIdentifier = require("../common/mobile/app-identifier");
 import constants = require("../common/mobile/constants");
 import commandParams = require("../common/command-params");
@@ -27,9 +26,10 @@ class LiveSyncDevicesCommand implements ICommand {
 $injector.registerCommand(["livesync|*devices", "live-sync|*devices"], LiveSyncDevicesCommand);
 
 class LiveSyncAndroidCommand implements ICommand {
-	constructor(private $liveSyncService: ILiveSyncService) { }
+	constructor(private $liveSyncService: ILiveSyncService,
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) { }
 	execute(args: string[]): IFuture<void> {
-		return this.$liveSyncService.livesync(MobileHelper.DevicePlatforms[MobileHelper.DevicePlatforms.Android]);
+		return this.$liveSyncService.livesync(this.$devicePlatformsConstants.Android);
 	}
 
 	allowedParameters: ICommandParameter[] = [];
@@ -37,9 +37,10 @@ class LiveSyncAndroidCommand implements ICommand {
 $injector.registerCommand(["livesync|android", "live-sync|android"], LiveSyncAndroidCommand);
 
 class LiveSyncIosCommand implements ICommand {
-	constructor(private $liveSyncService: ILiveSyncService) { }
+	constructor(private $liveSyncService: ILiveSyncService,
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) { }
 	execute(args: string[]): IFuture<void> {
-		return this.$liveSyncService.livesync(MobileHelper.DevicePlatforms[MobileHelper.DevicePlatforms.iOS]);
+		return this.$liveSyncService.livesync(this.$devicePlatformsConstants.iOS);
 	}
 
 	allowedParameters: ICommandParameter[] = [];
@@ -47,9 +48,10 @@ class LiveSyncIosCommand implements ICommand {
 $injector.registerCommand(["livesync|ios", "live-sync|ios"], LiveSyncIosCommand);
 
 class LiveSyncWP8Command implements ICommand {
-	constructor(private $liveSyncService: ILiveSyncService) { }
+	constructor(private $liveSyncService: ILiveSyncService,
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) { }
 	execute(args: string[]): IFuture<void> {
-		return this.$liveSyncService.livesync(MobileHelper.DevicePlatforms[MobileHelper.DevicePlatforms.WP8]);
+		return this.$liveSyncService.livesync(this.$devicePlatformsConstants.WP8);
 	}
 
 	allowedParameters: ICommandParameter[] = [];

--- a/lib/commands/project.ts
+++ b/lib/commands/project.ts
@@ -3,7 +3,6 @@
 
 import path = require("path");
 import util = require("util");
-import MobileHelper = require("./../common/mobile/mobile-helper");
 
 export class ProjectCommandBase implements ICommand {
 	constructor(protected $project: Project.IProject,
@@ -52,14 +51,15 @@ export class InitProjectCommandBase extends ProjectCommandBase {
 	constructor($project: Project.IProject,
 		$errors: IErrors,
 		protected $fs: IFileSystem,
-		protected $logger: ILogger) {
+		protected $logger: ILogger,
+		protected $mobileHelper: Mobile.IMobileHelper) {
 		super($project, $errors, $logger);
 
 		this.projectDir = $project.getNewProjectDir();
 		this.tnsModulesDir = new FileDescriptor(path.join(this.projectDir, "tns_modules"), "directory");
 		this.bootstrapFile = new FileDescriptor(path.join(this.projectDir, "app", "bootstrap.js"), "file");
 		this.indexHtml = new FileDescriptor(path.join(this.projectDir, "index.html"), "file");
-		this.cordovaFiles = _.map(Object.keys(MobileHelper.platformCapabilities), platform => {
+		this.cordovaFiles = _.map(this.$mobileHelper.platformNames, platform => {
 			return new FileDescriptor(util.format("cordova.%s.js", platform).toLowerCase(), "file");
 		});
 
@@ -196,8 +196,9 @@ export class InitCommand extends InitProjectCommandBase {
 		$errors: IErrors,
 		$fs: IFileSystem,
 		$logger: ILogger,
+		$mobileHelper: Mobile.IMobileHelper,
 		private $projectConstants: Project.IProjectConstants) {
-		super($project, $errors, $fs, $logger);
+		super($project, $errors, $fs, $logger, $mobileHelper);
 	}
 
 	public execute(args: string[]): IFuture<void> {
@@ -224,8 +225,9 @@ export class InitHybridCommand extends InitProjectCommandBase {
 		$project: Project.IProject,
 		$fs: IFileSystem,
 		$logger: ILogger,
+		$mobileHelper: Mobile.IMobileHelper,
 		private $projectConstants: Project.IProjectConstants) {
-		super($project, $errors, $fs, $logger);
+		super($project, $errors, $fs, $logger, $mobileHelper);
 	}
 
 	public execute(args: string[]): IFuture<void> {
@@ -239,8 +241,9 @@ export class InitNativeCommand extends InitProjectCommandBase {
 		$project: Project.IProject,
 		$fs: IFileSystem,
 		$logger: ILogger,
+		$mobileHelper: Mobile.IMobileHelper,
 		private $projectConstants: Project.IProjectConstants) {
-		super($project, $errors, $fs, $logger);
+		super($project, $errors, $fs, $logger, $mobileHelper);
 	}
 
 	public execute(args: string[]): IFuture<void> {
@@ -254,8 +257,9 @@ export class InitWebsiteCommand extends InitProjectCommandBase {
 	$project: Project.IProject,
 	$fs: IFileSystem,
 	$logger: ILogger,
+	$mobileHelper: Mobile.IMobileHelper,
 	private $projectConstants: Project.IProjectConstants) {
-		super($project, $errors, $fs, $logger);
+		super($project, $errors, $fs, $logger, $mobileHelper);
 	}
 
 	public execute(args: string[]): IFuture<void> {

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -85,7 +85,7 @@ $injector.register("config", Configuration);
 
 export class StaticConfig extends staticConfigBaseLib.StaticConfigBase implements IStaticConfig {
 	public PROJECT_FILE_NAME = ".abproject";
-	public CLIENT_NAME = "appbuilder";
+	public CLIENT_NAME = "AppBuilder";
 	public ANALYTICS_API_KEY = "13eaa7db90224aa1861937fc71863ab8";
 	public TRACK_FEATURE_USAGE_SETTING_NAME = "AnalyticsSettings.TrackFeatureUsage";
 	public ANALYTICS_INSTALLATION_ID_SETTING_NAME = "AnalyticsInstallationID";
@@ -95,6 +95,7 @@ export class StaticConfig extends staticConfigBaseLib.StaticConfigBase implement
 		return project.startPackageActivity;
 	}
 
+	public SYS_REQUIREMENTS_LINK = "http://docs.telerik.com/platform/appbuilder/running-appbuilder/running-the-cli/system-requirements-cli";
 	public SOLUTION_SPACE_NAME = "Private_Build_Folder";
 	public QR_SIZE = 300;
 

--- a/lib/mobile-platforms-capabilities.ts
+++ b/lib/mobile-platforms-capabilities.ts
@@ -1,0 +1,42 @@
+///<reference path=".d.ts"/>
+"use strict";
+
+export class MobilePlatformsCapabilities implements Mobile.IPlatformsCapabilities {
+	private platformCapabilities: IDictionary<Mobile.IPlatformCapabilities>;
+
+	constructor(private $errors: IErrors) { }
+
+	public getPlatformNames(): string[]{
+		return _.keys(this.getAllCapabilities());
+	}
+
+	public getAllCapabilities(): IDictionary<Mobile.IPlatformCapabilities> {
+		if(this.platformCapabilities) {
+			return this.platformCapabilities;
+		}
+
+		var platformCapabilities: IDictionary<Mobile.IPlatformCapabilities> = {
+			iOS: {
+				wirelessDeploy: true,
+				cableDeploy: true,
+				companion: true,
+				hostPlatformsForDeploy: ["win32", "darwin"]
+			},
+			Android: {
+				wirelessDeploy: true,
+				cableDeploy: true,
+				companion: true,
+				hostPlatformsForDeploy: ["win32", "darwin", "linux"]
+			},
+			WP8: {
+				wirelessDeploy: true,
+				cableDeploy: false,
+				companion: true,
+				hostPlatformsForDeploy: ["win32"]
+			}
+		}
+
+		return platformCapabilities;
+	}
+}
+$injector.register("mobilePlatformsCapabilities", MobilePlatformsCapabilities);

--- a/lib/project.ts
+++ b/lib/project.ts
@@ -7,7 +7,6 @@ import util = require("util");
 
 import commonHelpers = require("./common/helpers");
 import helpers = require("./helpers");
-import MobileHelper = require("./common/mobile/mobile-helper");
 import options = require("./common/options");
 import projectPropertiesServiceLib = require("./services/project-properties-service");
 
@@ -40,18 +39,16 @@ export class Project implements Project.IProject {
 		private $resources: IResourceLoader,
 		private $staticConfig: IStaticConfig,
 		private $templatesService: ITemplatesService,
-		private $prompter: IPrompter) {
+		private $prompter: IPrompter,
+		private $mobileHelper: Mobile.IMobileHelper) {
 
 		this.configurationSpecificData = Object.create(null);
 		this.readProjectData().wait();
 
 		if(this.projectData && this.projectData["TemplateAppName"]) {
-			this.$errors.fail({
-				formatStr: "This hybrid project targets Apache Cordova 2.x. " +
+			this.$errors.failWithoutHelp("This hybrid project targets Apache Cordova 2.x. " +
 					"The AppBuilder CLI lets you target only Apache Cordova 3.0.0 or later. " +
-					"To develop your projects with Apache Cordova 2.x, run the AppBuilder Windows client or the in-browser client.",
-				suppressCommandHelp: true
-			});
+					"To develop your projects with Apache Cordova 2.x, run the AppBuilder Windows client or the in-browser client.");
 		}
 	}
 
@@ -359,7 +356,7 @@ export class Project implements Project.IProject {
 			var successfullyChanged: string[] = [],
 				backupSuffix = ".backup";
 			try {
-				Object.keys(MobileHelper.platformCapabilities).forEach((platform) => {
+				_.each(this.$mobileHelper.platformNames, (platform) => {
 					this.$logger.trace("Replacing cordova.js file for %s platform ", platform);
 					var cordovaJsFileName = path.join(this.getProjectDir().wait(), util.format("cordova.%s.js", platform).toLowerCase());
 					var cordovaJsSourceFilePath = this.$resources.buildCordovaJsFilePath(newVersion, platform);

--- a/lib/project/cordova-project.ts
+++ b/lib/project/cordova-project.ts
@@ -6,7 +6,6 @@ import util = require("util");
 
 import frameworkProjectBaseLib = require("./framework-project-base");
 import helpers = require("./../common/helpers");
-import MobileHelper = require("../common/mobile/mobile-helper");
 import options = require("../common/options");
 
 export class CordovaProject extends frameworkProjectBaseLib.FrameworkProjectBase implements Project.IFrameworkProject {
@@ -22,7 +21,8 @@ export class CordovaProject extends frameworkProjectBaseLib.FrameworkProjectBase
 		private $projectConstants: Project.IProjectConstants,
 		private $projectFilesManager: Project.IProjectFilesManager,
 		private $templatesService: ITemplatesService,
-		$resources: IResourceLoader) {
+		$resources: IResourceLoader,
+		private $mobileHelper: Mobile.IMobileHelper) {
 		super($logger, $fs, $resources, $errors, $jsonSchemaValidator);
 	}
 
@@ -111,7 +111,7 @@ export class CordovaProject extends frameworkProjectBaseLib.FrameworkProjectBase
 		buildProperties.CorePlugins = this.getProperty("CorePlugins", configurationName, projectInformation);
 
 		if(buildProperties.Platform === "WP8") {
-			buildProperties.WP8ProductID = projectData.WP8ProductID || MobileHelper.generateWP8GUID();
+			buildProperties.WP8ProductID = projectData.WP8ProductID || this.generateWP8GUID();
 			buildProperties.WP8PublisherID = projectData.WP8PublisherID;
 			buildProperties.WP8Publisher = projectData.WP8Publisher;
 			buildProperties.WP8TileTitle = projectData.WP8TileTitle;
@@ -127,7 +127,7 @@ export class CordovaProject extends frameworkProjectBaseLib.FrameworkProjectBase
 
 	public ensureAllPlatformAssets(projectDir: string, frameworkVersion: string): IFuture<void> {
 		return (() => {
-			var platforms = _.keys(MobileHelper.platformCapabilities);
+			var platforms = this.$mobileHelper.platformNames;
 			_.each(platforms, (platform: string) => this.ensureCordovaJs(platform, projectDir, frameworkVersion).wait());
 
 			var appResourcesDir = this.$resources.appResourcesDir;
@@ -178,7 +178,7 @@ export class CordovaProject extends frameworkProjectBaseLib.FrameworkProjectBase
 
 		["WP8PublisherID", "WP8ProductID"].forEach((wp8guid) => {
 			if (!_.has(properties, wp8guid) || properties[wp8guid] === "") {
-				properties[wp8guid] = MobileHelper.generateWP8GUID();
+				properties[wp8guid] = this.generateWP8GUID();
 				updated = true;
 			}
 		});
@@ -199,6 +199,10 @@ export class CordovaProject extends frameworkProjectBaseLib.FrameworkProjectBase
 
 
 		return updated;
+	}
+
+	private generateWP8GUID(): string {
+		return helpers.createGUID();
 	}
 }
 $injector.register("cordovaProject", CordovaProject);

--- a/lib/project/nativescript-project.ts
+++ b/lib/project/nativescript-project.ts
@@ -5,7 +5,6 @@ import path = require("path");
 import util = require("util");
 import Future = require("fibers/future");
 import frameworkProjectBaseLib = require("./framework-project-base");
-import MobileHelper = require("../common/mobile/mobile-helper");
 
 export class NativeScriptProject extends frameworkProjectBaseLib.FrameworkProjectBase implements Project.IFrameworkProject {
 	constructor(private $config: IConfiguration,

--- a/lib/resource-loader.ts
+++ b/lib/resource-loader.ts
@@ -3,11 +3,10 @@
 
 import path = require("path");
 import helpers = require("./helpers");
-import MobileHelper = require("./common/mobile/mobile-helper");
 import util = require("util");
 
 export class ResourceLoader implements IResourceLoader {
-	constructor(private $fs: IFileSystem) {}
+	constructor(private $fs: IFileSystem) { }
 
 	resolvePath(resourcePath: string): string {
 		return path.join(__dirname, "../resources", resourcePath);
@@ -35,12 +34,13 @@ class ResourceDownloader implements IResourceDownloader {
 	constructor(private $server: Server.IServer,
 		private $fs: IFileSystem,
 		private $resources: IResourceLoader,
-		private $cordovaMigrationService: ICordovaMigrationService) { }
+		private $cordovaMigrationService: ICordovaMigrationService,
+		private $mobileHelper: Mobile.IMobileHelper) { }
 
 	public downloadCordovaJsFiles(): IFuture<void> {
 		return (() => {
 			var cordovaVersions = this.$cordovaMigrationService.getSupportedVersions().wait();
-			var platforms = Object.keys(MobileHelper.platformCapabilities);
+			var platforms = this.$mobileHelper.platformNames;
 			cordovaVersions.forEach((version) => {
 				platforms.forEach((platform) => {
 					var targetFilePath = this.$resources.buildCordovaJsFilePath(version, platform);

--- a/lib/services/analytics-settings-service.ts
+++ b/lib/services/analytics-settings-service.ts
@@ -2,7 +2,8 @@
 "use strict";
 export class AnalyticsSettingsService implements IAnalyticsSettingsService {
 	constructor(private $loginManager: ILoginManager,
-		private $userDataStore: IUserDataStore) { }
+		private $userDataStore: IUserDataStore,
+		private $staticConfig: IStaticConfig) { }
 
 	public canDoRequest(): IFuture<boolean> {
 		return this.$loginManager.isLoggedIn();
@@ -10,6 +11,14 @@ export class AnalyticsSettingsService implements IAnalyticsSettingsService {
 
 	public getUserId(): IFuture<string> {
 		return this.$userDataStore.getUser();
+	}
+
+	public getClientName(): string {
+		return "Telerik".white.bold + " " + this.$staticConfig.CLIENT_NAME.cyan.bold;
+	}
+
+	public getPrivacyPolicyLink(): string {
+		return "http://www.telerik.com/company/privacy-policy";
 	}
 }
 $injector.register("analyticsSettingsService", AnalyticsSettingsService);

--- a/lib/services/appmanager-service.ts
+++ b/lib/services/appmanager-service.ts
@@ -1,7 +1,6 @@
 ///<reference path="../.d.ts"/>
 "use strict";
 
-import MobileHelper = require("../common/mobile/mobile-helper");
 import constants = require("../common/mobile/constants");
 import util = require("util");
 import options = require("../options");
@@ -15,11 +14,12 @@ class AppManagerService implements IAppManagerService {
 		private $project: Project.IProject,
 		private $loginManager: ILoginManager,
 		private $opener: IOpener,
-		private $buildService: Project.IBuildService) { }
+		private $buildService: Project.IBuildService,
+		private $mobileHelper: Mobile.IMobileHelper) { }
 
 	upload(platform: string): IFuture<void> {
 		return (() => {
-			var mobilePlatform = MobileHelper.validatePlatformName(platform, this.$errors);
+			var mobilePlatform = this.$mobileHelper.validatePlatformName(platform);
 			this.$project.ensureProject();
 			this.$loginManager.ensureLoggedIn().wait();
 

--- a/lib/services/project-properties-service.ts
+++ b/lib/services/project-properties-service.ts
@@ -6,7 +6,6 @@ import xmlMapping = require("xml-mapping");
 import util = require("util");
 import Future = require("fibers/future");
 import helpers = require("../helpers");
-import MobileHelper = require("../common/mobile/mobile-helper");
 
 export class ProjectPropertiesService implements IProjectPropertiesService {
 	private static PROJECT_VERSION_DEFAULT_VALUE = 1;

--- a/lib/templates-service.ts
+++ b/lib/templates-service.ts
@@ -7,7 +7,6 @@ import options = require("./common/options");
 import Future = require("fibers/future");
 import util = require("util");
 import unzip = require("unzip");
-import MobileHelper = require("./common/mobile/mobile-helper");
 
 export class ConfigurationFile {
 	constructor(public template: string,

--- a/test/build-configurations.ts
+++ b/test/build-configurations.ts
@@ -15,6 +15,9 @@ import projectConstantsLib = require("../lib/project/project-constants");
 import jsonSchemaConstantsLib = require("../lib/json-schema/json-schema-constants");
 import stubs = require("./stubs");
 import yok = require("../lib/common/yok");
+import mobileHelperLib = require("../lib/common/mobile/mobile-helper");
+import mobilePlatformsCapabilitiesLib = require("../lib/mobile-platforms-capabilities");
+import devicePlatformsLib = require("../lib/common/mobile/device-platforms-constants");
 
 import assert = require("assert");
 import Future = require("fibers/future");
@@ -99,6 +102,9 @@ function createTestInjector() {
 	testInjector.register("fs", fslib.FileSystem);
 	testInjector.register("projectPropertiesService", projectPropertiesLib.ProjectPropertiesService);
 	testInjector.register("jsonSchemaConstants", jsonSchemaConstantsLib.JsonSchemaConstants);
+	testInjector.register("mobileHelper", mobileHelperLib.MobileHelper);
+	testInjector.register("devicePlatformsConstants", devicePlatformsLib.DevicePlatformsConstants);
+	testInjector.register("mobilePlatformsCapabilities", mobilePlatformsCapabilitiesLib.MobilePlatformsCapabilities);
 
 	return testInjector;
 }

--- a/test/project.ts
+++ b/test/project.ts
@@ -10,7 +10,8 @@ import fs = require("fs");
 import path = require("path");
 import temp = require("temp");
 import util = require("util");
-import MobileHelper = require("./../lib/common/mobile/mobile-helper");
+import mobileHelperLib = require("../lib/common/mobile/mobile-helper");
+import devicePlatformsLib = require("../lib/common/mobile/device-platforms-constants");
 import options = require("./../lib/common/options");
 import helpers = require("../lib/helpers");
 import cordovaProjectLib = require("./../lib/project/cordova-project");
@@ -23,6 +24,7 @@ import jsonSchemaResolverLib = require("../lib/json-schema/json-schema-resolver"
 import jsonSchemaValidatorLib = require("../lib/json-schema/json-schema-validator");
 import jsonSchemaConstantsLib = require("../lib/json-schema/json-schema-constants");
 import childProcessLib = require("../lib/common/child-process");
+import mobilePlatformsCapabilitiesLib = require("../lib/mobile-platforms-capabilities");
 import Future = require("fibers/future");
 var projectConstants = new projectConstantsLib.ProjectConstants();
 var assert = require("chai").assert;
@@ -97,6 +99,8 @@ function createTestInjector(): IInjector {
 	testInjector.register("jsonSchemaValidator", jsonSchemaValidatorLib.JsonSchemaValidator);
 	testInjector.register("childProcess", childProcessLib.ChildProcess);
 	testInjector.register("injector", testInjector);
+	testInjector.register("mobileHelper", mobileHelperLib.MobileHelper);
+	testInjector.register("devicePlatformsConstants", devicePlatformsLib.DevicePlatformsConstants);
 	testInjector.register("frameworkProjectResolver", {
 		resolve: (framework: string) => {
 			if(!framework || framework === "Cordova") {
@@ -112,6 +116,8 @@ function createTestInjector(): IInjector {
 	testInjector.register("projectFilesManager", projectFilesManagerLib.ProjectFilesManager);
 	testInjector.register("jsonSchemaConstants", jsonSchemaConstantsLib.JsonSchemaConstants);
 	testInjector.register("loginManager", { ensureLoggedIn: (): IFuture<void> => { return (() => { }).future<void>()() } });
+	testInjector.register("mobilePlatformsCapabilities", mobilePlatformsCapabilitiesLib.MobilePlatformsCapabilities);
+
 	return testInjector;
 }
 
@@ -265,11 +271,13 @@ describe("project integration tests", () => {
 		var options: any;
 		var tempFolder: string;
 		var projectName = "Test";
+		var mobileHelper: Mobile.IMobileHelper;
 		beforeEach(() => {
 			options = require("../lib/common/options");
 			tempFolder = temp.mkdirSync("template");
 			options.path = tempFolder;
 			options.appid = "com.telerik.Test";
+			mobileHelper = testInjector.resolve("mobileHelper");
 		});
 
 		describe("NativeScript project", () => {
@@ -351,7 +359,7 @@ describe("project integration tests", () => {
 				project.createNewProject(projectName, projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait();
 				var projectDir = project.getProjectDir().wait();
 
-				var cordovaMandatoryFiles = _.forEach(Object.keys(MobileHelper.platformCapabilities), platform => {
+				var cordovaMandatoryFiles = _.forEach(mobileHelper.platformNames, platform => {
 					var cordovaFile = util.format("cordova.%s.js", platform).toLowerCase();
 					assert.isTrue(fs.existsSync(path.join(projectDir, cordovaFile)), util.format("Cordova Blank template does not contain mandatory '%s' file. This file is required in init command. You should check if this is problem with the template or change init command to use another file.", cordovaFile));
 				});
@@ -362,7 +370,7 @@ describe("project integration tests", () => {
 				project.createNewProject(projectName, projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait();
 				var projectDir = project.getProjectDir().wait();
 
-				var cordovaMandatoryFiles = _.forEach(Object.keys(MobileHelper.platformCapabilities), platform => {
+				var cordovaMandatoryFiles = _.forEach(mobileHelper.platformNames, platform => {
 					var cordovaFile = util.format("cordova.%s.js", platform).toLowerCase();
 					assert.isTrue(fs.existsSync(path.join(projectDir, cordovaFile)), util.format("Cordova TypeScript.Blank template does not contain mandatory '%s' file. This file is required in init command. You should check if this is problem with the template or change init command to use another file.", cordovaFile));
 				});
@@ -373,7 +381,7 @@ describe("project integration tests", () => {
 				project.createNewProject(projectName, projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait();
 				var projectDir = project.getProjectDir().wait();
 
-				var cordovaMandatoryFiles = _.forEach(Object.keys(MobileHelper.platformCapabilities), platform => {
+				var cordovaMandatoryFiles = _.forEach(mobileHelper.platformNames, platform => {
 					var cordovaFile = util.format("cordova.%s.js", platform).toLowerCase();
 					assert.isTrue(fs.existsSync(path.join(projectDir, cordovaFile)), util.format("Cordova KendoUI.Drawer template does not contain mandatory '%s' file. This file is required in init command. You should check if this is problem with the template or change init command to use another file.", cordovaFile));
 				});
@@ -384,7 +392,7 @@ describe("project integration tests", () => {
 				project.createNewProject(projectName, projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait();
 				var projectDir = project.getProjectDir().wait();
 
-				var cordovaMandatoryFiles = _.forEach(Object.keys(MobileHelper.platformCapabilities), platform => {
+				var cordovaMandatoryFiles = _.forEach(mobileHelper.platformNames, platform => {
 					var cordovaFile = util.format("cordova.%s.js", platform).toLowerCase();
 					assert.isTrue(fs.existsSync(path.join(projectDir, cordovaFile)), util.format("Cordova KendoUI.Empty template does not contain mandatory '%s' file. This file is required in init command. You should check if this is problem with the template or change init command to use another file.", cordovaFile));
 				});
@@ -395,7 +403,7 @@ describe("project integration tests", () => {
 				project.createNewProject(projectName, projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait();
 				var projectDir = project.getProjectDir().wait();
 
-				var cordovaMandatoryFiles = _.forEach(Object.keys(MobileHelper.platformCapabilities), platform => {
+				var cordovaMandatoryFiles = _.forEach(mobileHelper.platformNames, platform => {
 					var cordovaFile = util.format("cordova.%s.js", platform).toLowerCase();
 					assert.isTrue(fs.existsSync(path.join(projectDir, cordovaFile)), util.format("Cordova KendoUI.TabStrip template does not contain mandatory '%s' file. This file is required in init command. You should check if this is problem with the template or change init command to use another file.", cordovaFile));
 				});

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -367,9 +367,8 @@ export class StaticConfig implements IStaticConfig {
 	public ANALYTICS_API_KEY = "13eaa7db90224aa1861937fc71863ab8";
 	public TRACK_FEATURE_USAGE_SETTING_NAME = "AnalyticsSettings.TrackFeatureUsage";
 	public ANALYTICS_INSTALLATION_ID_SETTING_NAME = "AnalyticsInstallationID";
-
 	public START_PACKAGE_ACTIVITY_NAME = ".TelerikCallbackActivity";
-
+	public SYS_REQUIREMENTS_LINK = "";
 	public SOLUTION_SPACE_NAME = "Private_Build_Folder";
 	public QR_SIZE = 300;
 	public version = "1";


### PR DESCRIPTION
Common lib is used by several CLIs - appbuilder-cli, nativescript-cli, etc. 

- There are several places where appbuilder is used, while it should be staticConfig.CLIENT_NAME. Fix all of these.
- Replace MobileHelper's exported functions in a new class - MobileHelper. This way we can resolve it from injector and it can easily use staticConfig's CLIENT_NAME. 
- Remove DevicePlatforms enum and add DevicePlatformsConstants class which can be used instead of the enum. 
- Add SYS_REQUIREMENTS_LINK to StaticConfig in order to have different links for each CLI. 
- Add getClientName and getPrivacyPolicyLink methods to IAnalyticsSettingsService.

http://teampulse.telerik.com/view#item/287728