### PR TITLE
Forbid remote command on Windows and Linux

### DIFF
--- a/lib/mobile-platforms-capabilities.ts
+++ b/lib/mobile-platforms-capabilities.ts
@@ -11,11 +11,7 @@ export class MobilePlatformsCapabilities implements Mobile.IPlatformsCapabilitie
 	}
 
 	public getAllCapabilities(): IDictionary<Mobile.IPlatformCapabilities> {
-		if(this.platformCapabilities) {
-			return this.platformCapabilities;
-		}
-
-		var platformCapabilities: IDictionary<Mobile.IPlatformCapabilities> = {
+		this.platformCapabilities = this.platformCapabilities || {
 			iOS: {
 				wirelessDeploy: true,
 				cableDeploy: true,
@@ -36,7 +32,7 @@ export class MobilePlatformsCapabilities implements Mobile.IPlatformsCapabilitie
 			}
 		}
 
-		return platformCapabilities;
+		return this.platformCapabilities;
 	}
 }
 $injector.register("mobilePlatformsCapabilities", MobilePlatformsCapabilities);


### PR DESCRIPTION
Remote command can work only on MacOS. Forbid using it on any other platform. Move some duplicate logic from execute method of RemoteCommand to validate method of PortCommandParameter.
Minor fix in mobile-platforms-capabilities where the property used to cache platforms, never received value, so the caching was not really working.

Fixes http://teampulse.telerik.com/view#item/287833