### PR TITLE
Fix livesync commands

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -106,9 +106,9 @@ $injector.requireCommand("deploy|wp8", "./commands/deploy");
 
 $injector.requireCommand(["livesync|*devices", "live-sync|*devices"], "./commands/live-sync");
 $injector.requireCommand(["livesync|cloud", "live-sync|cloud"], "./commands/livesync-cloud");
-$injector.requireCommand(["livesync|android", "live-sync|android"], "./commands/livesync-cloud");
-$injector.requireCommand(["livesync|ios", "live-sync|ios"], "./commands/livesync-cloud");
-$injector.requireCommand(["livesync|wp8", "live-sync|wp8"], "./commands/livesync-cloud");
+$injector.requireCommand(["livesync|android", "live-sync|android"], "./commands/live-sync");
+$injector.requireCommand(["livesync|ios", "live-sync|ios"], "./commands/live-sync");
+$injector.requireCommand(["livesync|wp8", "live-sync|wp8"], "./commands/live-sync");
 
 $injector.require("identityManager", "./commands/cryptographic-identities");
 $injector.requireCommand("provision|*list", "./commands/cryptographic-identities");

--- a/lib/services/livesync-service.ts
+++ b/lib/services/livesync-service.ts
@@ -34,9 +34,8 @@ export class LiveSyncService implements ILiveSyncService {
 	public livesync(platform: string): IFuture<void> {
 		return (() => {
 			this.$project.ensureProject();
-
 			this.$devicesServices.initialize({ platform: platform, deviceId: options.device }).wait();
-			var platform = this.$devicesServices.platform;
+			platform = this.$devicesServices.platform;
 
 			if(!this.$mobileHelper.getPlatformCapabilities(platform).companion && options.companion) {
 				this.$errors.fail("The AppBuilder Companion app is not available on %s devices.", platform);


### PR DESCRIPTION
Fix bootstrap, where livesync <platform> commands had been required from incorrect file. Fix livesyncService where the platform variable had been reset, so the passed one was not used.

Fixes http://teampulse.telerik.com/view#item/287904