### PR TITLE
Remove hardcoded "Debug" configuration when starting ios emulator

### DIFF
--- a/lib/commands/emulate.ts
+++ b/lib/commands/emulate.ts
@@ -59,7 +59,6 @@ export class EmulateIosCommand implements ICommand {
 				var tempDir = this.$project.getTempDir("emulatorfiles").wait();
 				var packageDefs = this.$buildService.build(<Project.IBuildSettings>{
 					platform: this.$devicePlatformsConstants.iOS,
-					configuration: "Debug",
 					showQrCodes: false,
 					downloadFiles: true,
 					downloadedFilePath: path.join(tempDir, "package.ipa"),


### PR DESCRIPTION
Fixes http://teampulse.telerik.com/view#item/287958