### PR TITLE
Fix installation and uninstall of CLI

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -10,11 +10,11 @@ for-developers.md
 prepublish.js
 Gruntfile.js
 *.cmd
-tscommand.tmp.txt
+tscommand*.tmp.txt
 .tscache/
-
 bin/appbuilder
 bin/*.cmd
+**/bin/Microsoft.NodejsTools.WebRole.dll
 
 config/config-*
 
@@ -25,13 +25,10 @@ scratch/
 test/
 **/docs/html
 **/obj
-**/bin/Microsoft.NodejsTools.WebRole.dll
 **/.vs
 **/.ntvs_analysis.dat
+**/*.njsproj
+**/*.sln
+**/*.suo
 npm-debug.log
 node_modules
-resources/App_Resources
-resources/Cordova
-resources/ItemTemplates
-resources/ProjectTemplates
-resources/json-schemas

--- a/AppBuilderCLI.njsproj
+++ b/AppBuilderCLI.njsproj
@@ -46,6 +46,7 @@
     <Content Include="config\config.json" />
     <TypeScriptCompile Include="lib\appbuilder-cli.ts" />
     <TypeScriptCompile Include="lib\bootstrap.ts" />
+    <TypeScriptCompile Include="lib\common\commands\preuninstall.ts" />
     <TypeScriptCompile Include="lib\config.ts" />
     <TypeScriptCompile Include="lib\declarations.d.ts" />
     <TypeScriptCompile Include="lib\dns.ts" />
@@ -188,7 +189,6 @@
     <TypeScriptCompile Include="lib\commands\itunes-connect.ts" />
     <TypeScriptCompile Include="lib\commands\live-sync.ts" />
     <TypeScriptCompile Include="lib\commands\livesync-cloud.ts" />
-    <TypeScriptCompile Include="lib\commands\project.ts" />
     <TypeScriptCompile Include="lib\commands\remote.ts" />
     <TypeScriptCompile Include="lib\commands\samples.ts" />
     <TypeScriptCompile Include="lib\commands\simulate.ts" />

--- a/preuninstall.js
+++ b/preuninstall.js
@@ -1,24 +1,10 @@
 var child_process = require("child_process");
-var util = require("util");
-var path = require("path");
-var fs = require("fs");
-var options = require("./lib/options");
 
-var adbPath = util.format("resources/platform-tools/android/%s/adb", process.platform);
-var executableAdbPath = process.platform === "win32" ? adbPath + ".exe" : adbPath;
-if(!fs.existsSync(executableAdbPath)) {
-	adbPath = "lib/common/" + adbPath;
-}
-
-var killAdbServerCommand = util.format("\"%s\" %s", adbPath, " kill-server");
-child_process.exec(killAdbServerCommand, function(error) {
-	if(error) {
-		console.log(error.toString());
+var child = child_process.exec("node bin/appbuilder.js dev-preuninstall", function (error) {
+	if (error) {
+		console.error("Failed to complete all pre-uninstall steps. ");
+		console.log(error);
 	}
 });
 
-fs.unlink(path.join(options["profile-dir"], "KillSwitches/cli"), function(err) {
-	if (!err) {
-		setTimeout(function(){}, 3000);
-	}
-});
+child.stdout.pipe(process.stdout);


### PR DESCRIPTION
Fix installation of appbuilder-cli by removing ProjectTemplates, ItemTemplates, etc. directories from .npmignore file. This way our resources are uploaded to npm and we are working fine.
Fix preuninstall script which was failing on several places (missing lodash as it was not required, unable to resolve injector, etc.) In order to fix the issues, new command  "dev-preuninstall" is introduced. This way injector can be resolved.