### PR TITLE
Integrate new ScreenBuilder version

### DIFF
--- a/config/dependency-config.json
+++ b/config/dependency-config.json
@@ -1,9 +1,9 @@
 {
 	"appScaffolding": {
-		"version": "0.0.2"
+		"version": "0.0.1"
 	},
 	"generators": [{
 		"name": "generator-kendo-ui-mobile",
-		"version": "0.0.2"
+		"version": "0.0.1"
 	}]
 }

--- a/lib/commands/project/create.ts
+++ b/lib/commands/project/create.ts
@@ -7,19 +7,31 @@ import options = require("./../../options");
 import util = require("util");
 
 export class CreateCommand implements ICommand {
-	constructor(public $project: Project.IProject,
+	constructor(private $fs: IFileSystem,
+		private $nameCommandParameter: ICommandParameter,
+		private $project: Project.IProject,
 		private $projectConstants: Project.IProjectConstants,
 		private $screenBuilderService: IScreenBuilderService) { }
 
 	public execute(args: string[]): IFuture<void> {
 		return (() => {
-			this.$screenBuilderService.prepareAndGeneratePrompt(this.$screenBuilderService.generatorName).wait();
+			var projectName = args[0];
+			var projectPath = path.join(this.$project.getNewProjectDir(), projectName);
+			this.$fs.createDirectory(projectPath).wait();
+
+			var screenBuilderOptions = {
+				projectPath: projectPath,
+				answers: {
+					name: projectName
+				}
+			};
+			this.$screenBuilderService.prepareAndGeneratePrompt(this.$screenBuilderService.generatorName, screenBuilderOptions).wait();
 			this.$screenBuilderService.installAppDependencies().wait();
 
 			this.$project.initializeProjectFromExistingFiles(this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait();
 		}).future<void>()();
 	}
 
-	allowedParameters: ICommandParameter[] = [];
+	allowedParameters = [this.$nameCommandParameter];
 }
 $injector.registerCommand("create|*default", CreateCommand);

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -328,7 +328,6 @@ interface IDependencyExtensionsServiceBase extends IExtensionsServiceBase {
 }
 
 interface IGeneratorExtensionsService {
-	getGeneratorCachePath(generatorName: string): string;
 	prepareGenerator(generatorName: string): IFuture<void>;
 }
 
@@ -339,10 +338,20 @@ interface IAppScaffoldingExtensionsService {
 
 interface IScreenBuilderService {
 	generatorName: string;
-	prepareAndGeneratePrompt(generatorName: string, type?: string): IFuture<void>;
-	allSupportedCommands(): IFuture<string[]>;
+	prepareAndGeneratePrompt(generatorName: string, screenBuilderOptions?: IScreenBuilderOptions): IFuture<void>;
+	allSupportedCommands(generatorName: string): IFuture<string[]>;
 	generateAllCommands(generatorName: string): IFuture<void>;
 	installAppDependencies(): IFuture<void>;
+}
+
+interface IScreenBuilderOptions {
+	type?: string;
+	answers?: IScreenBuilderAnswer;
+	projectPath?: string;
+}
+
+interface IScreenBuilderAnswer {
+	name?: string;
 }
 
 interface IExtensionData {

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -5,7 +5,9 @@ import path = require("path");
 import util = require("util");
 import querystring = require("querystring");
 import Future = require("fibers/future");
+import osenv = require("osenv");
 import commonHelpers = require("./common/helpers");
+import hostInfo = require("./common/host-info");
 
 export function fromWindowsRelativePathToUnix(windowsRelativePath: string): string {
 	return windowsRelativePath.replace(/\\/g, "/");
@@ -216,4 +218,9 @@ export function fill(value: string, times: number): string[]{
 	}
 
 	return repeatedValues;
+}
+
+export function defaultProfileDir(): string {
+	var cacheRootDirectoryPath = hostInfo.isWindows() ? process.env.LocalAppData : path.join(osenv.home(), ".local/share");
+	return path.join(cacheRootDirectoryPath, "Telerik", "BlackDragon", ".appbuilder-cli");
 }

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -4,7 +4,7 @@
 import path = require("path");
 import osenv = require("osenv");
 import commonOptions = require("./common/options");
-import hostInfo = require("./common/host-info");
+import helpers = require("./helpers");
 
 declare var exports: any;
 
@@ -33,16 +33,9 @@ var knownOpts: any = {
 _.extend(commonOptions.knownOpts, knownOpts);
 _.extend(commonOptions.shorthands, shorthands);
 
-var defaultProfileDir = "";
-var blackDragonCacheFolder = "Telerik/BlackDragon";
-var appBuilderCacheFolder = ".appbuilder-cli";
-if(hostInfo.isWindows()) {
-	defaultProfileDir = path.join(process.env.LocalAppData, blackDragonCacheFolder, appBuilderCacheFolder);
-} else {
-	defaultProfileDir = path.join(osenv.home(), ".local/share", blackDragonCacheFolder, appBuilderCacheFolder);
-}
-
+var defaultProfileDir = helpers.defaultProfileDir();
 commonOptions.setProfileDir(defaultProfileDir);
+
 var errors: IErrors = $injector.resolve("errors");
 _(errors.validateArgs("appbuilder", commonOptions.knownOpts, commonOptions.shorthands)).each((val,key) => {
 	key = shorthands[key] || key;

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -5,6 +5,7 @@ import path = require("path");
 import osenv = require("osenv");
 import commonOptions = require("./common/options");
 import helpers = require("./helpers");
+import hostInfo = require("./common/host-info");
 
 declare var exports: any;
 
@@ -22,7 +23,8 @@ var knownOpts: any = {
 		"available": Boolean,
 		"release": Boolean,
 		"debug": Boolean,
-		"valid-value": Boolean
+		"valid-value": Boolean,
+		"screenBuilderCacheDir": String
 	},
 	shorthands: IStringDictionary = {
 		"t": "template",
@@ -41,6 +43,8 @@ _(errors.validateArgs("appbuilder", commonOptions.knownOpts, commonOptions.short
 	key = shorthands[key] || key;
 	commonOptions[key] = val;
 }).value();
+
+commonOptions["screenBuilderCacheDir"] = (hostInfo.isWindows() && commonOptions.defaultProfileDir === commonOptions.profileDir) ? path.join(process.env.LocalAppData, "Telerik", "sb"): commonOptions.profileDir;
 
 exports.knownOpts = knownOpts;
 exports.shorthands = shorthands;

--- a/lib/providers/commands-service-provider.ts
+++ b/lib/providers/commands-service-provider.ts
@@ -6,7 +6,7 @@ class CommandsServiceProvider implements ICommandsServiceProvider {
 		private $screenBuilderService: IScreenBuilderService) { }
 
 	public getDynamicCommands(): IFuture<string[]> {
-		return this.$screenBuilderService.allSupportedCommands();
+		return this.$screenBuilderService.allSupportedCommands(this.$screenBuilderService.generatorName);
 	}
 
 	public generateDynamicCommands(): IFuture<void> {

--- a/lib/services/app-scaffolding-extensions-service.ts
+++ b/lib/services/app-scaffolding-extensions-service.ts
@@ -2,6 +2,7 @@
 "use strict";
 
 import dependencyExtensionsServiceLib = require("./dependency-extensions-service-base");
+import hostInfo = require("./../common/host-info");
 import options = require("../common/options");
 import path = require("path");
 import util = require("util");
@@ -15,7 +16,7 @@ export class AppScaffoldingExtensionsService extends dependencyExtensionsService
 		$progressIndicator: IProgressIndicator,
 		protected $childProcess: IChildProcess,
 		protected $dependencyConfigService: IDependencyConfigService) {
-		super(options.defaultProfileDir === options.profileDir ? path.join(process.env.LocalAppData, "Telerik", "sb") : options.profileDir, $fs, $httpClient, $logger, $progressIndicator); // We should pass here the correct profileDir
+		super(options.screenBuilderCacheDir, $fs, $httpClient, $logger, $progressIndicator); // We should pass here the correct profileDir
 	}
 
 	public get appScaffoldingPath(): string {
@@ -25,7 +26,7 @@ export class AppScaffoldingExtensionsService extends dependencyExtensionsService
 	public prepareAppScaffolding(): IFuture<void> {
 		return (() => {
 			var appScaffoldingConfig = this.$dependencyConfigService.getAppScaffoldingConfig().wait();
-			appScaffoldingConfig.pathToSave = options.defaultProfileDir === options.profileDir ? path.join(process.env.LocalAppData, "Telerik", "sb") : options.profileDir;
+			appScaffoldingConfig.pathToSave = options.screenBuilderCacheDir;
 			var afterPrepareAction = () => {
 				return (() => {
 					this.npmInstall("glob-watcher@0.0.8").wait(); // HACK: With this we are able to make paths shorter with 20 symbols.

--- a/lib/services/app-scaffolding-extensions-service.ts
+++ b/lib/services/app-scaffolding-extensions-service.ts
@@ -2,17 +2,20 @@
 "use strict";
 
 import dependencyExtensionsServiceLib = require("./dependency-extensions-service-base");
+import options = require("../common/options");
+import path = require("path");
+import util = require("util");
 
 export class AppScaffoldingExtensionsService extends dependencyExtensionsServiceLib.DependencyExtensionsServiceBase implements IAppScaffoldingExtensionsService {
 	private static APP_SCAFFOLDING_NAME = "app-scaffolding";
 
 	constructor($fs: IFileSystem,
-				$httpClient: Server.IHttpClient,
-				$logger: ILogger,
-				$progressIndicator: IProgressIndicator,
-				private $childProcess: IChildProcess,
-		private $dependencyConfigService: IDependencyConfigService) {
-		super($fs, $httpClient, $logger, $progressIndicator);
+		$httpClient: Server.IHttpClient,
+		$logger: ILogger,
+		$progressIndicator: IProgressIndicator,
+		protected $childProcess: IChildProcess,
+		protected $dependencyConfigService: IDependencyConfigService) {
+		super(options.defaultProfileDir === options.profileDir ? path.join(process.env.LocalAppData, "Telerik", "sb") : options.profileDir, $fs, $httpClient, $logger, $progressIndicator); // We should pass here the correct profileDir
 	}
 
 	public get appScaffoldingPath(): string {
@@ -22,9 +25,26 @@ export class AppScaffoldingExtensionsService extends dependencyExtensionsService
 	public prepareAppScaffolding(): IFuture<void> {
 		return (() => {
 			var appScaffoldingConfig = this.$dependencyConfigService.getAppScaffoldingConfig().wait();
-			var afterPrepareAction = () => this.$childProcess.exec("npm install", {cwd: this.appScaffoldingPath });
+			appScaffoldingConfig.pathToSave = options.defaultProfileDir === options.profileDir ? path.join(process.env.LocalAppData, "Telerik", "sb") : options.profileDir;
+			var afterPrepareAction = () => {
+				return (() => {
+					this.npmInstall("glob-watcher@0.0.8").wait(); // HACK: With this we are able to make paths shorter with 20 symbols.
+					this.npmInstall().wait();
+					this.npmDedupe().wait();
+				}).future<void>()();
+			};
 			this.prepareDependencyExtension(AppScaffoldingExtensionsService.APP_SCAFFOLDING_NAME, appScaffoldingConfig, afterPrepareAction).wait();
 		}).future<void>()();
+	}
+
+	protected npmInstall(packageToInstall?: string): IFuture<void> {
+		packageToInstall = packageToInstall || "";
+		var command = util.format("npm install %s --production", packageToInstall);
+		return this.$childProcess.exec(command, {cwd: this.appScaffoldingPath });
+	}
+
+	protected npmDedupe(): IFuture<void> {
+		return this.$childProcess.exec("npm dedupe", {cwd: this.appScaffoldingPath});
 	}
 }
 $injector.register("appScaffoldingExtensionsService", AppScaffoldingExtensionsService);

--- a/lib/services/dependency-extensions-service-base.ts
+++ b/lib/services/dependency-extensions-service-base.ts
@@ -34,7 +34,7 @@ export class DependencyExtensionsServiceBase extends serverExtensionsBaseLib.Ext
 					pathToSave: dependencyConfig.pathToSave
 				};
 
-				this.$progressIndicator.showProgressIndicator(this.prepareExtensionBase(dependencyExtensionData, cachedVersion), 2000).wait();
+				this.$progressIndicator.showProgressIndicator(this.prepareExtensionBase(dependencyExtensionData, cachedVersion), 5000).wait();
 				this.$progressIndicator.showProgressIndicator(afterPrepareAction(), 100).wait();
 			}
 		}).future<void>()();

--- a/lib/services/dependency-extensions-service-base.ts
+++ b/lib/services/dependency-extensions-service-base.ts
@@ -8,11 +8,12 @@ export class DependencyExtensionsServiceBase extends serverExtensionsBaseLib.Ext
 	private static SCREEN_BUILDER_BUCKET_NAME = "http://s3.amazonaws.com/screenbuilder-cli";
 	private static DEFAULT_CACHED_VERSION = "0.0.0";
 
-	constructor($fs: IFileSystem,
-				$httpClient: Server.IHttpClient,
-				$logger: ILogger,
-				private $progressIndicator: IProgressIndicator) {
-		super($fs, $httpClient, $logger);
+	constructor(public cacheDir: string,
+		$fs: IFileSystem,
+		$httpClient: Server.IHttpClient,
+		$logger: ILogger,
+		private $progressIndicator: IProgressIndicator) {
+		super(cacheDir, $fs, $httpClient, $logger);
 	}
 
 	public prepareDependencyExtension(dependencyExtensionName: string, dependencyConfig: IDependencyConfig, afterPrepareAction?: () => IFuture<void>): IFuture<void> {
@@ -33,7 +34,7 @@ export class DependencyExtensionsServiceBase extends serverExtensionsBaseLib.Ext
 					pathToSave: dependencyConfig.pathToSave
 				};
 
-				this.$progressIndicator.showProgressIndicator(this.prepareExtensionBase(dependencyExtensionData, cachedVersion), 1000).wait();
+				this.$progressIndicator.showProgressIndicator(this.prepareExtensionBase(dependencyExtensionData, cachedVersion), 2000).wait();
 				this.$progressIndicator.showProgressIndicator(afterPrepareAction(), 100).wait();
 			}
 		}).future<void>()();

--- a/lib/services/extensions-service-base.ts
+++ b/lib/services/extensions-service-base.ts
@@ -10,16 +10,13 @@ temp.track();
 export class ExtensionsServiceBase {
 	private extensionVersions: IStringDictionary = {};
 
-	constructor(public $fs: IFileSystem,
-				public $httpClient: Server.IHttpClient,
-				public $logger: ILogger) {
+	constructor(public cacheDir: string,
+		protected $fs: IFileSystem,
+		protected $httpClient: Server.IHttpClient,
+		protected $logger: ILogger) {
 		if (this.$fs.exists(this.versionsFile).wait()) {
 			this.extensionVersions = this.$fs.readJson(this.versionsFile).wait() || {};
 		}
-	}
-
-	public get cacheDir(): string {
-		return path.join(options.profileDir, "Cache");
 	}
 
 	public getExtensionVersion(packageName: string): string {
@@ -84,7 +81,7 @@ export class ExtensionsServiceBase {
 	}
 
 	private get versionsFile(): string {
-		return path.join(this.cacheDir, "extension-versions.json");
+		return path.join(options.profileDir, "Cache", "extension-versions.json");
 	}
 
 	private saveVersionsFile() : IFuture<void> {

--- a/lib/services/generator-extensions-service.ts
+++ b/lib/services/generator-extensions-service.ts
@@ -12,13 +12,13 @@ export class GeneratorExtensionsService extends appScaffoldingExtensionsServiceL
 		$progressIndicator: IProgressIndicator,
 		$childProcess: IChildProcess,
 		$dependencyConfigService: IDependencyConfigService) {
-			super($fs, $httpClient, $logger, $progressIndicator, $childProcess, $dependencyConfigService);
+		super($fs, $httpClient, $logger, $progressIndicator, $childProcess, $dependencyConfigService);
 	}
 
 	public prepareGenerator(generatorName: string): IFuture<void> {
 		return (() => {
 			var generatorConfig = this.$dependencyConfigService.getGeneratorConfig(generatorName).wait();
-			generatorConfig.pathToSave = path.join(this.appScaffoldingPath, generatorName, "latest", "node_modules");
+			generatorConfig.pathToSave = path.join(this.appScaffoldingPath, "H", generatorConfig.version , "node_modules");
 
 			this.$fs.ensureDirectoryExists(generatorConfig.pathToSave).wait();
 

--- a/lib/services/screen-builder-service.ts
+++ b/lib/services/screen-builder-service.ts
@@ -84,7 +84,7 @@ export class ScreenBuilderService implements IScreenBuilderService {
 				generatorsCache: appScaffoldingPath,
 				generatorsAlias: ['H'],
 				path: screenBuilderOptions.projectPath || path.resolve(options.path || "."),
-				dependencies: util.format("%s@latest", generatorName),
+				dependencies: [generatorName + "@0.0.1"],
 				connect: (done:Function) => {
 					done();
 				},

--- a/lib/services/server-extensions.ts
+++ b/lib/services/server-extensions.ts
@@ -2,8 +2,9 @@
 "use strict";
 
 import Future = require("fibers/future");
-
+import options = require("./../common/options");
 import serverExtensionsBaseLib = require("./extensions-service-base");
+import path = require("path");
 
 export class ServerExtensionsService extends serverExtensionsBaseLib.ExtensionsServiceBase implements IServerExtensionsService {
 	constructor($logger: ILogger,
@@ -11,7 +12,7 @@ export class ServerExtensionsService extends serverExtensionsBaseLib.ExtensionsS
 		$fs: IFileSystem,
 		private $config: IConfiguration,
 		private $serverConfiguration: IServerConfiguration){
-			super($fs, $httpClient, $logger);
+			super(path.join(options.profileDir, "Cache"), $fs, $httpClient, $logger);
 	}
 
 	public prepareExtension(packageName: string, beforeDownloadExtensionAction: () => IFuture<void>): IFuture<void> {


### PR DESCRIPTION
This PR fixes 2 problems with ScreenBuilder integration:
1. Currently we are creating files in the current dir - I fixed this behavior and we create directory with appName.
2. Long paths on windows - I moved ScreenBuilder cache directory to <%localappdata%>/Telerik

Should be merged after this https://github.com/telerik/mobile-cli-lib/pull/257