### PR TITLE
Add timeout on preuninstall

### DIFF
--- a/preuninstall.js
+++ b/preuninstall.js
@@ -8,3 +8,5 @@ var child = child_process.exec("node bin/appbuilder.js dev-preuninstall", functi
 });
 
 child.stdout.pipe(process.stdout);
+
+setTimeout(function(){}, 3000);


### PR DESCRIPTION
In some cases the preuninstall operations requires some more time and leads to errors if we do exit immediately. Add timeout of 3 seconds (it was removed with one of the previous commits by mistake).
Sync with latest common lib.