### PR TITLE
AppManager LiveSync

### DIFF
--- a/AppBuilderCLI.njsproj
+++ b/AppBuilderCLI.njsproj
@@ -45,8 +45,10 @@
     <Content Include="config\config-sttap.json" />
     <Content Include="config\config-test.json" />
     <Content Include="config\config.json" />
+    <TypeScriptCompile Include="lib\.d.ts" />
     <TypeScriptCompile Include="lib\appbuilder-cli.ts" />
     <TypeScriptCompile Include="lib\bootstrap.ts" />
+    <TypeScriptCompile Include="lib\commands\livepatch.ts" />
     <TypeScriptCompile Include="lib\common\commands\preuninstall.ts" />
     <TypeScriptCompile Include="lib\config.ts" />
     <TypeScriptCompile Include="lib\declarations.d.ts" />
@@ -74,6 +76,7 @@
     <TypeScriptCompile Include="lib\services\dependency-extensions-service-base.ts" />
     <TypeScriptCompile Include="lib\services\extensions-service-base.ts" />
     <TypeScriptCompile Include="lib\services\generator-extensions-service.ts" />
+    <TypeScriptCompile Include="lib\services\livepatch-service.ts" />
     <TypeScriptCompile Include="lib\services\project-commands-service.ts" />
     <TypeScriptCompile Include="lib\services\screen-builder-service.ts" />
     <TypeScriptCompile Include="lib\templates-service.ts" />

--- a/docs/man_pages/index.md
+++ b/docs/man_pages/index.md
@@ -77,6 +77,7 @@ Command | Description
 [appstore&nbsp;list](publishing/appstore-list.html) | Lists all applications in iTunes Connect.
 [appstore&nbsp;upload](publishing/appstore-upload.html) | Builds the project and uploads the binary to iTunes Connect.
 [appmanager&nbsp;upload&nbsp;`<Platform>`](publishing/appmanager.html) | Builds the project and uploads the binary to Telerik AppManager.
+[appmanager&nbsp;livesync&nbsp;`<Platforms>`](publishing/appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 
 ## Global Options
 Option | Description

--- a/docs/man_pages/publishing/appmanager-livesync.md
+++ b/docs/man_pages/publishing/appmanager-livesync.md
@@ -1,21 +1,36 @@
-certificate
+appmanager livesync
 ==========
 
 Usage | Synopsis
 ------|-------
-List certificates | `$ appbuilder certificate`    
-Manage certificates | `$ appbuilder certificate [<Command>]`
+General | `$ appbuilder appmanager livesync [<Platforms>]`
 
-Lists or lets you manage certificates for code signing iOS and Android applications. <% if(isHtml) { %>When building an app, you can set the certificate by index or name in the `--certificate` option.<% } %>  
+Publish a new update of your application in AppManager. <% if(isHtml) { %>If you have not enabled the AppManager LiveSync plugin for your project, it will be automatically enabled for the release build configuration.<% } %>
+In case you do not specify a platform, the patch will be published for all platforms (in case you confirm the prompt dialog).
 
+<% if(isConsole && isMobileWebsite) { %>WARNING: This command is not applicable to mobile website projects. To view the complete help for this command, run `$ appbuilder help appmanager livesync`<% } %>
+
+<% if((isConsole && (isNativeScript || isCordova)) || isHtml) { %>
 ### Attributes
-`<Command>` extends the `certificate` command. You can set the following values for this attribute.
-* `create-self-signed` - Creates a self-signed certificate for code signing Android applications.
-* `remove` - Removes the selected certificate from the server.
-* `export` - Exports the selected certificate from the server on your file system.
-* `import` - Imports a certificate from your file system to the server.
+`<Platforms>` is one or more target platforms, separated by a space, for which you want to publish an update in AppManager. You can set the following target platforms.
+* `android` - Publishes an update for your Android application.
+* `ios` - Publishes an update for your iOS application.
+<% if(isCordova) { %>* `wp8` - Publishes an update for your Windows Phone application.<% } %>
+
+If you do not set a target platform, the AppBuilder CLI publishes an update for all platforms. 
+<% } %>
 
 <% if(isHtml) { %> 
+
+### Prerequisites
+
+* You must have published a major version of your app, enabled for AppManager LiveSync. To create a new major version enabled for AppManager LiveSync, run `$ appbuilder appmanager upload <Platform>`
+
+### Command Limitations
+
+* You cannot run this command on mobile website projects.
+* You cannot publish an update for Windows Phone for NativeScript projects.
+
 ### Related Commands
 
 Command | Description
@@ -23,10 +38,10 @@ Command | Description
 [appmanager upload](appmanager.html) | Allows interaction with appmanager.
 [appmanager upload android](appmanager-upload-android.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
-[appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appstore](appstore.html) | Allows interaction with iTunes Connect.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.
+[certificate](certificate.html) | Lists all configured certificates for code signing iOS and Android applications with index and name.
 [certificate create-self-signed](certificate-create-self-signed.html) | Creates a self-signed certificate for code signing Android applications.
 [certificate export](certificate-export.html) | Exports a selected certificate from the server as a P12 file.
 [certificate import](certificate-import.html) | Imports an existing certificate from a P12 or a CER file stored on your local file system.

--- a/docs/man_pages/publishing/appmanager-upload-android.md
+++ b/docs/man_pages/publishing/appmanager-upload-android.md
@@ -28,6 +28,7 @@ Command | Description
 ----------|----------
 [appmanager upload](appmanager.html) | Allows interaction with appmanager.
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
+[appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appstore](appstore.html) | Allows interaction with iTunes Connect.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.

--- a/docs/man_pages/publishing/appmanager-upload-ios.md
+++ b/docs/man_pages/publishing/appmanager-upload-ios.md
@@ -30,6 +30,7 @@ Command | Description
 ----------|----------
 [appmanager upload](appmanager.html) | Allows interaction with appmanager.
 [appmanager upload android](appmanager-upload-android.html) | Builds the project and uploads the application to Telerik AppManager.
+[appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appstore](appstore.html) | Allows interaction with iTunes Connect.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.

--- a/docs/man_pages/publishing/appmanager-upload-wp8.md
+++ b/docs/man_pages/publishing/appmanager-upload-wp8.md
@@ -30,6 +30,7 @@ Command | Description
 ----------|----------
 [appmanager upload](appmanager.html) | Allows interaction with appmanager.
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
+[appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appstore](appstore.html) | Allows interaction with iTunes Connect.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.

--- a/docs/man_pages/publishing/appmanager.md
+++ b/docs/man_pages/publishing/appmanager.md
@@ -28,6 +28,7 @@ Command | Description
 ----------|----------
 [appmanager upload android](appmanager-upload-android.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
+[appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appstore](appstore.html) | Allows interaction with iTunes Connect.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.

--- a/docs/man_pages/publishing/appstore-list.md
+++ b/docs/man_pages/publishing/appstore-list.md
@@ -19,6 +19,7 @@ Command | Description
 [appmanager upload](appmanager.html) | Allows interaction with appmanager.
 [appmanager upload android](appmanager-upload-android.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
+[appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appstore](appstore.html) | Allows interaction with iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.
 [certificate](certificate.html) | Lists all configured certificates for code signing iOS and Android applications with index and name.

--- a/docs/man_pages/publishing/appstore-upload.md
+++ b/docs/man_pages/publishing/appstore-upload.md
@@ -33,6 +33,7 @@ Command | Description
 [appmanager upload](appmanager.html) | Allows interaction with appmanager.
 [appmanager upload android](appmanager-upload-android.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
+[appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appstore](appstore.html) | Allows interaction with iTunes Connect.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [certificate](certificate.html) | Lists all configured certificates for code signing iOS and Android applications with index and name.

--- a/docs/man_pages/publishing/appstore.md
+++ b/docs/man_pages/publishing/appstore.md
@@ -20,6 +20,7 @@ Command | Description
 [appmanager upload](appmanager.html) | Allows interaction with appmanager.
 [appmanager upload android](appmanager-upload-android.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
+[appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.
 [certificate](certificate.html) | Lists all configured certificates for code signing iOS and Android applications with index and name.

--- a/docs/man_pages/publishing/certificate-create-self-signed.md
+++ b/docs/man_pages/publishing/certificate-create-self-signed.md
@@ -24,6 +24,7 @@ Command | Description
 [appmanager upload](appmanager.html) | Allows interaction with appmanager.
 [appmanager upload android](appmanager-upload-android.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
+[appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appstore](appstore.html) | Allows interaction with iTunes Connect.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.

--- a/docs/man_pages/publishing/certificate-export.md
+++ b/docs/man_pages/publishing/certificate-export.md
@@ -21,6 +21,7 @@ Command | Description
 [appmanager upload](appmanager.html) | Allows interaction with appmanager.
 [appmanager upload android](appmanager-upload-android.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
+[appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appstore](appstore.html) | Allows interaction with iTunes Connect.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.

--- a/docs/man_pages/publishing/certificate-import.md
+++ b/docs/man_pages/publishing/certificate-import.md
@@ -19,6 +19,7 @@ Command | Description
 [appmanager upload](appmanager.html) | Allows interaction with appmanager.
 [appmanager upload android](appmanager-upload-android.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
+[appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appstore](appstore.html) | Allows interaction with iTunes Connect.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.

--- a/docs/man_pages/publishing/certificate-remove.md
+++ b/docs/man_pages/publishing/certificate-remove.md
@@ -20,6 +20,7 @@ Command | Description
 [appmanager upload](appmanager.html) | Allows interaction with appmanager.
 [appmanager upload android](appmanager-upload-android.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
+[appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appstore](appstore.html) | Allows interaction with iTunes Connect.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.

--- a/docs/man_pages/publishing/certificate-request-create.md
+++ b/docs/man_pages/publishing/certificate-request-create.md
@@ -20,6 +20,7 @@ Command | Description
 [appmanager upload](appmanager.html) | Allows interaction with appmanager.
 [appmanager upload android](appmanager-upload-android.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
+[appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appstore](appstore.html) | Allows interaction with iTunes Connect.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.

--- a/docs/man_pages/publishing/certificate-request-download.md
+++ b/docs/man_pages/publishing/certificate-request-download.md
@@ -21,6 +21,7 @@ Command | Description
 [appmanager upload](appmanager.html) | Allows interaction with appmanager.
 [appmanager upload android](appmanager-upload-android.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
+[appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appstore](appstore.html) | Allows interaction with iTunes Connect.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.

--- a/docs/man_pages/publishing/certificate-request-remove.md
+++ b/docs/man_pages/publishing/certificate-request-remove.md
@@ -18,6 +18,7 @@ Command | Description
 [appmanager upload](appmanager.html) | Allows interaction with appmanager.
 [appmanager upload android](appmanager-upload-android.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
+[appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appstore](appstore.html) | Allows interaction with iTunes Connect.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.

--- a/docs/man_pages/publishing/certificate-request.md
+++ b/docs/man_pages/publishing/certificate-request.md
@@ -22,6 +22,7 @@ Command | Description
 [appmanager upload](appmanager.html) | Allows interaction with appmanager.
 [appmanager upload android](appmanager-upload-android.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
+[appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appstore](appstore.html) | Allows interaction with iTunes Connect.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.

--- a/docs/man_pages/publishing/provision-import.md
+++ b/docs/man_pages/publishing/provision-import.md
@@ -18,6 +18,7 @@ Command | Description
 [appmanager upload](appmanager.html) | Allows interaction with appmanager.
 [appmanager upload android](appmanager-upload-android.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
+[appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appstore](appstore.html) | Allows interaction with iTunes Connect.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.

--- a/docs/man_pages/publishing/provision-remove.md
+++ b/docs/man_pages/publishing/provision-remove.md
@@ -18,6 +18,7 @@ Command | Description
 [appmanager upload](appmanager.html) | Allows interaction with appmanager.
 [appmanager upload android](appmanager-upload-android.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
+[appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appstore](appstore.html) | Allows interaction with iTunes Connect.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.

--- a/docs/man_pages/publishing/provision.md
+++ b/docs/man_pages/publishing/provision.md
@@ -25,6 +25,7 @@ Command | Description
 [appmanager upload](appmanager.html) | Allows interaction with appmanager.
 [appmanager upload android](appmanager-upload-android.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
+[appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appstore](appstore.html) | Allows interaction with iTunes Connect.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.

--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -160,6 +160,8 @@ $injector.require("jsonSchemaConstants", "./json-schema/json-schema-constants");
 
 $injector.require("liveSyncService", "./services/livesync-service");
 $injector.require("appManagerService", "./services/appmanager-service");
+$injector.requireCommand("appmanager|livesync", "./commands/appmanager-livesync");
+
 $injector.require("dynamicHelpProvider", "./dynamic-help-provider");
 $injector.require("mobilePlatformsCapabilities", "./mobile-platforms-capabilities");
 
@@ -167,3 +169,4 @@ $injector.require("commandsServiceProvider", "./providers/commands-service-provi
 $injector.require("progressIndicator", "./progress-indicator");
 
 $injector.require("projectCommandsService", "./services/project-commands-service");
+

--- a/lib/commands/appmanager-livesync.ts
+++ b/lib/commands/appmanager-livesync.ts
@@ -1,0 +1,40 @@
+﻿///<reference path="../.d.ts"/>
+"use strict";
+
+export class AppManagerLiveSyncCommand implements ICommand {
+	private static ALL_PLATFORMS_OPTION = "All platforms";
+
+	constructor(private $prompter: IPrompter,
+		private $mobileHelper: Mobile.IMobileHelper,
+		private $appManagerService: IAppManagerService,
+		private $errors: IErrors,
+		private $logger:ILogger) { }
+
+	public execute(args: string[]): IFuture<void> {
+		return ((): void => {
+			if(!args || args.length === 0) {
+				var options = this.$mobileHelper.platformNames.concat(AppManagerLiveSyncCommand.ALL_PLATFORMS_OPTION);
+				var selectedPlatform = this.$prompter.promptForChoice("This command will publish a new update version to AppManager. Please select platform?", options).wait();
+				if(selectedPlatform === AppManagerLiveSyncCommand.ALL_PLATFORMS_OPTION) {
+					this.$appManagerService.publishLivePatch(this.$mobileHelper.platformNames).wait();
+				} else {
+					this.$appManagerService.publishLivePatch([selectedPlatform]).wait();
+				}
+			} else {
+				// make sure each platform is specified only once
+				var platforms = _.keys(_.groupBy(args, arg => this.$mobileHelper.normalizePlatformName(arg)));
+				this.$appManagerService.publishLivePatch(platforms).wait();
+			}
+		}).future<void>()();
+	}
+
+	public canExecute(args: string[]): IFuture<boolean> {
+		return ((): boolean => {
+			_.each(args, platform => this.$mobileHelper.validatePlatformName(platform));
+			return true;
+		}).future<boolean>()();
+	}
+
+	public allowedParameters: ICommandParameter[] = [];
+}
+$injector.registerCommand("appmanager|livesync", AppManagerLiveSyncCommand);

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -465,6 +465,8 @@ interface ILiveSyncService {
 
 interface IAppManagerService {
 	upload(platform: string): IFuture<void>;
+	openAppManagerStore(): void;
+	publishLivePatch(platforms: string[]): IFuture<void>;
 }
 
 interface IProgressIndicator {

--- a/lib/server-api.d.ts
+++ b/lib/server-api.d.ts
@@ -428,6 +428,9 @@ declare module Server{
 		getLinuxBuildMachineStatus(): IFuture<string>;
 		getMacBuildMachineStatus(): IFuture<string>;
 	}
+	interface PatchData{
+		Platforms: Server.DevicePlatform[];
+	}
 	interface FeatureStatus{
 		IsAvailable: boolean;
 		IsAccountUpgradeRequired: boolean;
@@ -436,6 +439,7 @@ declare module Server{
 	interface ITamServiceContract{
 		verifyStoreCreated(): IFuture<void>;
 		uploadApplication(solutionName: string, projectName: string, relativePackagePath: string): IFuture<void>;
+		uploadPatch(solutionName: string, projectName: string, patchData: Server.PatchData): IFuture<void>;
 		getAccountStatus(): IFuture<Server.FeatureStatus>;
 	}
 	interface TapSolutionData{

--- a/lib/server-api.ts
+++ b/lib/server-api.ts
@@ -364,6 +364,9 @@ export class TamService implements Server.ITamServiceContract{
 	public uploadApplication(solutionName: string, projectName: string, relativePackagePath: string): IFuture<void>{
 		return this.$serviceProxy.call<void>('UploadApplication', 'POST', ['api','tam','applications',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(projectName.replace(/\\/g, '/')),encodeURI(relativePackagePath.replace(/\\/g, '/'))].join('/'), null, null, null);
 	}
+	public uploadPatch(solutionName: string, projectName: string, patchData: Server.PatchData): IFuture<void>{
+		return this.$serviceProxy.call<void>('UploadPatch', 'POST', ['api','tam',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(projectName.replace(/\\/g, '/')),'patches'].join('/'), null, [{name: 'patchData', value: JSON.stringify(patchData), contentType: 'application/json'}], null);
+	}
 	public getAccountStatus(): IFuture<Server.FeatureStatus>{
 		return this.$serviceProxy.call<Server.FeatureStatus>('GetAccountStatus', 'GET', ['api','tam','account','status'].join('/'), 'application/json', null, null);
 	}

--- a/lib/services/appmanager-service.ts
+++ b/lib/services/appmanager-service.ts
@@ -4,8 +4,12 @@
 import constants = require("../common/mobile/constants");
 import util = require("util");
 import options = require("../options");
+import os = require("os");
+import commonOptions = require("../common/options");
 
 class AppManagerService implements IAppManagerService {
+	private static LIVEPATCH_PLUGIN_ID = "com.telerik.LivePatch";
+
 	constructor(
 		private $config: IConfiguration,
 		private $server: Server.IServer,
@@ -15,7 +19,10 @@ class AppManagerService implements IAppManagerService {
 		private $loginManager: ILoginManager,
 		private $opener: IOpener,
 		private $buildService: Project.IBuildService,
-		private $mobileHelper: Mobile.IMobileHelper) { }
+		private $pluginsService: IPluginsService,
+		private $progressIndicator: IProgressIndicator,
+		private $mobileHelper: Mobile.IMobileHelper,
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) { }
 
 	upload(platform: string): IFuture<void> {
 		return (() => {
@@ -48,9 +55,44 @@ class AppManagerService implements IAppManagerService {
 
 			this.$logger.info("Successfully uploaded package.");
 
-			var tamUrl = util.format("%s://%s/appbuilder/Services/tam", this.$config.AB_SERVER_PROTO, this.$config.AB_SERVER);
-			this.$logger.info("Go to %s to manage your apps.", tamUrl);
-			this.$opener.open(tamUrl);
+			this.openAppManagerStore();
+		}).future<void>()();
+	}
+
+	public openAppManagerStore(): void {
+		var tamUrl = util.format("%s://%s/appbuilder/Services/tam", this.$config.AB_SERVER_PROTO, this.$config.AB_SERVER);
+		this.$logger.info("Go to %s to manage your apps.", tamUrl);
+		this.$opener.open(tamUrl);
+	}
+
+	public publishLivePatch(platforms: string[]): IFuture<void> {
+		return (() => {
+			platforms = _.map(platforms, platform => this.$mobileHelper.normalizePlatformName(platform));
+			var cachedOptionsRelease = commonOptions.release;
+			commonOptions.release = true;
+			this.configureLivePatchPlugin().wait();
+
+			this.$logger.warn("If you have not published an AppManager LiveSync-enabled major version of this app before, you will not be able to distribute an AppManager LiveSync update for it.");
+			this.$logger.info("To create a new major version enabled for AppManager LiveSync, run `$ appbuilder appmanager upload <Platform>`");
+
+			this.$project.importProject().wait();
+			this.$logger.printInfoMessageOnSameLine("Publishing patch for " + platforms.join(", ") + "...");
+			this.$progressIndicator.showProgressIndicator(this.$server.tam.uploadPatch(this.$project.projectData.ProjectName, this.$project.projectData.ProjectName, <any>{ Platforms: platforms }), 2000).wait();
+			this.$logger.printInfoMessageOnSameLine(os.EOL);
+			commonOptions.release = cachedOptionsRelease;
+
+			this.openAppManagerStore();
+		}).future<void>()();
+	}
+
+	private configureLivePatchPlugin(): IFuture<void> {
+		return (() => {
+			var plugins = this.$pluginsService.getInstalledPlugins();
+			if(!_.any(plugins, plugin => plugin.data.Identifier === AppManagerService.LIVEPATCH_PLUGIN_ID)) {
+				this.$logger.warn("The AppManager LiveSync plugin is not enabled for your project. Enabling it now for the release build configuration...");
+				this.$pluginsService.addPlugin(AppManagerService.LIVEPATCH_PLUGIN_ID).wait();
+				this.$logger.info("AppManager LiveSync is now enabled for the release build configuration.");
+			}
 		}).future<void>()();
 	}
 }

--- a/lib/services/plugins-service.ts
+++ b/lib/services/plugins-service.ts
@@ -5,6 +5,7 @@ import os = require("os");
 import util = require("util");
 import options = require("../common/options");
 import pluginsDataLib = require("../plugins-data");
+import Future = require("fibers/future");
 
 export class PluginsService implements IPluginsService {
 	private static CORE_PLUGINS_PROPERTY_NAME = "CorePlugins";
@@ -23,11 +24,9 @@ export class PluginsService implements IPluginsService {
 		// Cordova plugin commands are only applicable to Cordova projects
 		this.$project.ensureCordovaProject();
 
-		this.$logger.info("Gathering information for plugins...");
-
 		this.identifierToPlugin = Object.create(null);
-		this.createPluginsData($cordovaPluginsService).wait();
-		this.createPluginsData($marketplacePluginsService).wait();
+		Future.wait([this.createPluginsData($cordovaPluginsService),
+			this.createPluginsData($marketplacePluginsService)]);
 	}
 
 	public getInstalledPlugins(): IPlugin[] {


### PR DESCRIPTION
Allow publishing of patches in AppManager. Add new command: `appmanager livesync`. It can be used without parameters in which case the user must confirm that the patch should be published to all platforms. The command accepts multiple arguments, which are the platforms. It can be used with one or with many platforms:
* `$ appmanager livesync android`
* `$ appmanager livesync android ios`
etc.

In case LivePatch plugin is not enabled for release configuration, we notify the user the we are enabling it.
http://teampulse.telerik.com/view#/12319