### PR TITLE
Fix init command and unit tests

### DIFF
--- a/lib/commands/project/init.ts
+++ b/lib/commands/project/init.ts
@@ -12,7 +12,6 @@ export class InitProjectCommand implements ICommand {
 	private cordovaFiles: FileDescriptor[];
 	public projectDir: string;
 	public tnsModulesDir: FileDescriptor;
-	public bootstrapFile: FileDescriptor;
 	public indexHtml: FileDescriptor;
 	public projectFilesDescriptors: any;
 
@@ -25,7 +24,6 @@ export class InitProjectCommand implements ICommand {
 
 		this.projectDir = $project.getNewProjectDir();
 		this.tnsModulesDir = new FileDescriptor(path.join(this.projectDir, "tns_modules"), "directory");
-		this.bootstrapFile = new FileDescriptor(path.join(this.projectDir, "app", "bootstrap.js"), "file");
 		this.indexHtml = new FileDescriptor(path.join(this.projectDir, "index.html"), "file");
 		this.cordovaFiles = _.map(this.$mobileHelper.platformNames, platform => new FileDescriptor(util.format("cordova.%s.js", platform).toLowerCase(), "file"));
 
@@ -81,9 +79,9 @@ export class InitProjectCommand implements ICommand {
 	private generateMandatoryAndForbiddenFiles() {
 		this.projectFilesDescriptors = Object.create(null);
 
-		this.generateMandatoryAndForbiddenFilesCore(this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova,  this.cordovaFiles, [this.bootstrapFile, this.tnsModulesDir]);
-		this.generateMandatoryAndForbiddenFilesCore(this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript, [this.bootstrapFile, this.tnsModulesDir], this.cordovaFiles.concat([this.indexHtml]));
-		this.generateMandatoryAndForbiddenFilesCore(this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.MobileWebsite, [this.indexHtml],  this.cordovaFiles.concat([this.bootstrapFile, this.tnsModulesDir]));
+		this.generateMandatoryAndForbiddenFilesCore(this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova, this.cordovaFiles, [this.tnsModulesDir]);
+		this.generateMandatoryAndForbiddenFilesCore(this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript, [this.tnsModulesDir], this.cordovaFiles.concat([this.indexHtml]));
+		this.generateMandatoryAndForbiddenFilesCore(this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.MobileWebsite, [this.indexHtml], this.cordovaFiles.concat([this.tnsModulesDir]));
 	}
 
 	private generateMandatoryAndForbiddenFilesCore(frameworkIdentifer: string, manddatorFiles: FileDescriptor[], forbiddenFiles: FileDescriptor[]): void {

--- a/lib/project.ts
+++ b/lib/project.ts
@@ -250,6 +250,7 @@ export class Project implements Project.IProject {
 			this.$fs.unzip(path.join(this.$templatesService.projectTemplatesDir, blankTemplateFile), projectDir, { overwriteExisitingFiles: false }, ["*.abproject", ".abignore"]).wait();
 
 			this.createProjectFileFromExistingProject(projectDir, framework).wait();
+			this.$logger.info("Successfully initialized %s project.", framework); 
 		}).future<void>()();
 	}
 

--- a/test/project.ts
+++ b/test/project.ts
@@ -288,9 +288,6 @@ describe("project integration tests", () => {
 				options.template = "Blank";
 				project.createNewProject(projectName, projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript).wait();
 				var projectDir = project.getProjectDir().wait();
-				var bootstrapJsFile = path.join(projectDir, "app", "bootstrap.js");
-				assert.isTrue(fs.existsSync(bootstrapJsFile), "NativeScript Blank template does not contain mandatory 'app/bootstrap.js' file. This file is required in init command. You should check if this is problem with the template or change init command to use another file.");
-
 				var tnsDir = path.join(projectDir, "tns_modules");
 				assert.isTrue(fs.existsSync(tnsDir), "NativeScript Blank template does not contain mandatory 'tns_modules' directory. This directory is required in init command. You should check if this is problem with the template or change init command to use another file.");
 			});
@@ -299,9 +296,6 @@ describe("project integration tests", () => {
 				options.template = "TypeScript.Blank";
 				project.createNewProject(projectName, projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript).wait();
 				var projectDir = project.getProjectDir().wait();
-				var bootstrapJsFile = path.join(projectDir, "app", "bootstrap.js");
-				assert.isTrue(fs.existsSync(bootstrapJsFile), "NativeScript TypeScript Blank template does not contain mandatory 'app/bootstrap.js' file. This file is required in init command. You should check if this is problem with the template or change init command to use another file.");
-
 				var tnsDir = path.join(projectDir, "tns_modules");
 				assert.isTrue(fs.existsSync(tnsDir), "NativeScript TypeScript.Blank template does not contain mandatory 'tns_modules' directory. This directory is required in init command. You should check if this is problem with the template or change init command to use another file.");
 			});

--- a/test/resources/blank-NativeScript.abproject
+++ b/test/resources/blank-NativeScript.abproject
@@ -12,7 +12,7 @@
         "2"
     ]
     ,"iOSBackgroundMode": []
-    ,"FrameworkVersion": "0.9.0"
+    ,"FrameworkVersion": "0.10.0"
     ,"AndroidPermissions": [
         "android.permission.INTERNET"
      ]


### PR DESCRIPTION
`appbuilder init` is trying to determine project type based on the files in the current directory. As NativeScript had changed their templates we have to update our logic. Remove the check for bootstrap.js file as it is not required anymore. Fix unit tests.