### PR TITLE
Allow setting of multiple values with prop set

### DIFF
--- a/lib/commands/prop/prop-set.ts
+++ b/lib/commands/prop/prop-set.ts
@@ -10,17 +10,9 @@ export class SetProjectPropertyCommand extends projectPropertyCommandBaseLib.Pro
 	}
 
 	canExecute(args: string[]): IFuture<boolean> {
-		return (() => {
 			var property = args[0];
 			var propertyValues = _.rest(args, 1);
-			if(this.$project.validateProjectProperty(property, propertyValues, "set").wait()) {
-				if(propertyValues.length === 1 && propertyValues[0]) {
-					return true;
-				}
-			}
-
-			return false;
-		}).future<boolean>()();
+			return this.$project.validateProjectProperty(property, propertyValues, "set");
 	}
 
 	execute(args: string[]): IFuture<void> {


### PR DESCRIPTION
`$ appbuilder prop set` should work for setting array values. Remove incorrect validation logic which was allowing only singe value to be used.

Fixes http://teampulse.telerik.com/view#item/289487