### PR TITLE
Fix markdown links in console

### DIFF
--- a/docs/man_pages/index.md
+++ b/docs/man_pages/index.md
@@ -8,7 +8,7 @@ General | `$ appbuilder <Command> [Parameters] [--options <Values>]`
 ## General Commands
 Command | Description
 -------|----------
-[help <Command>](general/help.html) | Shows additional information about the commands in this list.
+[help `<Command>`](general/help.html) | Shows additional information about the commands in this list.
 [login](general/login.html) | Logs you in the Telerik Platform.
 [logout](general/logout.html) | Logs you out from the Telerik Platform.
 [user](general/user.html) | Prints information about the currently logged in user.


### PR DESCRIPTION
Links in markdown files should be stripped in console help. Fix the incorrect regex, so now the correct text between [ and ] will be shown.
Fixes: http://teampulse.telerik.com/view#item/290105