### PR TITLE
Fix dynamic help for edit-configuration command.

### DIFF
--- a/lib/project.ts
+++ b/lib/project.ts
@@ -105,9 +105,11 @@ export class Project implements Project.IProject {
 			_.each(_.values(this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS), (framework: string) => {
 				var frameworkProject = this.$frameworkProjectResolver.resolve(framework);
 				var configFiles = frameworkProject.configFiles;
-				var title = util.format("Configuration files for %s projects:", framework);
-				result.push(title);
-				result.push(this.configurationFilesStringCore(configFiles));
+				if(configFiles && configFiles.length > 0) {
+					var title = util.format("Configuration files for %s projects:", framework);
+					result.push(title);
+					result.push(this.configurationFilesStringCore(configFiles));
+				}
 			});
 
 			return result.join("\n")


### PR DESCRIPTION
Mobile websites do not have configuration specific files. Executing `$ appbuilder edit-configuration -h` is trying to print list of configuration files for all frameworks. Do not print message for frameworks which do not have configuration specific files.

Fixes http://teampulse.telerik.com/view#item/289440