### PR TITLE
Mentioned programmatic LiveSync. Fixed spelling for three-finger.

### DIFF
--- a/docs/man_pages/project/testing/livesync-cloud.md
+++ b/docs/man_pages/project/testing/livesync-cloud.md
@@ -5,7 +5,7 @@ Usage | Synopsis
 ------|-------
 General | `$ appbuilder livesync cloud`
 
-Synchronizes the project with the cloud to enable LiveSync via wireless connection (using the three finger tap and hold gesture). 
+Synchronizes the project with the cloud to enable LiveSync via wireless connection (using the three-finger tap and hold gesture). <% if(isHtml) { %>You can also control LiveSync with the three-finger tap and hold gesture programmatically. For more information, see [Enable or Disable LiveSync Programmatically](http://docs.telerik.com/platform/appbuilder/testing-your-app/livesync/configuring-livesync/configure-livesync-programmatically) and [LiveSync Changes Programmatically](http://docs.telerik.com/platform/appbuilder/testing-your-app/livesync/livesync-programmatically).<% } %> 
 
 <% if((isConsole && (isNativeScript || isCordova)) || isHtml) { %>
 To get the latest changes on device, tap and hold with three fingers on the device screen until the download pop-up

--- a/docs/man_pages/project/testing/livesync.md
+++ b/docs/man_pages/project/testing/livesync.md
@@ -14,7 +14,7 @@ WARNING: This command is not applicable to mobile website projects. To view the 
 <% } %>
 <% if((isConsole && (isNativeScript || isCordova)) || isHtml) { %>
 `<Command>` extends the `livesync` command. You can set the following values for this attribute.
-* `cloud` - Synchronizes the project with the cloud to enable LiveSync for remote devices (using the three finger tap and hold gesture).
+* `cloud` - Synchronizes the project with the cloud to enable LiveSync for remote devices (using the three-finger tap and hold gesture).
 * `android` - Synchronizes the latest changes in your project to connected Android devices. 
 * `ios` - Synchronizes the latest changes in your project to connected iOS devices.
 <% } %>


### PR DESCRIPTION
NOTE: The links will not work until we have published the 2.9 docs.