### PR TITLE
Fix simulator error on Linux

### DIFF
--- a/lib/commands/debug.ts
+++ b/lib/commands/debug.ts
@@ -26,10 +26,6 @@ export class DebugCommand implements ICommand {
 
 	public execute(args: string[]): IFuture<void> {
 		return (() => {
-			if(!hostInfo.hostCapabilities[process.platform].debugToolsSupported) {
-				this.$errors.fail("In this version of the Telerik AppBuilder CLI, you cannot run the debug tools on Linux. The debug tools for Linux will become available in a future release of the Telerik AppBuilder CLI.");
-			}
-
 			this.$loginManager.ensureLoggedIn().wait();
 
 			var debuggerPackageName = this.$debuggerPlatformServices.getPackageName();
@@ -41,6 +37,10 @@ export class DebugCommand implements ICommand {
 	}
 
 	public canExecute(args: string[]): IFuture<boolean> {
+		if(!hostInfo.hostCapabilities[process.platform].debugToolsSupported) {
+			this.$errors.fail("In this version of the Telerik AppBuilder CLI, you cannot run the debug tools on %s. The debug tools for %s will become available in a future release of the Telerik AppBuilder CLI.", process.platform, process.platform);
+		}
+
 		return this.$debuggerPlatformServices.canRunApplication();
 	}
 

--- a/lib/commands/simulate.ts
+++ b/lib/commands/simulate.ts
@@ -32,15 +32,6 @@ export class SimulateCommand implements ICommand {
 
 	public execute(args: string[]): IFuture<void> {
 		return (() => {
-			this.$project.ensureProject();
-
-			if (!this.$project.capabilities.simulate) {
-				this.$errors.fail("You cannot run %s based projects in the device simulator.", this.$project.projectData.Framework);
-			}
-
-			if(!hostInfo.hostCapabilities[process.platform].debugToolsSupported) {
-				this.$errors.fail("In this version of the Telerik AppBuilder CLI, you cannot run the device simulator on Linux. The device simulator for Linux will become available in a future release of the Telerik AppBuilder CLI.");
-			}
 
 			this.$loginManager.ensureLoggedIn().wait();
 
@@ -57,6 +48,16 @@ export class SimulateCommand implements ICommand {
 	allowedParameters: ICommandParameter[] = [];
 
 	public canExecute(args: string[]): IFuture<boolean> {
+		if(!hostInfo.hostCapabilities[process.platform].debugToolsSupported) {
+			this.$errors.fail("In this version of the Telerik AppBuilder CLI, you cannot run the device simulator on %s. The device simulator for %s will become available in a future release of the Telerik AppBuilder CLI.", process.platform, process.platform);
+		}
+
+		this.$project.ensureProject();
+
+		if(!this.$project.capabilities.simulate) {
+			this.$errors.fail("You cannot run %s based projects in the device simulator.", this.$project.projectData.Framework);
+		}
+
 		return this.$simulatorPlatformServices.canRunApplication();
 	}
 


### PR DESCRIPTION
Move validation logic from execute method of simulate command to canExecute in order to prevent incorrect exception when command is invoked on Linux. Use hostCapabilities as top priority when validating - if the current os does not support simulator/debugger, we should fail immediately.

Fixes http://teampulse.telerik.com/view#item/284572