### PR TITLE
Fix default appid creation

### DIFF
--- a/lib/project/framework-project-base.ts
+++ b/lib/project/framework-project-base.ts
@@ -71,9 +71,9 @@ export class FrameworkProjectBase implements Project.IFrameworkProjectBase {
 	}
 
 	private generateDefaultAppId(appName: string): string {
-		var sanitizedName = _.filter(appName.split(""), (c) => /[a-zA-Z0-9]/.test(c)).join("");
+		var sanitizedName = _.filter(appName.split(""), c => /[a-zA-Z0-9]/.test(c)).join("");
 		if(sanitizedName) {
-			if(/^\d+$/.test(sanitizedName)) {
+			if(/^\d.*$/.test(sanitizedName)) {
 				sanitizedName = "the" + sanitizedName;
 			}
 			return "com.telerik." + sanitizedName;


### PR DESCRIPTION
When user does not specify appid, we set default one based on appName. If the name starts with number, we should prefix the appid with "the" keyword. This was not working due to incorrect regex in our code. The regex was checking if the name contains only numbers. Fix this to check if the name starts with number.

Fixes http://teampulse.telerik.com/view#item/290326