### PR TITLE
Fix plugin remove output

### DIFF
--- a/lib/services/plugins-service.ts
+++ b/lib/services/plugins-service.ts
@@ -134,7 +134,8 @@ export class PluginsService implements IPluginsService {
 			var plugin = this.getPluginByName(pluginName, installedPlugin.data.Version);
 
 			if(this.$project.hasBuildConfigurations()) {
-				_.each(plugin.configurations, (configuration:string) => {
+				var configurations = this.$project.configurations;
+				_.each(configurations, (configuration:string) => {
 					this.removePluginCore(pluginName, plugin, configuration).wait();
 				});
 			} else {


### PR DESCRIPTION
When you use `$appbuilder plugin remove <plugin> --debug` or `$appbuilder plugin remove <plugin> --release` you expect to remove the plugin only for the specified configuration. The output always shows that the plugin has been removed for both configurations, but in fact its removed only for the specified one.

http://teampulse.telerik.com/view#item/290590