### PR TITLE
Fix appmanager livesync messages

### DIFF
--- a/lib/services/appmanager-service.ts
+++ b/lib/services/appmanager-service.ts
@@ -67,13 +67,16 @@ class AppManagerService implements IAppManagerService {
 
 	public publishLivePatch(platforms: string[]): IFuture<void> {
 		return (() => {
+			this.$project.ensureCordovaProject();
+			this.$loginManager.ensureLoggedIn().wait();
+
 			platforms = _.map(platforms, platform => this.$mobileHelper.normalizePlatformName(platform));
 			var cachedOptionsRelease = commonOptions.release;
 			commonOptions.release = true;
 			this.configureLivePatchPlugin().wait();
 
-			this.$logger.warn("If you have not published an AppManager LiveSync-enabled major version of this app before, you will not be able to distribute an AppManager LiveSync update for it.");
-			this.$logger.info("To create a new major version enabled for AppManager LiveSync, run `$ appbuilder appmanager upload <Platform>`");
+			this.$logger.warn("If you have not published an AppManager LiveSync-enabled version of this app before, you will not be able to distribute an AppManager LiveSync update for it.");
+			this.$logger.info("To learn how to create a new version enabled for AppManager LiveSync, run `$ appbuilder help appmanager livesync`");
 
 			this.$project.importProject().wait();
 			this.$logger.printInfoMessageOnSameLine("Publishing patch for " + platforms.join(", ") + "...");

--- a/lib/services/plugins-service.ts
+++ b/lib/services/plugins-service.ts
@@ -19,11 +19,12 @@ export class PluginsService implements IPluginsService {
 		private $errors: IErrors,
 		private $logger: ILogger,
 		private $project: Project.IProject,
-		private $prompter: IPrompter) {
+		private $prompter: IPrompter,
+		private $loginManager: ILoginManager) {
 
 		// Cordova plugin commands are only applicable to Cordova projects
 		this.$project.ensureCordovaProject();
-
+		this.$loginManager.ensureLoggedIn().wait();
 		this.identifierToPlugin = Object.create(null);
 		Future.wait([this.createPluginsData($cordovaPluginsService),
 			this.createPluginsData($marketplacePluginsService)]);

--- a/test/build-configurations.ts
+++ b/test/build-configurations.ts
@@ -109,7 +109,11 @@ function createTestInjector() {
 	testInjector.register("mobileHelper", mobileHelperLib.MobileHelper);
 	testInjector.register("devicePlatformsConstants", devicePlatformsLib.DevicePlatformsConstants);
 	testInjector.register("mobilePlatformsCapabilities", mobilePlatformsCapabilitiesLib.MobilePlatformsCapabilities);
-
+	testInjector.register("loginManager", {
+		ensureLoggedIn: (): IFuture<void> => {
+			return Future.fromResult();
+		}
+	});
 	return testInjector;
 }
 

--- a/test/plugins-service.ts
+++ b/test/plugins-service.ts
@@ -78,6 +78,12 @@ function createTestInjector(cordovaPlugins: any[], installedMarketplacePlugins: 
 		}
 	});
 
+	testInjector.register("loginManager", {
+		ensureLoggedIn: (): IFuture<void> => {
+			return Future.fromResult();
+		}
+	});
+
 	return testInjector;
 }
 


### PR DESCRIPTION
Fix the messages shown to user when using AppManager LiveSync. Ensure user is logged in and the project type is cordova.
Make sure user is loggedIn when collecting plugins information in order to prevent output like:
```
Multiple exceptions were thrown:
Not logged in.
Not logged in.
```