### PR TITLE
Remove gratuitous information when creating website project

### DIFF
--- a/lib/project.ts
+++ b/lib/project.ts
@@ -639,7 +639,9 @@ export class Project implements Project.IProject {
 
 	private validateProjectData(properties: any): void {
 		this.$jsonSchemaValidator.validate(properties);
-		this.$jsonSchemaValidator.validatePropertyUsingBuildSchema(this.$projectConstants.APPIDENTIFIER_PROPERTY_NAME, properties.AppIdentifier);
+		if (this.capabilities.build) {
+			this.$jsonSchemaValidator.validatePropertyUsingBuildSchema(this.$projectConstants.APPIDENTIFIER_PROPERTY_NAME, properties.AppIdentifier);
+		}
 	}
 
 	public saveProject(projectDir: string): IFuture<void> {


### PR DESCRIPTION
When running `$ appbuilder create website SomeName` gratuitous information about application identifiers is shown
Fixes http://teampulse.telerik.com/view#item/290638