### PR TITLE
Fix plugin add/remove

### DIFF
--- a/lib/commands/plugin/list-plugin.ts
+++ b/lib/commands/plugin/list-plugin.ts
@@ -8,7 +8,7 @@ export class ListPluginCommand implements ICommand {
 
 	public execute(args: string[]): IFuture<void> {
 		return (() => {
-			var plugins = options.available ? this.$pluginsService.getAvailablePlugins() : this.$pluginsService.getInstalledPluginsEnabledAtLeastInOneConfiguration();
+			var plugins = options.available ? this.$pluginsService.getAvailablePlugins() : this.$pluginsService.getInstalledPlugins();
 			this.$pluginsService.printPlugins(plugins);
 		}).future<void>()();
 	}

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -402,7 +402,6 @@ interface ICordovaPluginsService {
 interface IPluginsService {
 	getAvailablePlugins(): IPlugin[];
 	getInstalledPlugins(): IPlugin[];
-	getInstalledPluginsEnabledAtLeastInOneConfiguration(): IPlugin[];
 	printPlugins(plugins: IPlugin[]): void;
 	addPlugin(pluginName: string): IFuture<void>;
 	removePlugin(pluginName: string): IFuture<void>;


### PR DESCRIPTION
When plugin is enabled in only one configuration (for example in release only), trying to remove it with `$ appbuilder plugin remove <pluginid>` is telling you that the plugin is not enabled for this project.
When plugin is enabled in only one configuration (for example in release only) trying to add it with `$ appbuilder plugin add <pluginid>` is adding it to both configurations, so in release config the plugin is added twice.
When plugin is enabled in only one configuration (for example in release only) trying to add it with `$ appbuilder plugin add <pluginid> --debug --release` is adding it to both configurations, so in release config the plugin is added twice.

Remove `getInstalledPluginsEnabledAtLeastInOneConfiguration` and use its logic as default for getInstalledPlugins. This way we always get full list of plugins enabled in all configurations. In case you specify configuration (`--release` for example) `getInstalledPlugins` will give you only the plugins enabled in this configuration.

Fixes http://teampulse.telerik.com/view#item/290735