### PR TITLE
Fix indentation issues in livesync help

### DIFF
--- a/docs/man_pages/project/testing/livesync-android.md
+++ b/docs/man_pages/project/testing/livesync-android.md
@@ -21,7 +21,7 @@ WARNING: This command is applicable only to the NativeScript companion app. Make
 
 ### Options
 * `--watch` - If set, when you save changes to the project, changes are automatically synchronized to the connected device.
-* `--device` - Specifies the serial number or the index of the connected device to which you want to synchronize changes. To list all connected devices, grouped by platform, run `$ appbuilder device`    
+* `--device` - Specifies the serial number or the index of the connected device to which you want to synchronize changes. To list all connected devices, grouped by platform, run `$ appbuilder device`
 * `--companion` - If set, when you save changes to the project, changes are automatically synchronized to the companion app. <% if(isNativeScript) { %>This switch is mandatory for NativeScript projects.<% } %>
 <% } %>
 <% if(isHtml) { %>

--- a/docs/man_pages/project/testing/livesync-cloud.md
+++ b/docs/man_pages/project/testing/livesync-cloud.md
@@ -8,8 +8,7 @@ General | `$ appbuilder livesync cloud`
 Synchronizes the project with the cloud to enable LiveSync via wireless connection (using the three-finger tap and hold gesture). <% if(isHtml) { %>You can also control LiveSync with the three-finger tap and hold gesture programmatically. For more information, see [Enable or Disable LiveSync Programmatically](http://docs.telerik.com/platform/appbuilder/testing-your-app/livesync/configuring-livesync/configure-livesync-programmatically) and [LiveSync Changes Programmatically](http://docs.telerik.com/platform/appbuilder/testing-your-app/livesync/livesync-programmatically).<% } %> 
 
 <% if((isConsole && (isNativeScript || isCordova)) || isHtml) { %>
-To get the latest changes on device, tap and hold with three fingers on the device screen until the download pop-up
-appears. When the download completes, the app refreshes automatically.
+To get the latest changes on device, tap and hold with three fingers on the device screen until the download pop-up appears. When the download completes, the app refreshes automatically.
 <% } %>
 <% if(isConsole) { %>
 <% if(isNativeScript) { %>

--- a/docs/man_pages/project/testing/livesync-ios.md
+++ b/docs/man_pages/project/testing/livesync-ios.md
@@ -22,8 +22,8 @@ WARNING: This command is not applicable to NativeScript projects. To view the co
 
 ### Options
 * `--watch` - If set, when you save changes to the project, changes are automatically synchronized to the connected device.
-* `--device` - Specifies the serial number or the index of the connected device to which you want to synchronize changes. To list all connected devices, grouped by platform, run `$ appbuilder device`    
->* `--companion` - If set, when you save changes to the project, changes are automatically synchronized to the companion app.
+* `--device` - Specifies the serial number or the index of the connected device to which you want to synchronize changes. To list all connected devices, grouped by platform, run `$ appbuilder device`
+* `--companion` - If set, when you save changes to the project, changes are automatically synchronized to the companion app.
 <% } %>
 <% if(isHtml) { %> 
 ### Command Limitations


### PR DESCRIPTION
Fix some spaces and additional symbols in livesync help, which are causing incorrect rendering of the content.