### PR TITLE
Prevent doubling of typescript definitions

### DIFF
--- a/lib/hooks/typescript-compilation.ts
+++ b/lib/hooks/typescript-compilation.ts
@@ -14,10 +14,9 @@ fiberBootstrap.run(() => {
 
 	var typeScriptFiles = _.filter(projectFiles, file => path.extname(file) === ".ts");
 	var definitionFiles = _.filter(typeScriptFiles, file => _.endsWith(file, ".d.ts"));
-
 	if(typeScriptFiles.length > definitionFiles.length) { // We need this check because some of non-typescript templates(for example KendoUI.Strip) contain typescript definition files
 		var typeScriptCompilationService = $injector.resolve("typeScriptCompilationService");
-		typeScriptCompilationService.initialize(typeScriptFiles);
+		typeScriptCompilationService.initialize(typeScriptFiles, definitionFiles);
 		typeScriptCompilationService.compileAllFiles().wait();
 	}
 });


### PR DESCRIPTION
CLI has its own typescript definition files, which are used when we build typescript projects. Make sure to exclude them in case the project directory already has files with such name. This is the scenario with NativeScript TypeScript projects, which have android17.d.ts files in the templates and we are adding them again on build.

Fixes http://teampulse.telerik.com/view#item/290964
