### PR TITLE
Change iOS build message

### DIFF
--- a/lib/services/build.ts
+++ b/lib/services/build.ts
@@ -310,7 +310,7 @@ export class BuildService implements Project.IBuildService {
 			var packageDefs = buildResult.packageDefs;
 
 			if((buildResult.provisionType === constants.ProvisionType.Development || buildResult.provisionType === constants.ProvisionType.AppStore) && !settings.downloadFiles && !settings.buildForTAM) {
-				this.$logger.info("Package built with 'Development' provision type. Downloading package, instead of generating QR code.");
+				this.$logger.info("Package built with '%s' provision type. Downloading package, instead of generating QR code.", buildResult.provisionType);
 				this.$logger.info("Deploy manually to your device using iTunes.");
 				settings.showQrCodes = false;
 				settings.downloadFiles = true;


### PR DESCRIPTION
Replace the static 'Development'
with the actual provision type used for the build
Fixes http://teampulse.telerik.com/view#item/291106