### PR TITLE
Fail android build if iOS certificate is used

### DIFF
--- a/lib/definitions/cryptographic-identities.d.ts
+++ b/lib/definitions/cryptographic-identities.d.ts
@@ -17,7 +17,7 @@ interface IProvision {
 interface ICryptographicIdentity {
 	Alias: string;
 	Attributes: string[];
-	Type: string;
+	isiOS: boolean;
 	Certificate: string;
 }
 

--- a/lib/services/build.ts
+++ b/lib/services/build.ts
@@ -137,6 +137,10 @@ export class BuildService implements Project.IBuildService {
 				}
 
 				if(certificateData) {
+					if (certificateData.isiOS) {
+						this.$errors.failWithoutHelp("The certificate you have chosen is ineligible for the Android platform.");
+					}
+
 					buildProperties.AndroidCodesigningIdentity = certificateData.Alias;
 					this.$logger.info("Using certificate '%s'", certificateData.Alias);
 				} else {


### PR DESCRIPTION
In theory it is possible to build an android application
with a certificate issued by Apple Inc. however such apps
cannot actually be installed on Android devices.
Fixes http://teampulse.telerik.com/view#item/291032