### PR TITLE
Stop execution of sample commands for on-prem deploy

### DIFF
--- a/lib/commands/samples.ts
+++ b/lib/commands/samples.ts
@@ -6,22 +6,33 @@ var options: any = require("../common/options");
 
 export class PrintSamplesCommand implements ICommand {
 	constructor(private $samplesService: ISamplesService,
-		private frameworkIdentifier: string) { }
+		private frameworkIdentifier: string,
+		private $config: IConfiguration) { }
 
 	execute(args: string[]): IFuture<void> {
 		return this.$samplesService.printSamplesInformation(this.frameworkIdentifier);
 	}
 
+	get isDisabled() {
+		return this.$config.ON_PREM;
+	}
+
 	allowedParameters: ICommandParameter[] = []
 }
-$injector.registerCommand("sample|*list", $injector.resolve(PrintSamplesCommand, {frameworkIdentifier: "" }));
+$injector.registerCommand("sample|*list", $injector.resolve(PrintSamplesCommand, {frameworkIdentifier: ""}));
 
 export class CloneSampleCommand implements ICommand {
 	constructor(private $samplesService: ISamplesService,
 		private $fs: IFileSystem,
-		private $errors: IErrors) { }
+		private $errors: IErrors,
+		private $config: IConfiguration) { }
+
 	execute(args: string[]): IFuture<void> {
 		return this.$samplesService.cloneSample(args[0]);
+	}
+
+	get isDisabled() {
+		return this.$config.ON_PREM;
 	}
 
 	allowedParameters: ICommandParameter[] = [new CloneCommandParameter(this.$samplesService, this.$fs, this.$errors)]

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -10,10 +10,11 @@ import configBaseLib = require("./common/config-base");
 export class Configuration extends configBaseLib.ConfigBase implements IConfiguration { // User specific config
 	AB_SERVER_PROTO: string;
 	AB_SERVER: string;
-	DEBUG :boolean;
+	DEBUG: boolean;
 	USE_PROXY: boolean;
 	PROXY_HOSTNAME: string;
 	PROXY_PORT: number;
+	ON_PREM: boolean;
 	DEFAULT_CORDOVA_PROJECT_TEMPLATE: string;
 	DEFAULT_NATIVESCRIPT_PROJECT_TEMPLATE: string;
 	DEFAULT_WEBSITE_PROJECT_TEMPLATE: string;
@@ -75,6 +76,7 @@ export class Configuration extends configBaseLib.ConfigBase implements IConfigur
 	private mergeConfig(config: IConfiguration, mergeFrom: IConfiguration): void {
 		_.extend(config, mergeFrom);
 	}
+
 }
 $injector.register("config", Configuration);
 


### PR DESCRIPTION
Stop execution of sample command and its subcommands for on-premise deployments

Fix unit tests which breaks newly added ones

Introduce ON_PREM configuration setting
Introduce ICommand.isEnabled property with semantics:
 - when explicitly false, do not execute command
 - when true or undefined, execute it

See http://teampulse.telerik.com/view#item/288143