### PR TITLE
Improve update-kendoui command

### DIFF
--- a/docs/man_pages/lib-management/update-kendoui.md
+++ b/docs/man_pages/lib-management/update-kendoui.md
@@ -3,7 +3,7 @@ update-kendoui
 
 Usage | Synopsis
 ------|-------
-General | `$ appbuilder update-kendoui`
+General | `$ appbuilder update-kendoui [--verified] [--core] [--professional] [--latest]`
 
 Lists officially supported Kendo UI Core and Kendo UI Professional versions and downloads and extracts the selected package in the project directory.<% if(isHtml || isCordova) { %> The verified tag marks stable Kendo UI Service Pack releases.<% } %> 
 <% if(isConsole) { %>
@@ -14,6 +14,13 @@ WARNING: This command is not applicable to mobile website projects. To view the 
 WARNING: This command is not applicable to NativeScript projects. To view the complete help for this command, run `$ appbuilder help update-kendoui`
 <% } %>
 <% } %>
+### Options
+* `--verified` - Lists version marked with verified tag.
+* `--core` - Lists Kendo UI Core versions. When combined with `--verified` option, lists only Kendo UI Core verified versions.
+* `--professional` - Lists Kendo UI Professional versions. When combined with `--verified` option, lists only Kendo UI Professional verified versions.
+* `--latest` - Installs the latest available version without prompt for selection. This option can be combined with all other options. For example `$ appbuilder update-kendoui --latest --verified --core` will install latest available verified version of Kendo UI Core.
+
+> NOTE: `--core` and `--professional` options cannot be used simultaneously.
 <% if(isHtml) { %> 
 ### Command Limitations
 

--- a/lib/commands/update-kendoui.ts
+++ b/lib/commands/update-kendoui.ts
@@ -2,9 +2,14 @@
 "use strict";
 import temp = require("temp");
 import path = require("path");
+import options = require("../common/options");
 var Table = require("cli-table");
 
 class UpdateKendoUICommand implements ICommand {
+	private static VERIFIED_TAG = "verified";
+	private static KENDO_CORE = "Kendo UI Core";
+	private static KENDO_PROFESSIONAL = "Kendo UI Professional";
+
 	constructor(
 		private $errors: IErrors
 		,private $logger: ILogger
@@ -18,6 +23,20 @@ class UpdateKendoUICommand implements ICommand {
 
 	allowedParameters: ICommandParameter[] = [];
 
+	canExecute(args: string[]): IFuture<boolean> {
+		return ((): boolean => {
+			if(args && args.length > 0) {
+				this.$errors.fail("This command does not accept parameters.");
+			}
+
+			if(options.core && options.professional) {
+				this.$errors.fail("You cannot specify core and professional options simultaneously.");
+			}
+
+			return true;
+		}).future<boolean>()();
+	}
+
 	execute(args: string[]): IFuture<void> {
 		return (() => {
 			this.$loginManager.ensureLoggedIn().wait();
@@ -27,31 +46,30 @@ class UpdateKendoUICommand implements ICommand {
 			}
 
 			var packages: Server.IKendoDownloadablePackageData[] = _.filter(<Server.IKendoDownloadablePackageData[]>this.$server.kendo.getPackages().wait(), p => !p.NeedPurchase);
+			if(options.verified) {
+				packages = _.filter(packages, pack => _.any(pack.VersionTags, tag => tag.toLowerCase() === UpdateKendoUICommand.VERIFIED_TAG));
+			}
 
-			this.$logger.out("You can download and install the following Kendo UI Core or Kendo UI Professional packages.");
-			var table = new Table({
-				head: ["#", "KendoUI", "Version", "Tags"],
-				chars: {'mid': '', 'left-mid': '', 'mid-mid': '', 'right-mid': ''}
-			});
-			_.each(packages, (update: Server.IKendoDownloadablePackageData, idx: number) => table.push([
-					(idx + 1).toString().cyan.toString(),
-					update.Name,
-					update.Version,
-					(update.VersionTags || []).join(", ").cyan.toString()
-				]));
-			this.$logger.out(table.toString());
+			if(options.core) {
+				packages = _.filter(packages, pack => pack.Name === UpdateKendoUICommand.KENDO_CORE);
+			}
 
-			var schema : IPromptSchema = {
-				type: "input",
-				name: "packageIdx",
-				message: "Enter the index of the package that you want to install",
-				validate: (value: string) => {
-					var num = parseInt(value, 10);
-					return !isNaN(num) && num >= 1 && num <= packages.length ? true : "Valid values are between 1 and " + packages.length;
+			if(options.professional) {
+				packages = _.filter(packages, pack => pack.Name === UpdateKendoUICommand.KENDO_PROFESSIONAL);
+			}
+
+			var downloadUri: string;
+			if(options.latest) {
+				var latestPackage = _.first(packages);
+				var sameDateItems = _.filter(packages, pack => pack.Version === latestPackage.Version);
+				if(sameDateItems.length > 1) {
+					downloadUri = this.selectKendoVersion(sameDateItems).wait();
+				} else {
+					downloadUri = latestPackage.DownloadUrl;
 				}
-			};
-
-			var choice = this.$prompter.get([schema]).wait();
+			} else {
+				downloadUri = this.selectKendoVersion(packages).wait();
+			}
 
 			var confirm = this.$prompter.confirm(
 				"This operation will overwrite existing Kendo UI framework files and " +
@@ -62,11 +80,48 @@ class UpdateKendoUICommand implements ICommand {
 				return;
 			}
 
-			var packageIdx = parseInt(choice.packageIdx, 10)-1;
-			var downloadUri = packages[packageIdx].DownloadUrl;
 			this.updateKendoFiles(downloadUri).wait();
 
 		}).future<void>()();
+	}
+
+	private selectKendoVersion(packages: Server.IKendoDownloadablePackageData[]): IFuture<string> {
+		return ((): string => {
+			this.showAvailableVersions(packages);
+			var schema: IPromptSchema = {
+				type: "input",
+				name: "packageIdx",
+				message: "Enter the index of the package that you want to install",
+				validate: (value: string) => {
+					var num = parseInt(value, 10);
+					return !isNaN(num) && num >= 1 && num <= packages.length ? true : "Valid values are between 1 and " + packages.length;
+				}
+			};
+
+			var choice = this.$prompter.get([schema]).wait();
+			var packageIdx = parseInt(choice.packageIdx, 10) - 1;
+			var selectedPackage = packages[packageIdx];
+			this.$logger.trace("Selected package is:");
+			this.$logger.trace(selectedPackage);
+			return selectedPackage.DownloadUrl;
+		}).future<string>()();
+	}
+
+	private showAvailableVersions(packages: Server.IKendoDownloadablePackageData[]): void {
+		this.$logger.out("You can download and install the following Kendo UI packages.");
+		var table = new Table({
+			head: ["#", "KendoUI", "Version", "Tags"],
+			chars: { 'mid': '', 'left-mid': '', 'mid-mid': '', 'right-mid': '' }
+		});
+
+		_.each(packages,(update: Server.IKendoDownloadablePackageData, idx: number) => table.push([
+			(idx + 1).toString().cyan.toString(),
+			update.Name,
+			update.Version,
+			(update.VersionTags || []).join(", ").cyan.toString()
+		]));
+
+		this.$logger.out(table.toString());
 	}
 
 	private updateKendoFiles(downloadUri: string): IFuture<void> {
@@ -81,7 +136,7 @@ class UpdateKendoUICommand implements ICommand {
 
 			var outDir = path.join(this.$project.getProjectDir().wait(), "kendo");
 			this.$fs.unzip(filepath, outDir).wait();
-
+			this.$logger.info("Successfully updated Kendo package.");
 		}).future<void>()();
 	}
 }

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -25,7 +25,11 @@ var knownOpts: any = {
 		"debug": Boolean,
 		"valid-value": Boolean,
 		"screenBuilderCacheDir": String,
-		"force": Boolean
+		"force": Boolean,
+		"verified": Boolean,
+		"core": Boolean,
+		"professional": Boolean,
+		"latest": Boolean
 	},
 	shorthands: IStringDictionary = {
 		"t": "template",


### PR DESCRIPTION
Improve update-kendoui command to accept several -- options:
* `--verified` - lists verified plugins
* `--core` - lists core plugins
* `--professional` - lists professional plugins

They can be combined, but core and professional cannot be used simultaneously. For example `$ appbuilder update-kendoui --core --verified` will list only verified core plugins.

Add `--latest` option. If it is specified, the user will not be prompted to select version, but the latest available version will be installed. This option can be combined with the other options. for example:
* `$ appbuilder update-kendoui --verified --latest` will install latest available verified version
* `$ appbuilder update-kendoui --verified --core --latest` will install latest available verified core version

http://teampulse.telerik.com/view#item/288592
http://teampulse.telerik.com/view#item/284131