### PR TITLE
Fix error when printing errorMessage from json schemas

### DIFF
--- a/lib/json-schema/json-schema-validator.ts
+++ b/lib/json-schema/json-schema-validator.ts
@@ -143,10 +143,12 @@ export class JsonSchemaValidator implements IJsonSchemaValidator {
 				error.details = util.format("Expected %s but got %s", error.details, data[propertyName]);
 			}
 
-			var errorMessage =  util.format("Property %s: %s. %s", propertyName, error.message, error.details);
+			var errorMessage = util.format("Property %s: %s. %s", propertyName, error.message, error.details);
 			this.$logger.trace("JSV error: %s", errorMessage);
 
-			result[propertyName] = (opts.usePredefinedErrors === false ? undefined : JsonSchemaValidator.PREDEFINED_ERRORS[propertyName]) || this.tryResolveValidationSchemaCore(undefined, opts.validationSchemaName).properties[propertyName].errorMessage || errorMessage;
+			var property = this.tryResolveValidationSchemaCore(undefined, opts.validationSchemaName).properties[propertyName];
+			result[propertyName] = (opts.usePredefinedErrors === false ? undefined :
+				JsonSchemaValidator.PREDEFINED_ERRORS[propertyName]) || (property ? property.errorMessage : errorMessage);
 		});
 
 		return result;


### PR DESCRIPTION
When trying to show error from JsonSchemas and the property is not part of Base schema, an error is raised (Cannot read property 'errorMessage' of undefined).
Add check if the property is part of the schema.

Fixes http://teampulse.telerik.com/view#item/290863