### PR TITLE
Fix update-kendoui --professional --latest

### DIFF
--- a/lib/commands/update-kendoui.ts
+++ b/lib/commands/update-kendoui.ts
@@ -58,6 +58,14 @@ class UpdateKendoUICommand implements ICommand {
 				packages = _.filter(packages, pack => pack.Name === UpdateKendoUICommand.KENDO_PROFESSIONAL);
 			}
 
+			if(packages.length === 0) {
+				let message = "Cannot find Kendo UI packages that match the provided parameters.";
+				if(options.professional) {
+					message += " Verify that your subscription plan provides 'Kendo UI Professional'.";
+				}
+				this.$errors.failWithoutHelp(message);
+			}
+
 			let downloadUri: string;
 			if(options.latest) {
 				let latestPackage = _.first(packages);


### PR DESCRIPTION
When user cannot use professional versions and tries to execute `appbuilder update-kendoui --professional --latest` leads to `Cannot read property 'DownloadUrl' of undefined`
The problem is that packages collection that we are using becomes empty and we are trying to get the first item of it (undefined), so it does not have DownloadUrl property.
Prevent this case by checking the length of packages collection and show correct error message in case --professional is specified.

Fixes http://teampulse.telerik.com/view#item/291742