### PR TITLE
Fix upload of nativescript projects to appmanager

### DIFF
--- a/lib/services/appmanager-service.ts
+++ b/lib/services/appmanager-service.ts
@@ -19,10 +19,10 @@ class AppManagerService implements IAppManagerService {
 		private $loginManager: ILoginManager,
 		private $opener: IOpener,
 		private $buildService: Project.IBuildService,
-		private $pluginsService: IPluginsService,
 		private $progressIndicator: IProgressIndicator,
 		private $mobileHelper: Mobile.IMobileHelper,
-		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) { }
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
+		private $injector: IInjector) { }
 
 	upload(platform: string): IFuture<void> {
 		return (() => {
@@ -90,10 +90,11 @@ class AppManagerService implements IAppManagerService {
 
 	private configureLivePatchPlugin(): IFuture<void> {
 		return (() => {
-			var plugins = this.$pluginsService.getInstalledPlugins();
-			if(!_.any(plugins, plugin => plugin.data.Identifier === AppManagerService.LIVEPATCH_PLUGIN_ID)) {
+			var $pluginsService: IPluginsService = this.$injector.resolve("pluginsService");
+			var plugins = $pluginsService.getInstalledPlugins();
+			if(!_.any(plugins, plugin => plugin && plugin.data && plugin.data.Identifier === AppManagerService.LIVEPATCH_PLUGIN_ID)) {
 				this.$logger.warn("The AppManager LiveSync plugin is not enabled for your project. Enabling it now for the release build configuration...");
-				this.$pluginsService.addPlugin(AppManagerService.LIVEPATCH_PLUGIN_ID).wait();
+				$pluginsService.addPlugin(AppManagerService.LIVEPATCH_PLUGIN_ID).wait();
 				this.$logger.info("AppManager LiveSync is now enabled for the release build configuration.");
 			}
 		}).future<void>()();

--- a/lib/services/appmanager-service.ts
+++ b/lib/services/appmanager-service.ts
@@ -3,9 +3,8 @@
 
 import constants = require("../common/mobile/constants");
 import util = require("util");
-import options = require("../options");
 import os = require("os");
-import commonOptions = require("../common/options");
+import options = require("../common/options");
 
 class AppManagerService implements IAppManagerService {
 	private static LIVEPATCH_PLUGIN_ID = "com.telerik.LivePatch";
@@ -71,8 +70,8 @@ class AppManagerService implements IAppManagerService {
 			this.$loginManager.ensureLoggedIn().wait();
 
 			platforms = _.map(platforms, platform => this.$mobileHelper.normalizePlatformName(platform));
-			var cachedOptionsRelease = commonOptions.release;
-			commonOptions.release = true;
+			var cachedOptionsRelease = options.release;
+			options.release = true;
 			this.configureLivePatchPlugin().wait();
 
 			this.$logger.warn("If you have not published an AppManager LiveSync-enabled version of this app before, you will not be able to distribute an AppManager LiveSync update for it.");
@@ -82,7 +81,7 @@ class AppManagerService implements IAppManagerService {
 			this.$logger.printInfoMessageOnSameLine("Publishing patch for " + platforms.join(", ") + "...");
 			this.$progressIndicator.showProgressIndicator(this.$server.tam.uploadPatch(this.$project.projectData.ProjectName, this.$project.projectData.ProjectName, <any>{ Platforms: platforms }), 2000).wait();
 			this.$logger.printInfoMessageOnSameLine(os.EOL);
-			commonOptions.release = cachedOptionsRelease;
+			options.release = cachedOptionsRelease;
 
 			this.openAppManagerStore();
 		}).future<void>()();
@@ -90,6 +89,7 @@ class AppManagerService implements IAppManagerService {
 
 	private configureLivePatchPlugin(): IFuture<void> {
 		return (() => {
+			// Resolve pluginsService here as in its constructor it fails when project is not Cordova.
 			var $pluginsService: IPluginsService = this.$injector.resolve("pluginsService");
 			var plugins = $pluginsService.getInstalledPlugins();
 			if(!_.any(plugins, plugin => plugin && plugin.data && plugin.data.Identifier === AppManagerService.LIVEPATCH_PLUGIN_ID)) {


### PR DESCRIPTION
Fix upload of nativescript projects to appmanager. The issue is raised from resolving `pluginsService` in the constructor of AppmanagerService. PluginsService constructor is failing when the project is **NOT** Cordova.
Use injector to resolve pluginsService only where it is required.
Fix error when plugin is enabled manually in configuration, but we are unable to find it in marketplace (for example manually add com.telerik.LivePatch in release config and try $ appbuilder appmanager livesync android with user who does not have access to this feature. You'll receive error **Cannot read property data of undefined**

Fixes http://teampulse.telerik.com/view#item/291755