### PR TITLE
Fix no error when invalid plugin installed

### DIFF
--- a/lib/services/plugins-service.ts
+++ b/lib/services/plugins-service.ts
@@ -56,7 +56,17 @@ export class PluginsService implements IPluginsService {
 			corePlugins = <string[]>_.union(this.$project.getProperty(PluginsService.CORE_PLUGINS_PROPERTY_NAME, this.$projectConstants.DEBUG_CONFIGURATION_NAME), this.$project.getProperty(PluginsService.CORE_PLUGINS_PROPERTY_NAME, this.$projectConstants.RELEASE_CONFIGURATION_NAME));
 		}
 
-		return _.map(corePlugins,(pluginIdentifier: string) => this.identifierToPlugin[pluginIdentifier]);
+		return _.map(corePlugins, pluginIdentifier => {
+			let plugin = this.identifierToPlugin[pluginIdentifier];
+			if (!plugin) {
+				let failMessage = config ?
+					`You have enabled an invalid plugin: ${pluginIdentifier} for the ${config} build configuration. Check your .${config}.abproject file in the project root and correct or remove the invalid plugin entry.` :
+					`You have enabled an invalid plugin: ${pluginIdentifier}. Check your ${this.$projectConstants.DEBUG_PROJECT_FILE_NAME} and ${this.$projectConstants.RELEASE_PROJECT_FILE_NAME} files in the project root and correct or remove the invalid plugin entry.`;
+				this.$errors.failWithoutHelp(failMessage);
+			}
+
+			return plugin;
+		});
 	}
 
 	public getAvailablePlugins(): IPlugin[] {

--- a/test/plugins-service.ts
+++ b/test/plugins-service.ts
@@ -375,6 +375,19 @@ describe("plugins-service", () => {
 
 		assert.equal(3, service.getInstalledPlugins().length);
 	});
+	it("throw if installed plugin is not available", () => {
+		let installedMarketplacePlugins = [{
+				Identifier: "com.telerik.Invalid",
+				Name: "Stripe",
+				Version: "1.0.4"
+			}
+		];
+
+		let testInjector = createTestInjector([], installedMarketplacePlugins, []);
+
+		let service: IPluginsService = testInjector.resolve(pluginsService.PluginsService);
+		assert.throws(() => service.getInstalledPlugins());
+	});
 	it("does not fail if data for one of the plugins cannot be fetched", () => {
 		let cordovaPlugins = [
 			{


### PR DESCRIPTION
If an invalid plugin is installed in either build configuration (regardless whether the users just modified the file themselves or something just went wrong) an error should be thrown indicating that this plugin is not eligible
Fixes http://teampulse.telerik.com/view#item/291777