### PR TITLE
Allow modification of CorePlugins in configuration specific files

### DIFF
--- a/lib/commands/prop/prop-print.ts
+++ b/lib/commands/prop/prop-print.ts
@@ -14,7 +14,16 @@ export class PrintProjectCommand extends projectPropertyCommandBaseLib.ProjectPr
 	}
 
 	execute(args:string[]): IFuture<void> {
-		return	this.$project.printProjectProperty(args[0]);
+		return ((): void => {
+			let configs = this.$project.getConfigurationsSpecifiedByUser();
+			if(configs.length) {
+				_.each(configs, config => {
+					this.$project.printProjectProperty(args[0], config).wait();
+				})
+			} else {
+				this.$project.printProjectProperty(args[0]).wait();
+			}
+		}).future<void>()();
 	}
 
 	allowedParameters:ICommandParameter[] = [new PrintProjectCommandParameter(this.$project)];

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -199,10 +199,20 @@ interface IProjectData extends IDictionary<any> {
 interface IProjectPropertiesService {
 	getProjectProperties(projectFile: string, isJsonProjectFile: boolean, frameworkProject: Project.IFrameworkProject): IFuture<IProjectData>;
 	completeProjectProperties(properties: any, frameworkProject: Project.IFrameworkProject): boolean;
-	updateProjectProperty(projectData: any, mode: string, property: string, newValue: any): IFuture<void>;
+	updateProjectProperty(projectData: any, configurationSpecificData: IProjectData, mode: string, property: string, newValue: any): IFuture<void>;
 	normalizePropertyName(property: string, projectData: IProjectData): string;
 	getValidValuesForProperty(propData: any): IFuture<string[]>;
 	getPropertiesForAllSupportedProjects(): IFuture<string>;
+	/**
+	 * Removes property from the project and validates the result data.  If it is configuration specific (commonly written in .debug.abproject or .release.abproject) 
+	 * you have to pass the projectData as last parameter of the method.
+	 * @param {IProjectData} dataToBeUpdated The data from which to remove the property.
+	 * @param {string} propertyName The name of the property that should be removed from the data. 
+	 * @param {IProjectData} projectData Optional parameter. The project data, commonly written in .abproject. Set this property whenever you want to remove property from configuration specific data.
+	 * @return {IProjectData} Modified data. In case configurationSpecificData exists, returns it, else returns projectData.
+	 * @throws Error when the modified data cannot be validated with the respective JSON schema. In this case the modification is not saved to the file. 
+	 */
+	removeProjectProperty(dataToBeUpdated: IProjectData, property: string, projectData?: IProjectData) : IProjectData;
 }
 
 interface IServerConfigurationData {

--- a/lib/project/project.d.ts
+++ b/lib/project/project.d.ts
@@ -24,7 +24,7 @@ declare module Project {
 		getProjectTargets(): IFuture<string[]>;
 		getConfigFileContent(template: string): IFuture<any>;
 		updateProjectPropertyAndSave(mode: string, propertyName: string, propertyValues: string[]): IFuture<void>;
-		printProjectProperty(property: string): IFuture<void>;
+		printProjectProperty(property: string, configuration?: string): IFuture<void>;
 		setProperty(propertyName: string, value: any, configuration: string): void;
 		validateProjectProperty(property: string, args: string[], mode: string): IFuture<boolean>;
 		adjustBuildProperties(buildProperties: any): any;
@@ -36,6 +36,8 @@ declare module Project {
 		ensureProject(): void;
 		ensureAllPlatformAssets(): IFuture<void>;
 		enumerateProjectFiles(additionalExcludedProjectDirsAndFiles?: string[]): IFuture<string[]>;
+		
+		getConfigurationsSpecifiedByUser(): string[];
 	}
 
 	interface IFrameworkProject {

--- a/test/project.ts
+++ b/test/project.ts
@@ -233,6 +233,7 @@ describe("project integration tests", () => {
 			let projectName = "Test";
 			project = testInjector.resolve("project");
 			project.createNewProject(projectName, projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait();
+			options.debug = options.release = false;
 		});
 
 		it("updates WPSdk to 8.0 when Cordova is downgraded from 3.7.0",() => {
@@ -503,7 +504,7 @@ function getProjectData(): IProjectData {
 
 describe("project unit tests", () => {
 	let projectProperties: IProjectPropertiesService, testInjector: IInjector;
-
+	let configSpecificData: any;
 	beforeEach(() => {
 		testInjector = createTestInjector();
 		testInjector.register("fs", fslib.FileSystem);
@@ -514,6 +515,7 @@ describe("project unit tests", () => {
 		let staticConfig = testInjector.resolve("staticConfig");
 		staticConfig.PROJECT_FILE_NAME = "";
 		config.AUTO_UPGRADE_PROJECT_FILE = false;
+		configSpecificData = undefined;
 		projectProperties = testInjector.resolve(projectPropertiesLib.ProjectPropertiesService);
 	});
 
@@ -521,107 +523,159 @@ describe("project unit tests", () => {
 		it("sets unconstrained string property", () => {
 			let projectData = getProjectData();
 			projectData.DisplayName = "wrong";
-			projectProperties.updateProjectProperty(projectData, "set", "DisplayName", ["fine"]).wait();
+			projectProperties.updateProjectProperty(projectData, configSpecificData, "set", "DisplayName", ["fine"]).wait();
 			assert.equal("fine", projectData.DisplayName);
 		});
 
 		it("sets string property with custom validator", () => {
 			let projectData = getProjectData();
 			projectData.ProjectName = "wrong";
-			projectProperties.updateProjectProperty(projectData, "set", "ProjectName", ["fine"]).wait();
+			projectProperties.updateProjectProperty(projectData, configSpecificData, "set", "ProjectName", ["fine"]).wait();
 			assert.equal("fine", projectData.ProjectName);
 		});
 
 		it("disallows 'add' on non-flag property", () => {
 			let projectData = getProjectData();
 			projectData.ProjectName = "wrong";
-			assert.throws(() => projectProperties.updateProjectProperty(projectData, "add", "ProjectName", ["fine"]).wait());
+			assert.throws(() => projectProperties.updateProjectProperty(projectData, configSpecificData, "add", "ProjectName", ["fine"]).wait());
 		});
 
 		it("disallows 'del' on non-flag property", () => {
 			let projectData = getProjectData();
 			projectData.ProjectName = "wrong";
-			assert.throws(() => projectProperties.updateProjectProperty(projectData, "del", "ProjectName", ["fine"]).wait());
+			assert.throws(() => projectProperties.updateProjectProperty(projectData, configSpecificData, "del", "ProjectName", ["fine"]).wait());
 		});
 
 		it("sets bundle version when given proper input", () => {
 			let projectData = getProjectData();
 			projectData.BundleVersion = "0";
-			projectProperties.updateProjectProperty(projectData, "set", "BundleVersion", ["10.20.30"]).wait();
+			projectProperties.updateProjectProperty(projectData, configSpecificData, "set", "BundleVersion", ["10.20.30"]).wait();
 			assert.equal("10.20.30", projectData.BundleVersion);
 		});
 
 		it("throws on invalid bundle version string", () => {
 			let projectData = getProjectData();
 			projectData.BundleVersion = "0";
-			assert.throws(() => projectProperties.updateProjectProperty(projectData, "set", "BundleVersion", ["10.20.30c"]).wait());
+			assert.throws(() => projectProperties.updateProjectProperty(projectData, configSpecificData, "set", "BundleVersion", ["10.20.30c"]).wait());
 		});
 
 		it("sets enumerated property", () => {
 			let projectData = getProjectData();
 			projectData.iOSStatusBarStyle = "Default";
-			projectProperties.updateProjectProperty(projectData, "set", "iOSStatusBarStyle", ["Hidden"]).wait();
+			projectProperties.updateProjectProperty(projectData, configSpecificData, "set", "iOSStatusBarStyle", ["Hidden"]).wait();
 			assert.equal("Hidden", projectData.iOSStatusBarStyle);
 		});
 
 		it("disallows unrecognized values for enumerated property", () => {
 			let projectData = getProjectData();
 			projectData.iOSStatusBarStyle = "Default";
-			assert.throws(() => projectProperties.updateProjectProperty(projectData, "set", "iOSStatusBarStyle", ["does not exist"]).wait());
+			assert.throws(() => projectProperties.updateProjectProperty(projectData, configSpecificData, "set", "iOSStatusBarStyle", ["does not exist"]).wait());
 		});
 
 		it("appends to verbatim enumerated collection property", () => {
 			let projectData = getProjectData();
 			projectData.DeviceOrientations = [];
-			projectProperties.updateProjectProperty(projectData, "add", "DeviceOrientations", ["Portrait"]).wait();
+			projectProperties.updateProjectProperty(projectData, configSpecificData, "add", "DeviceOrientations", ["Portrait"]).wait();
 			assert.deepEqual(["Portrait"], projectData.DeviceOrientations);
-			projectProperties.updateProjectProperty(projectData, "add", "DeviceOrientations", ["Landscape"]).wait();
+			projectProperties.updateProjectProperty(projectData, configSpecificData, "add", "DeviceOrientations", ["Landscape"]).wait();
 			assert.deepEqual(["Portrait", "Landscape"], projectData.DeviceOrientations);
 		});
 
 		it("appends to enumerated collection property with shorthand", () => {
 			let projectData = getProjectData();
 			projectData.iOSDeviceFamily = [];
-			projectProperties.updateProjectProperty(projectData, "add", "iOSDeviceFamily", ["1"]).wait();
+			projectProperties.updateProjectProperty(projectData, configSpecificData, "add", "iOSDeviceFamily", ["1"]).wait();
 			assert.deepEqual(["1"], projectData.iOSDeviceFamily);
-			projectProperties.updateProjectProperty(projectData, "add", "iOSDeviceFamily", ["2"]).wait();
+			projectProperties.updateProjectProperty(projectData, configSpecificData, "add", "iOSDeviceFamily", ["2"]).wait();
 			assert.deepEqual(["1", "2"], projectData.iOSDeviceFamily);
 		});
 
 		it("appends multiple values to enumerated collection property", () => {
 			let projectData = getProjectData();
 			projectData.iOSDeviceFamily = [];
-			projectProperties.updateProjectProperty(projectData, "add", "iOSDeviceFamily", ["1", "2"]).wait();
+			projectProperties.updateProjectProperty(projectData, configSpecificData, "add", "iOSDeviceFamily", ["1", "2"]).wait();
 			assert.deepEqual(["1", "2"], projectData.iOSDeviceFamily);
 		});
 
 		it("removes from enumerated collection property", () => {
 			let projectData = getProjectData();
 			projectData.DeviceOrientations = ["Landscape", "Portrait"];
-			projectProperties.updateProjectProperty(projectData, "del", "DeviceOrientations", ["Portrait"]).wait();
+			projectProperties.updateProjectProperty(projectData, configSpecificData, "del", "DeviceOrientations", ["Portrait"]).wait();
 			assert.deepEqual(["Landscape"], projectData.DeviceOrientations);
-			projectProperties.updateProjectProperty(projectData, "del", "DeviceOrientations", ["Portrait"]).wait();
+			projectProperties.updateProjectProperty(projectData, configSpecificData, "del", "DeviceOrientations", ["Portrait"]).wait();
 			assert.deepEqual(["Landscape"], projectData.DeviceOrientations);
 		});
 
 		it("disallows unrecognized values for enumerated collection property", () => {
 			let projectData = getProjectData();
 			projectData.DeviceOrientations = [];
-			assert.throws(() => projectProperties.updateProjectProperty(projectData, "add", "DeviceOrientations", ["Landscape", "bar"]).wait());
+			assert.throws(() => projectProperties.updateProjectProperty(projectData, configSpecificData, "add", "DeviceOrientations", ["Landscape", "bar"]).wait());
 		});
 
 		it("makes case-insensitive comparisons of property name", () => {
 			let projectData = getProjectData();
 			projectData.DeviceOrientations = [];
-			projectProperties.updateProjectProperty(projectData, "add", "deviceorientations", ["Landscape"]).wait();
+			projectProperties.updateProjectProperty(projectData, configSpecificData, "add", "deviceorientations", ["Landscape"]).wait();
 			assert.deepEqual(["Landscape"], projectData.DeviceOrientations);
 		});
 
 		it("makes case-insensitive comparisons of property values", () => {
 			let projectData = getProjectData();
 			projectData.DeviceOrientations = [];
-			projectProperties.updateProjectProperty(projectData, "add", "DeviceOrientations", ["Landscape"]).wait();
+			projectProperties.updateProjectProperty(projectData, configSpecificData, "add", "DeviceOrientations", ["Landscape"]).wait();
 			assert.deepEqual(["Landscape"], projectData.DeviceOrientations);
+		});
+
+		it("adds CorePlugins to configuration specfic data when it is specified", () => {
+			// this is the equivalent of $ appbuilder prop set CorePlugins A B C --debug
+			let projectData = getProjectData();
+			configSpecificData = {
+				"CorePlugins": ["org.apache.cordova.battery-status",
+ 								"org.apache.cordova.camera",
+ 								"org.apache.cordova.contacts"]
+			};
+			
+			projectProperties.updateProjectProperty(projectData, configSpecificData, "add", "CorePlugins", ["org.apache.cordova.file"]).wait();
+			assert.deepEqual([], projectData.CorePlugins);
+			assert.deepEqual({
+				"CorePlugins": ["org.apache.cordova.battery-status",
+ 								"org.apache.cordova.camera",
+ 								"org.apache.cordova.contacts",
+								"org.apache.cordova.file"]
+			}, configSpecificData);
+		});
+		
+		it("removes value from configuration specfic data when CorePlugins are modified in it", () => {
+			// this is the equivalent of $ appbuilder prop remove CorePlugins A B C --debug
+			let projectData = getProjectData();
+			configSpecificData = {
+				"CorePlugins": ["org.apache.cordova.battery-status",
+ 								"org.apache.cordova.camera",
+ 								"org.apache.cordova.contacts"]
+			};
+			projectProperties.updateProjectProperty(projectData, configSpecificData, "del", "CorePlugins", ["org.apache.cordova.contacts"]).wait();
+			assert.deepEqual([], projectData.CorePlugins, "CorePlugins in project data should not be modified.");
+			assert.deepEqual({
+				"CorePlugins": ["org.apache.cordova.battery-status",
+ 								"org.apache.cordova.camera"]
+			}, configSpecificData, "CorePlugins in configuration specific data should be modified.");
+		});
+		
+		it("sets CorePlugins to configuration specfic data when it is specified", () => {
+			// this is the equivalent of $ appbuilder prop set CorePlugins A B C --debug
+			let projectData = getProjectData();
+			configSpecificData = {
+				"CorePlugins": ["org.apache.cordova.battery-status",
+ 								"org.apache.cordova.camera",
+ 								"org.apache.cordova.contacts"]
+			};
+			
+			projectProperties.updateProjectProperty(projectData, configSpecificData, "set", "CorePlugins", ["org.apache.cordova.file", "org.apache.cordova.camera"]).wait();
+			assert.deepEqual([], projectData.CorePlugins);
+			assert.deepEqual({
+				"CorePlugins": ["org.apache.cordova.file",
+ 								"org.apache.cordova.camera"]
+			}, configSpecificData);
 		});
 	});
 });


### PR DESCRIPTION
In case you try `$appbuilder prop set CorePlugins A B C --debug` the value of CorePlugins will be modified in .abproject instead of .debug.abproject file. Fix this behavior by passing configurationSpecificData to updateProjectProperty method and modify it instead of the projectData.
In case user had not specified --debug or --release flag (`$appbuilder prop set CorePlugins A B C`, we will update the .abproject, but when the app is built, this value will be overwritten by the value in the configuration specific file. Add removeProjectProperty method to ProjectPropertiesService, so when user modifies any property in .abproject, the value in the configuration files will be removed. This way the build will use the correct data from .abproject.
Fix printing of properties inside project dir to use configuration specific flag.

The final result of this refactoring should be:
* `appbuilder prop set CorePlugins A B C --debug` - set CorePlugins in .debug.abproject to [ A, B, C]
* `appbuilder prop set CorePlugins A B C` - set CorePlugins in .abproject to [ A, B, C]. Remove CorePlugins from .debug.abproject and .release.abproject.
* `appbuilder prop remove CorePlugins A --debug` - removes A from the value of CorePlugins in .debug.abproject
* `appbuilder prop remove CorePlugins A` - removes A from the value of CorePlugins in .abproject. Removes CorePlugins from .debug.abproject and .release.abproject
* `appbuilder prop add CorePlugins D --debug` - adds D to value of CorePlugins in .debug.abproject
* `appbuilder prop add CorePlugins D` - adds D to value of CorePlugins in .abproject. Remove CorePlugins from .debug.abproject and .release.abproject.

Prop print behavior inside project dir:
* `appbuilder prop print` - prints all values of properties and tables with configuration specific properties
* `appbuilder prop print CorePlugins` - prints the value of property from .abproject. In case it does not exist, print table of the values of the property from debug and release configs
* `appbuilder prop print --debug` - prints the full debug configuration of the project (merge .debug.abproject and .abproject - same as what our build does)
* `appbuilder prop print CorePlugins --debug` -prints the value of CorePlugins property in debug configuration.

Implements http://teampulse.telerik.com/view#item/285810 and http://teampulse.telerik.com/view#item/285700