### PR TITLE
Use access_token for samples

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -6,6 +6,7 @@ import fiber = require("fibers");
 import helpers = require("./helpers");
 import staticConfigBaseLib = require("./common/static-config-base");
 import configBaseLib = require("./common/config-base");
+import osenv = require("osenv");
 
 export class Configuration extends configBaseLib.ConfigBase implements IConfiguration { // User specific config
 	AB_SERVER_PROTO: string;
@@ -81,6 +82,7 @@ export class Configuration extends configBaseLib.ConfigBase implements IConfigur
 $injector.register("config", Configuration);
 
 export class StaticConfig extends staticConfigBaseLib.StaticConfigBase implements IStaticConfig {
+	private static TOKEN_FILENAME = ".abgithub";
 	public PROJECT_FILE_NAME = ".abproject";
 	public CLIENT_NAME = "AppBuilder";
 	public ANALYTICS_API_KEY = "13eaa7db90224aa1861937fc71863ab8";
@@ -95,6 +97,9 @@ export class StaticConfig extends staticConfigBaseLib.StaticConfigBase implement
 	public SYS_REQUIREMENTS_LINK = "http://docs.telerik.com/platform/appbuilder/running-appbuilder/running-the-cli/system-requirements-cli";
 	public SOLUTION_SPACE_NAME = "Private_Build_Folder";
 	public QR_SIZE = 300;
+	public get GITHUB_ACCESS_TOKEN_FILEPATH(): string {
+		return path.join(osenv.home(), StaticConfig.TOKEN_FILENAME);
+	}
 
 	public version = require("../package.json").version;
 

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -230,6 +230,10 @@ interface IConfiguration extends Config.IConfig {
 }
 
 interface IStaticConfig extends Config.IStaticConfig {
+	/**
+	 * The full path to the file, which contains GitHub access token used for GitHub api calls.
+	 */
+	GITHUB_ACCESS_TOKEN_FILEPATH: string;
 	QR_SIZE: number;
 	SOLUTION_SPACE_NAME: string;
 	triggerJsonSchemaValidation: boolean;

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -403,8 +403,12 @@ export class StaticConfig implements IStaticConfig {
 
 	public get HTML_CLI_HELPERS_DIR(): string {
 		return path.join(__dirname, "..", "docs", "helpers");
-		
 	}
+	
+	public get GITHUB_ACCESS_TOKEN_FILEPATH(): string {
+		let tokenFileName = ".abgithub";
+		return tokenFileName;
+	} 
 }
 
 export class HooksService implements IHooksService {


### PR DESCRIPTION
When we call api.github.com, there are some limitations. In order to bypass them, we have to pass access token to the call. Take it from ~/.abgithub file and add it to our "samples" calls.
More info here http://teampulse.telerik.com/view#item/291726