### PR TITLE
Allow migration of NativeScript projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ npm-debug.log
 node_modules
 resources/App_Resources
 resources/Cordova
+resources/NativeScript
 resources/ItemTemplates
 resources/ProjectTemplates
 resources/json-schemas

--- a/docs/man_pages/project/configuration/mobileframework-set.md
+++ b/docs/man_pages/project/configuration/mobileframework-set.md
@@ -5,17 +5,16 @@ Usage | Synopsis
 ------|-------
 General | `$ appbuilder mobileframework set <Version> [--path <Directory>]`
 
-Sets the selected Apache Cordova version for the project and updates the enabled core or integrated plugins to match it.
+<% if(isHtml) { %>Sets the selected framework version for the project.<% } %>
 
 <% if(isConsole)  { %>
-<% if(isNativeScript)  { %>
-WARNING: This command is not applicable to NativeScript projects. To view the complete help for this command, run `$ appbuilder help mobileframework set`
-<% } %>
+<% if(isCordova) { %>Sets the selected Apache Cordova version for the project and updates the enabled core or integrated plugins to match it.<% } %>
+<% if(isNativeScript)  { %>Sets the selected NativeScript version for the project.<% } %>
 <% if(isMobileWebsite)  { %>
 WARNING: This command is not applicable to mobile website projects. To view the complete help for this command, run `$ appbuilder help mobileframework set`
 <% } %>
 <% } %>
-<% if((isConsole && isCordova) || isHtml) { %>
+<% if((isConsole && (isCordova || isNativeScript)) || isHtml) { %>
 ### Options
 * `--path` - Specifies the directory that contains the project. If not specified, the project is searched for in the current directory and all directories above it.
 
@@ -25,7 +24,6 @@ WARNING: This command is not applicable to mobile website projects. To view the 
 <% if(isHtml) { %> 
 ### Command Limitations
 
-* You cannot run this command on NativeScript projects.
 * You cannot run this command on mobile website projects.
 
 ### Related Commands

--- a/docs/man_pages/project/configuration/mobileframework.md
+++ b/docs/man_pages/project/configuration/mobileframework.md
@@ -5,29 +5,23 @@ Usage | Synopsis
 ------|-------
 General | `$ appbuilder mobileframework [<Command>] [--path <Directory>]`
 
-Lists all supported versions of Apache Cordova.
+<% if(isHtml) { %>Lists all supported versions of the framework.<% } %>
 
-<% if(isConsole) { %>
-<% if(isNativeScript)  { %>
-WARNING: This command and its extended commands are not applicable to NativeScript projects. To view the complete help for this command, run `$ appbuilder help mobileframework`
-<% } %>
-<% if(isMobileWebsite)  { %>
+<% if(isConsole && isMobileWebsite) { %>
 WARNING: This command and its extended commands are not applicable to mobile website projects. To view the complete help for this command, run `$ appbuilder help mobileframework`
 <% } %>
-<% } %>
-<% if((isConsole && isCordova) || isHtml) { %>
+<% if((isConsole && (isCordova || isNativeScript)) || isHtml) { %>
 ### Options
 * `--path` - Specifies the directory that contains the project. If not specified, the project is searched for in the current directory and all directories above it.
 
 ### Attributes
 
 `<Command>` extends the `mobileframework` command. You can set the following values for this attribute.
-* `set` - Sets the selected framework version for the project and updates the plugins according to the new version.
+* `set` -Sets the selected framework version for the project.
 <% } %>
 <% if(isHtml) { %> 
 ### Command Limitations
 
-* You cannot run this command on NativeScript projects.
 * You cannot run this command on mobile website projects.
 
 ### Related Commands

--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -24,6 +24,7 @@ $injector.require("marketplacePluginsService", "./services/marketplace-plugins-s
 $injector.require("pluginsService", "./services/plugins-service");
 
 $injector.require("cordovaMigrationService", "./services/cordova-migration-service");
+$injector.require("nativeScriptMigrationService", "./services/nativescript-migration-service");
 $injector.require("samplesService", "./services/samples-service");
 $injector.requireCommand("sample|*list", "./commands/samples");
 $injector.requireCommand("sample|clone", "./commands/samples");

--- a/lib/commands/dev/prepackage.ts
+++ b/lib/commands/dev/prepackage.ts
@@ -4,12 +4,13 @@
 import Future = require("fibers/future");
 
 export class PrePackageCommand implements ICommand {
-	constructor(private $cordovaMigrationService: ICordovaMigrationService,
+	constructor(private $cordovaMigrationService: IFrameworkMigrationService,
 		private $jsonSchemaLoader: IJsonSchemaLoader,
 		private $logger: ILogger,
 		private $resourceDownloader: IResourceDownloader,
 		private $serviceProxy: Server.IServiceProxy,
-		private $templatesService: ITemplatesService) { }
+		private $templatesService: ITemplatesService,
+		private $nativeScriptMigrationService: IFrameworkMigrationService) { }
 
 	public disableAnalytics = true;
 
@@ -28,11 +29,12 @@ export class PrePackageCommand implements ICommand {
 			this.$logger.info("Unpacking app resources.");
 			this.$templatesService.unpackAppResources().wait();
 			this.$logger.info("Downloading cordova migration data.");
-			this.$cordovaMigrationService.downloadCordovaMigrationData().wait();
-			//Cordova files have to be downloaded after cordova migration data so we know which cordova versions we support
+			this.$cordovaMigrationService.downloadMigrationData().wait();
+			// Cordova files have to be downloaded after cordova migration data so we know which cordova versions we support
 			this.$logger.info("Downloading cordova.js files.");
 			this.$resourceDownloader.downloadCordovaJsFiles().wait();
-
+			this.$logger.info("Downloading nativescript migration data.")
+			this.$nativeScriptMigrationService.downloadMigrationData().wait();
 			this.$serviceProxy.setShouldAuthenticate(true);
 		}).future<void>()();
 	}

--- a/lib/commands/dev/prepackage.ts
+++ b/lib/commands/dev/prepackage.ts
@@ -28,12 +28,12 @@ export class PrePackageCommand implements ICommand {
 			this.$jsonSchemaLoader.downloadSchemas().wait();
 			this.$logger.info("Unpacking app resources.");
 			this.$templatesService.unpackAppResources().wait();
-			this.$logger.info("Downloading cordova migration data.");
+			this.$logger.info("Downloading Cordova migration data.");
 			this.$cordovaMigrationService.downloadMigrationData().wait();
 			// Cordova files have to be downloaded after cordova migration data so we know which cordova versions we support
 			this.$logger.info("Downloading cordova.js files.");
 			this.$resourceDownloader.downloadCordovaJsFiles().wait();
-			this.$logger.info("Downloading nativescript migration data.")
+			this.$logger.info("Downloading NativeScript migration data.")
 			this.$nativeScriptMigrationService.downloadMigrationData().wait();
 			this.$serviceProxy.setShouldAuthenticate(true);
 		}).future<void>()();

--- a/lib/commands/framework-versions/print-versions.ts
+++ b/lib/commands/framework-versions/print-versions.ts
@@ -2,18 +2,19 @@
 "use strict";
 
 export class PrintFrameworkVersionsCommand implements ICommand {
-	constructor(private $cordovaMigrationService: ICordovaMigrationService,
+	constructor(private $cordovaMigrationService: IFrameworkMigrationService,
+		private $nativeScriptMigrationService: IFrameworkMigrationService,
 		private $project: Project.IProject,
 		private $logger: ILogger,
-		private $errors: IErrors) { }
+		private $errors: IErrors,
+		private $projectConstants: Project.IProjectConstants) { }
 
 	public execute(args: string[]): IFuture<void> {
 		return (() => {
-			let supportedVersions: Server.FrameworkVersion[] = this.$cordovaMigrationService.getSupportedFrameworks().wait();
+			let migrationService = this.$project.projectData.Framework === this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova ? this.$cordovaMigrationService : this.$nativeScriptMigrationService;
+			let supportedVersions: Server.FrameworkVersion[] = migrationService.getSupportedFrameworks().wait();
 
-			if(this.$project.projectData) {
-				this.$logger.info("Your project is using version " + this.$cordovaMigrationService.getDisplayNameForVersion(this.$project.projectData["FrameworkVersion"]).wait());
-			}
+			this.$logger.info("Your project is using version " + migrationService.getDisplayNameForVersion(this.$project.projectData.FrameworkVersion).wait());
 
 			this.$logger.info("Supported versions are: ");
 			_.each(supportedVersions, (sv: Server.FrameworkVersion) => {
@@ -26,8 +27,10 @@ export class PrintFrameworkVersionsCommand implements ICommand {
 
 	public canExecute(args: string[]): IFuture<boolean> {
 		return (() => {
-			this.$project.ensureCordovaProject();
-
+			this.$project.ensureProject();
+			if(this.$project.projectData.Framework !== this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova && this.$project.projectData.Framework !== this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript) {
+				this.$errors.failWithoutHelp("This command is applicable only for Cordova and NativeScript projects.")
+			}
 			return true;
 		}).future<boolean>()();
 	}

--- a/lib/commands/framework-versions/print-versions.ts
+++ b/lib/commands/framework-versions/print-versions.ts
@@ -28,9 +28,10 @@ export class PrintFrameworkVersionsCommand implements ICommand {
 	public canExecute(args: string[]): IFuture<boolean> {
 		return (() => {
 			this.$project.ensureProject();
-			if(this.$project.projectData.Framework !== this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova && this.$project.projectData.Framework !== this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript) {
-				this.$errors.failWithoutHelp("This command is applicable only for Cordova and NativeScript projects.")
+			if(!this.$project.capabilities.canChangeFrameworkVersion) {
+				this.$errors.failWithoutHelp(`This command is not applicable to ${this.$project.projectData.Framework} projects.`);
 			}
+
 			return true;
 		}).future<boolean>()();
 	}

--- a/lib/commands/framework-versions/set-version.ts
+++ b/lib/commands/framework-versions/set-version.ts
@@ -29,6 +29,10 @@ export class MobileFrameworkCommandParameter implements ICommandParameter {
 	public validate(value: string, errorMessage?: string): IFuture<boolean> {
 		return (() => {
 			this.$project.ensureProject();
+			if(!this.$project.capabilities.canChangeFrameworkVersion) {
+				this.$errors.failWithoutHelp(`You cannot change FrameworkVersion of '${this.$project.projectData.Framework}' project.`)
+			}
+
 			if(value.match(MobileFrameworkCommandParameter.VERSION_REGEX)) {
 				let supportedVersions: string[];
 				let migrationService = this.$project.projectData.Framework === this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova ? this.$cordovaMigrationService : this.$nativeScriptMigrationService;
@@ -38,7 +42,7 @@ export class MobileFrameworkCommandParameter implements ICommandParameter {
 					return true;
 				}
 
-				this.$errors.failWithoutHelp(`The value ${value} is not a supported version. Supported versions are: ${supportedVersions}`, value, supportedVersions);
+				this.$errors.failWithoutHelp(`The value ${value} is not a supported version. Supported versions are: ${supportedVersions.join(", ")}`);
 			}
 
 			this.$errors.failWithoutHelp("Version is not in correct format. Correct format is <Major>.<Minor>.<Patch>, for example '3.5.0'.");

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -162,6 +162,7 @@ interface IProjectCapabilities {
 	emulate: boolean;
 	publish: boolean;
 	uploadToAppstore: boolean;
+	canChangeFrameworkVersion: boolean;
 }
 
 interface IProjectData extends IDictionary<any> {
@@ -387,8 +388,6 @@ interface IPathFilteringService {
 interface IFrameworkMigrationService {
 	downloadMigrationData(): IFuture<void>;
 	getSupportedVersions(): IFuture<string[]>;
-	pluginsForVersion?(version: string): IFuture<string[]>;
-	migratePlugins?(plugins: string[], fromVersion: string, toVersion: string): IFuture<string[]>;
 	getSupportedFrameworks(): IFuture<Server.FrameworkVersion[]>;
 	getDisplayNameForVersion(version: string): IFuture<string>;
 	/**
@@ -397,6 +396,11 @@ interface IFrameworkMigrationService {
 	 * @return {IFuture<void>}
 	 */
 	onFrameworkVersionChanging(newVersion: string): IFuture<void>;
+}
+
+interface ICordovaMigrationService extends IFrameworkMigrationService {
+	pluginsForVersion(version: string): IFuture<string[]>;
+	migratePlugins(plugins: string[], fromVersion: string, toVersion: string): IFuture<string[]>;
 	/**
 	 * Hook which is dynamically called when a project's windows phone sdk version is changing
 	 * @param  {string} newVersion The version to upgrade/downgrade to
@@ -436,7 +440,7 @@ interface IPluginsService {
 	 * @param  {string}        pluginName     The name of the plugin.
 	 * @param  {string}        version        The version of the plugin.
 	 * @param  {string[]}      configurations Configurations in which the plugin should be configured. Example: ['debug'], ['debug', 'release']
-	 * @return {IFuture<void>}                
+	 * @return {IFuture<void>}
 	 */
 	configurePlugin(pluginName: string, version?: string, configurations?: string[]): IFuture<void>;
 	isPluginInstalled(pluginName: string): boolean;

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -384,11 +384,11 @@ interface IPathFilteringService {
 	isFileExcluded(file: string, rules: string[], rootDir: string): boolean
 }
 
-interface ICordovaMigrationService {
-	downloadCordovaMigrationData(): IFuture<void>;
+interface IFrameworkMigrationService {
+	downloadMigrationData(): IFuture<void>;
 	getSupportedVersions(): IFuture<string[]>;
-	pluginsForVersion(version: string): IFuture<string[]>;
-	migratePlugins(plugins: string[], fromVersion: string, toVersion: string): IFuture<string[]>;
+	pluginsForVersion?(version: string): IFuture<string[]>;
+	migratePlugins?(plugins: string[], fromVersion: string, toVersion: string): IFuture<string[]>;
 	getSupportedFrameworks(): IFuture<Server.FrameworkVersion[]>;
 	getDisplayNameForVersion(version: string): IFuture<string>;
 	/**
@@ -402,7 +402,7 @@ interface ICordovaMigrationService {
 	 * @param  {string} newVersion The version to upgrade/downgrade to
 	 * @return {IFuture<void>}
 	 */
-	onWPSdkVersionChanging(newVersion: string): IFuture<void>;
+	onWPSdkVersionChanging?(newVersion: string): IFuture<void>;
 }
 
 interface ISamplesService {

--- a/lib/hooks/typescript-compilation.ts
+++ b/lib/hooks/typescript-compilation.ts
@@ -10,13 +10,11 @@ fiberBootstrap.run(() => {
 	let project: Project.IProject = $injector.resolve("project");
 	let $fs: IFileSystem = $injector.resolve("fs");
 	project.ensureProject();
-	let projectFiles = $fs.enumerateFilesInDirectorySync(project.getProjectDir().wait());
 
-	let typeScriptFiles = _.filter(projectFiles, file => path.extname(file) === ".ts");
-	let definitionFiles = _.filter(typeScriptFiles, file => _.endsWith(file, ".d.ts"));
-	if(typeScriptFiles.length > definitionFiles.length) { // We need this check because some of non-typescript templates(for example KendoUI.Strip) contain typescript definition files
+	let typeScriptFiles = project.getTypeScriptFiles().wait();
+	if(typeScriptFiles.typeScriptFiles.length > typeScriptFiles.definitionFiles.length) { // We need this check because some of non-typescript templates(for example KendoUI.Strip) contain typescript definition files
 		let typeScriptCompilationService = $injector.resolve("typeScriptCompilationService");
-		typeScriptCompilationService.initialize(typeScriptFiles, definitionFiles);
+		typeScriptCompilationService.initialize(typeScriptFiles.typeScriptFiles, typeScriptFiles.definitionFiles);
 		typeScriptCompilationService.compileAllFiles().wait();
 	}
 });

--- a/lib/project.ts
+++ b/lib/project.ts
@@ -630,6 +630,18 @@ export class Project implements Project.IProject {
 		}).future<void>()();
 	}
 
+	public isTypeScriptProject(): IFuture<boolean> {
+		return ((): boolean => { 
+			let projectFiles = this.$fs.enumerateFilesInDirectorySync(this.getProjectDir().wait());
+			let typeScriptFiles = _.filter(projectFiles, file => path.extname(file) === ".ts");
+			let definitionFiles = _.filter(typeScriptFiles, file => _.endsWith(file, ".d.ts"));
+			if(typeScriptFiles.length > definitionFiles.length) { // We need this check because some of non-typescript templates(for example KendoUI.Strip) contain typescript definition files
+				return true;
+			}
+			return false;
+		}).future<boolean>()();
+	}
+
 	private getProjectRelativePath(fullPath: string, projectDir: string): string {
 		projectDir = path.join(projectDir, path.sep);
 		if (!_.startsWith(fullPath, projectDir)) {

--- a/lib/project.ts
+++ b/lib/project.ts
@@ -632,14 +632,22 @@ export class Project implements Project.IProject {
 
 	public isTypeScriptProject(): IFuture<boolean> {
 		return ((): boolean => { 
-			let projectFiles = this.$fs.enumerateFilesInDirectorySync(this.getProjectDir().wait());
-			let typeScriptFiles = _.filter(projectFiles, file => path.extname(file) === ".ts");
-			let definitionFiles = _.filter(typeScriptFiles, file => _.endsWith(file, ".d.ts"));
-			if(typeScriptFiles.length > definitionFiles.length) { // We need this check because some of non-typescript templates(for example KendoUI.Strip) contain typescript definition files
+			let typeScriptFiles = this.getTypeScriptFiles().wait();
+			
+			if(typeScriptFiles.typeScriptFiles.length > typeScriptFiles.definitionFiles.length) { // We need this check because some of non-typescript templates(for example KendoUI.Strip) contain typescript definition files
 				return true;
 			}
 			return false;
 		}).future<boolean>()();
+	}
+
+	public getTypeScriptFiles(): IFuture<Project.ITypeScriptFiles> {
+		return ((): Project.ITypeScriptFiles => {
+			let projectFiles = this.$fs.enumerateFilesInDirectorySync(this.getProjectDir().wait());
+			let typeScriptFiles = _.filter(projectFiles, file => path.extname(file) === ".ts");
+			let definitionFiles = _.filter(typeScriptFiles, file => _.endsWith(file, ".d.ts"));
+			return { definitionFiles: definitionFiles, typeScriptFiles: typeScriptFiles };
+		}).future<Project.ITypeScriptFiles>()();
 	}
 
 	private getProjectRelativePath(fullPath: string, projectDir: string): string {

--- a/lib/project/cordova-project.ts
+++ b/lib/project/cordova-project.ts
@@ -42,7 +42,8 @@ export class CordovaProject extends frameworkProjectBaseLib.FrameworkProjectBase
 			updateKendo: true,
 			emulate: true,
 			publish: false,
-			uploadToAppstore: true
+			uploadToAppstore: true,
+			canChangeFrameworkVersion: true
 		};
 	}
 

--- a/lib/project/nativescript-project.ts
+++ b/lib/project/nativescript-project.ts
@@ -36,7 +36,8 @@ export class NativeScriptProject extends frameworkProjectBaseLib.FrameworkProjec
 			updateKendo: false,
 			emulate: true,
 			publish: false,
-			uploadToAppstore: true
+			uploadToAppstore: true,
+			canChangeFrameworkVersion: true
 		};
 	}
 

--- a/lib/project/project.d.ts
+++ b/lib/project/project.d.ts
@@ -43,6 +43,11 @@ declare module Project {
 		 * @param {string} platform Android, iOS or WP8
 		 */
 		checkSdkVersions(platform: string): void;
+		/**
+		* Checks if the project language is TypeScript.
+		* @return {IFuture<boolean>} true when the project contains .ts files and false otherwise.
+		*/
+		isTypeScriptProject(): IFuture<boolean>;
 	}
 
 	interface IFrameworkProject {

--- a/lib/project/project.d.ts
+++ b/lib/project/project.d.ts
@@ -44,10 +44,16 @@ declare module Project {
 		 */
 		checkSdkVersions(platform: string): void;
 		/**
-		* Checks if the project language is TypeScript.
+		* Checks if the project language is TypeScript by enumerating all files and checking if there are at least one TypeScript file (.ts), that is not definition file(.d.ts)
 		* @return {IFuture<boolean>} true when the project contains .ts files and false otherwise.
 		*/
 		isTypeScriptProject(): IFuture<boolean>;
+		
+		/**
+		 * Returns new object, containing all typeScript and all TypeScript definition files.
+		 * @return {IFuture<ITypeScriptFiles>} all typeScript and all TypeScript definition files.
+		 */
+		getTypeScriptFiles(): IFuture<ITypeScriptFiles>
 	}
 
 	interface IFrameworkProject {
@@ -133,5 +139,14 @@ declare module Project {
 		filepath: string;
 		templateFilepath: string;
 		helpText: string;
+	}
+	/**
+	 * Defines an object, containing all TypeScript files (.ts) within project and all TypeScript definition files (.d.ts).
+	 * TypeScript files are all files ending with .ts, so if there are any definition files, they will be placed in both
+	 * typeScript files and definitionFiles collections.
+	 */
+	interface ITypeScriptFiles {
+		definitionFiles: string[],
+		typeScriptFiles: string[]
 	}
 }

--- a/lib/project/web-site-project.ts
+++ b/lib/project/web-site-project.ts
@@ -35,7 +35,8 @@ export class MobileWebSiteProject extends frameworkProjectBaseLib.FrameworkProje
 			updateKendo: false,
 			emulate: false,
 			publish: true,
-			uploadToAppstore: false
+			uploadToAppstore: false,
+			canChangeFrameworkVersion: false
 		};
 	}
 

--- a/lib/resource-loader.ts
+++ b/lib/resource-loader.ts
@@ -34,7 +34,7 @@ class ResourceDownloader implements IResourceDownloader {
 	constructor(private $server: Server.IServer,
 		private $fs: IFileSystem,
 		private $resources: IResourceLoader,
-		private $cordovaMigrationService: ICordovaMigrationService,
+		private $cordovaMigrationService: IFrameworkMigrationService,
 		private $mobileHelper: Mobile.IMobileHelper) { }
 
 	public downloadCordovaJsFiles(): IFuture<void> {

--- a/lib/server-api.d.ts
+++ b/lib/server-api.d.ts
@@ -256,6 +256,14 @@ declare module Server{
 		importProvision(provision: any): IFuture<Server.ProvisionData>;
 		removeProvision(identifier: string): IFuture<void>;
 	}
+	interface NativeScriptMigrationData{
+		ObsoleteVersions: Server.FrameworkVersion[];
+		SupportedVersions: Server.FrameworkVersion[];
+	}
+	interface INativescriptServiceContract{
+		getMigrationData(): IFuture<Server.NativeScriptMigrationData>;
+		migrate(solutionName: string, projectName: string, targetVersion: string): IFuture<Server.MigrationResult>;
+	}
 	interface BuildIssueData{
 		Code: string;
 		File: string;
@@ -621,6 +629,7 @@ declare module Server{
 		itmstransporter: Server.IItmstransporterServiceContract;
 		kendo: Server.IKendoServiceContract;
 		mobileprovisions: Server.IMobileprovisionsServiceContract;
+		nativescript: Server.INativescriptServiceContract;
 		build: Server.IBuildServiceContract;
 		projects: Server.IProjectsServiceContract;
 		packages: Server.IPackagesServiceContract;

--- a/lib/server-api.ts
+++ b/lib/server-api.ts
@@ -216,6 +216,16 @@ export class MobileprovisionsService implements Server.IMobileprovisionsServiceC
 		return this.$serviceProxy.call<void>('RemoveProvision', 'DELETE', ['api','mobileprovisions',encodeURI(identifier.replace(/\\/g, '/'))].join('/'), null, null, null);
 	}
 }
+export class NativescriptService implements Server.INativescriptServiceContract{
+	constructor(private $serviceProxy: Server.IServiceProxy){
+	}
+	public getMigrationData(): IFuture<Server.NativeScriptMigrationData>{
+		return this.$serviceProxy.call<Server.NativeScriptMigrationData>('GetMigrationData', 'GET', ['api','nativescript','migration-data'].join('/'), 'application/json', null, null);
+	}
+	public migrate(solutionName: string, projectName: string, targetVersion: string): IFuture<Server.MigrationResult>{
+		return this.$serviceProxy.call<Server.MigrationResult>('Migrate', 'POST', ['api','nativescript','migrate',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(projectName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'targetVersion': targetVersion }), 'application/json', null, null);
+	}
+}
 export class BuildService implements Server.IBuildServiceContract{
 	constructor(private $serviceProxy: Server.IServiceProxy){
 	}
@@ -516,6 +526,7 @@ export class ServiceContainer implements Server.IServer{
 	public itmstransporter: Server.IItmstransporterServiceContract = this.$injector.resolve(ItmstransporterService);
 	public kendo: Server.IKendoServiceContract = this.$injector.resolve(KendoService);
 	public mobileprovisions: Server.IMobileprovisionsServiceContract = this.$injector.resolve(MobileprovisionsService);
+	public nativescript: Server.INativescriptServiceContract = this.$injector.resolve(NativescriptService);
 	public build: Server.IBuildServiceContract = this.$injector.resolve(BuildService);
 	public projects: Server.IProjectsServiceContract = this.$injector.resolve(ProjectsService);
 	public packages: Server.IPackagesServiceContract = this.$injector.resolve(PackagesService);

--- a/lib/services/cordova-migration-service.ts
+++ b/lib/services/cordova-migration-service.ts
@@ -24,7 +24,7 @@ export class FrameworkVersion implements Server.FrameworkVersion {
 		public Version: string) { }
 }
 
-export class CordovaMigrationService implements IFrameworkMigrationService {
+export class CordovaMigrationService implements ICordovaMigrationService {
 	private _migrationData: MigrationData;
 	private minSupportedVersion: string = "3.0.0";
 	private invalidMarketplacePlugins: string[] = [];

--- a/lib/services/cordova-migration-service.ts
+++ b/lib/services/cordova-migration-service.ts
@@ -24,7 +24,7 @@ export class FrameworkVersion implements Server.FrameworkVersion {
 		public Version: string) { }
 }
 
-export class CordovaMigrationService implements ICordovaMigrationService {
+export class CordovaMigrationService implements IFrameworkMigrationService {
 	private _migrationData: MigrationData;
 	private minSupportedVersion: string = "3.0.0";
 	private invalidMarketplacePlugins: string[] = [];
@@ -122,7 +122,7 @@ export class CordovaMigrationService implements ICordovaMigrationService {
 		}).future<string[]>()();
 	}
 
-	public downloadCordovaMigrationData(): IFuture<void> {
+	public downloadMigrationData(): IFuture<void> {
 		return (() => {
 			let json = this.$server.cordova.getMigrationData().wait();
 			let renamedPlugins = _.map(json.RenamedPlugins, (plugin: any) => new RenamedPlugin(

--- a/lib/services/nativescript-migration-service.ts
+++ b/lib/services/nativescript-migration-service.ts
@@ -1,0 +1,143 @@
+///<reference path="../.d.ts"/>
+"use strict";
+
+import Future = require("fibers/future");
+import path = require("path");
+import helpers = require("./../helpers");
+
+export class NativeScriptMigrationService implements IFrameworkMigrationService {
+	private static TYPESCRIPT_ABBREVIATION = "TS";
+	private static JAVASCRIPT_ABBREVIATION = "JS";	
+	private nativeScriptMigrationFile: string = path.join(__dirname, "../../resources/NativeScript", "nativeScript-migration-data.json");
+	private tnsModulesDirectoryPath: string;
+	private remoteTnsModulesDirectoryPath: string;
+	private _nativeScriptMigrationData: Server.NativeScriptMigrationData;
+	private get nativeScriptMigrationData(): IFuture<Server.NativeScriptMigrationData> {
+		return ((): Server.NativeScriptMigrationData => {
+			this._nativeScriptMigrationData = this._nativeScriptMigrationData || this.$fs.readJson(this.nativeScriptMigrationFile).wait();
+			return this._nativeScriptMigrationData;
+		}).future<Server.NativeScriptMigrationData>()();
+	}
+
+	constructor(private $fs: IFileSystem,
+		private $server: Server.IServer,
+		private $errors: IErrors,
+		private $logger: ILogger,
+		private $project: Project.IProject,
+		private $resources: IResourceLoader,
+		private $config: IConfiguration,
+		private $httpClient: Server.IHttpClient) {
+			this.tnsModulesDirectoryPath = path.join(this.$resources.resolvePath("NativeScript"), "tns_modules");
+			this.remoteTnsModulesDirectoryPath = `http://${this.$config.AB_SERVER}/appbuilder/Resources/NativeScript/tns_modules`;
+		}
+		
+	private parseMscorlibVersion(json: any): string {
+		return [json._Major, json._Minor, json._Build].join('.');
+	}
+		
+	public downloadMigrationData(): IFuture<void> {
+		return (() => {
+			this.$fs.deleteDirectory(this.tnsModulesDirectoryPath).wait();
+			this.$fs.createDirectory(this.tnsModulesDirectoryPath).wait();
+	
+			let json = this.$server.nativescript.getMigrationData().wait();
+			let supportedVersions = _.map(json.SupportedVersions, supportedVersion => {
+				supportedVersion.Version = this.parseMscorlibVersion(supportedVersion.Version);
+				return supportedVersion;
+			});
+			_.each(json.ObsoleteVersions, obsoleteVersion => {
+				obsoleteVersion.Version = this.parseMscorlibVersion(obsoleteVersion.Version); 
+			});
+
+			this.$fs.writeJson(this.nativeScriptMigrationFile, json).wait();
+			let supportedLanguages = [NativeScriptMigrationService.JAVASCRIPT_ABBREVIATION, NativeScriptMigrationService.TYPESCRIPT_ABBREVIATION];
+			let fileDownloadFutures = _(supportedVersions)
+									.map(supportedVersion => _.map(supportedLanguages, language => this.downloadTnsModules(language, supportedVersion.Version)))
+									.flatten<IFuture<void>>()
+									.value();
+			Future.wait(fileDownloadFutures);
+		}).future<void>()();
+	}
+
+	public getSupportedVersions(): IFuture<string[]> {
+		return ((): string[] => {
+			let migrationData = this.nativeScriptMigrationData.wait();
+			return _.map(migrationData.SupportedVersions, supportedVersion => supportedVersion.Version);
+		}).future<string[]>()();
+	}
+
+	public getSupportedFrameworks(): IFuture<Server.FrameworkVersion[]> {
+		return ((): Server.FrameworkVersion[] => {
+			let migrationData = this.nativeScriptMigrationData.wait();
+			return migrationData.SupportedVersions;
+		}).future<Server.FrameworkVersion[]>()();
+	}
+
+	public getDisplayNameForVersion(version: string): IFuture<string>{
+		return ((): string => {
+			let framework = _.find(this.getSupportedFrameworks().wait(), (fw: Server.FrameworkVersion) => fw.Version === version);
+			if(framework) {
+				return framework.DisplayName;
+			}
+
+			this.$errors.fail("Cannot find version %s in the supported versions.", version);
+		}).future<string>()();
+	}
+	
+	public onFrameworkVersionChanging(newVersion: string): IFuture<void> {
+		return (() => {
+			let projectDir = this.$project.getProjectDir().wait();
+			let tnsModulesProjectPath = path.join(projectDir, "app", "tns_modules");
+			let backupName = `${tnsModulesProjectPath}.backup`;
+			// Check if current version is supported one. We cannot migrate ObsoleteVersions
+			let currentFrameworkVersion = this.$project.projectData.FrameworkVersion;
+			if(!_.contains(this.getSupportedVersions().wait(), currentFrameworkVersion)) {
+				if(_.contains(this.getObsoleteVersions().wait(), currentFrameworkVersion)) {
+					this.$errors.failWithoutHelp(`You can still build your project, but you cannot migrate from version '${currentFrameworkVersion}'. Consider creating a new NativeScript project.`)
+				} else {
+					this.$errors.failWithoutHelp(`You cannot migrate from version ${currentFrameworkVersion}.`)
+				}
+			}
+
+			try {
+				this.$fs.rename(tnsModulesProjectPath, backupName).wait();
+				this.$fs.createDirectory(tnsModulesProjectPath).wait();
+				let projectType = this.$project.isTypeScriptProject().wait() ? NativeScriptMigrationService.TYPESCRIPT_ABBREVIATION : NativeScriptMigrationService.JAVASCRIPT_ABBREVIATION;
+				let pathToNewTnsModules = path.join(this.tnsModulesDirectoryPath, projectType, this.getFileNameByVersion(newVersion));
+				this.$fs.unzip(pathToNewTnsModules, tnsModulesProjectPath).wait();
+				this.$fs.deleteDirectory(backupName).wait();
+			} catch(err) {
+				this.$logger.trace("Error during migration. Trying to restore previous state.");
+				this.$logger.trace(err);
+				this.$fs.deleteDirectory(tnsModulesProjectPath).wait();
+				this.$fs.rename(backupName, tnsModulesProjectPath).wait();
+				this.$errors.failWithoutHelp("Error during migration. Restored original state of the project.");
+			}
+		}).future<void>()();
+	}
+
+	private downloadTnsModules(language: string, version: string): IFuture<void> {
+		return (() => {
+			let fileName = this.getFileNameByVersion(version);
+			let filePath = path.join(this.tnsModulesDirectoryPath, language, fileName);
+			this.$fs.writeFile(filePath, "").wait();
+			let file = this.$fs.createWriteStream(filePath);
+			let fileEnd = this.$fs.futureFromEvent(file, "finish");
+			let remotePathUrl = `${this.remoteTnsModulesDirectoryPath}/${language}/${fileName}`;
+			this.$httpClient.httpRequest({ url:remotePathUrl, pipeTo: file}).wait();
+			fileEnd.wait();
+		}).future<void>()();
+	}
+
+	private getFileNameByVersion(version: string): string {
+		return `${version}.zip`;
+	}
+	
+	private getObsoleteVersions(): IFuture<string[]> {
+		return ((): string[] => {
+			let migrationData = this.nativeScriptMigrationData.wait();
+			return _.map(migrationData.ObsoleteVersions, obsoleteVersion => obsoleteVersion.Version);
+		}).future<string[]>()();
+	}
+}
+$injector.register("nativeScriptMigrationService", NativeScriptMigrationService);

--- a/resources/project-properties-nativescript.json
+++ b/resources/project-properties-nativescript.json
@@ -1,6 +1,7 @@
 {
 	"FrameworkVersion": {
 		"description": "NativeScript framework version.",
-		"range": ["0.3.0", "0.3.1", "0.4.0", "0.4.2", "0.5.0"]
+		"dynamicRange": "#{nativeScriptMigrationService.getSupportedVersions}",
+		"onChanging": "#{nativeScriptMigrationService.onFrameworkVersionChanging}"
 	}
 }

--- a/test/cordova-migration-service.ts
+++ b/test/cordova-migration-service.ts
@@ -61,7 +61,7 @@ describe("cordova-migration-service", () => {
 				}
 			});
 
-			let service: ICordovaMigrationService = testInjector.resolve(cordovaMigrationService.CordovaMigrationService);
+			let service: IFrameworkMigrationService = testInjector.resolve(cordovaMigrationService.CordovaMigrationService);
 			assert.deepEqual(service.migratePlugins(["plugin"], "3.0.0", "3.2.0").wait(), ["plugin"]);
 		});
 
@@ -79,7 +79,7 @@ describe("cordova-migration-service", () => {
 				}
 			});
 
-			let service: ICordovaMigrationService = testInjector.resolve(cordovaMigrationService.CordovaMigrationService);
+			let service: IFrameworkMigrationService = testInjector.resolve(cordovaMigrationService.CordovaMigrationService);
 			assert.deepEqual(service.migratePlugins(["org.apache.cordova.AudioHandler"], "3.0.0", "3.2.0").wait(), ["org.apache.cordova.AudioHandler"]);
 		});
 
@@ -92,7 +92,7 @@ describe("cordova-migration-service", () => {
 				}
 			});
 
-			let service: ICordovaMigrationService = testInjector.resolve(cordovaMigrationService.CordovaMigrationService);
+			let service: IFrameworkMigrationService = testInjector.resolve(cordovaMigrationService.CordovaMigrationService);
 			assert.deepEqual(service.migratePlugins(["org.apache.cordova.camera", "org.apache.cordova.statusbar"], "3.2.0", "3.0.0").wait(), ["org.apache.cordova.camera"]);
 		});
 
@@ -108,7 +108,7 @@ describe("cordova-migration-service", () => {
 				}
 			});
 
-			let service: ICordovaMigrationService = testInjector.resolve(cordovaMigrationService.CordovaMigrationService);
+			let service: IFrameworkMigrationService = testInjector.resolve(cordovaMigrationService.CordovaMigrationService);
 			assert.deepEqual(service.migratePlugins(["org.apache.cordova.AudioHandler"], "3.0.0", "3.2.0").wait(), ["org.apache.cordova.media"]);
 		});
 
@@ -124,7 +124,7 @@ describe("cordova-migration-service", () => {
 				}
 			});
 
-			let service: ICordovaMigrationService = testInjector.resolve(cordovaMigrationService.CordovaMigrationService);
+			let service: IFrameworkMigrationService = testInjector.resolve(cordovaMigrationService.CordovaMigrationService);
 			assert.deepEqual(service.migratePlugins(["org.apache.cordova.media"], "3.2.0", "3.0.0").wait(), ["org.apache.cordova.AudioHandler"]);
 		});
 
@@ -140,7 +140,7 @@ describe("cordova-migration-service", () => {
 				}
 			});
 
-			let service: ICordovaMigrationService = testInjector.resolve(cordovaMigrationService.CordovaMigrationService);
+			let service: IFrameworkMigrationService = testInjector.resolve(cordovaMigrationService.CordovaMigrationService);
 			assert.deepEqual(service.migratePlugins(["org.apache.cordova.sqlite"], "3.5.0", "3.7.0").wait(), ["org.apache.cordova.sqlite@1.0.2"]);
 		});
 
@@ -161,7 +161,7 @@ describe("cordova-migration-service", () => {
 				}
 			});
 
-			let service: ICordovaMigrationService = testInjector.resolve(cordovaMigrationService.CordovaMigrationService);
+			let service: IFrameworkMigrationService = testInjector.resolve(cordovaMigrationService.CordovaMigrationService);
 			assert.deepEqual(service.migratePlugins(["org.apache.cordova.AudioHandler"], "3.0.0", "3.4.0").wait(), ["org.apache.cordova.NewMedia"]);
 		});
 
@@ -182,7 +182,7 @@ describe("cordova-migration-service", () => {
 				}
 			});
 
-			let service: ICordovaMigrationService = testInjector.resolve(cordovaMigrationService.CordovaMigrationService);
+			let service: IFrameworkMigrationService = testInjector.resolve(cordovaMigrationService.CordovaMigrationService);
 			assert.deepEqual(service.migratePlugins(["org.apache.cordova.NewMedia"], "3.4.0", "3.0.0").wait(), ["org.apache.cordova.AudioHandler"]);
 		});
 	});

--- a/test/cordova-migration-service.ts
+++ b/test/cordova-migration-service.ts
@@ -61,7 +61,7 @@ describe("cordova-migration-service", () => {
 				}
 			});
 
-			let service: IFrameworkMigrationService = testInjector.resolve(cordovaMigrationService.CordovaMigrationService);
+			let service: ICordovaMigrationService = testInjector.resolve(cordovaMigrationService.CordovaMigrationService);
 			assert.deepEqual(service.migratePlugins(["plugin"], "3.0.0", "3.2.0").wait(), ["plugin"]);
 		});
 
@@ -79,7 +79,7 @@ describe("cordova-migration-service", () => {
 				}
 			});
 
-			let service: IFrameworkMigrationService = testInjector.resolve(cordovaMigrationService.CordovaMigrationService);
+			let service: ICordovaMigrationService = testInjector.resolve(cordovaMigrationService.CordovaMigrationService);
 			assert.deepEqual(service.migratePlugins(["org.apache.cordova.AudioHandler"], "3.0.0", "3.2.0").wait(), ["org.apache.cordova.AudioHandler"]);
 		});
 
@@ -92,7 +92,7 @@ describe("cordova-migration-service", () => {
 				}
 			});
 
-			let service: IFrameworkMigrationService = testInjector.resolve(cordovaMigrationService.CordovaMigrationService);
+			let service: ICordovaMigrationService = testInjector.resolve(cordovaMigrationService.CordovaMigrationService);
 			assert.deepEqual(service.migratePlugins(["org.apache.cordova.camera", "org.apache.cordova.statusbar"], "3.2.0", "3.0.0").wait(), ["org.apache.cordova.camera"]);
 		});
 
@@ -108,7 +108,7 @@ describe("cordova-migration-service", () => {
 				}
 			});
 
-			let service: IFrameworkMigrationService = testInjector.resolve(cordovaMigrationService.CordovaMigrationService);
+			let service: ICordovaMigrationService = testInjector.resolve(cordovaMigrationService.CordovaMigrationService);
 			assert.deepEqual(service.migratePlugins(["org.apache.cordova.AudioHandler"], "3.0.0", "3.2.0").wait(), ["org.apache.cordova.media"]);
 		});
 
@@ -124,7 +124,7 @@ describe("cordova-migration-service", () => {
 				}
 			});
 
-			let service: IFrameworkMigrationService = testInjector.resolve(cordovaMigrationService.CordovaMigrationService);
+			let service: ICordovaMigrationService = testInjector.resolve(cordovaMigrationService.CordovaMigrationService);
 			assert.deepEqual(service.migratePlugins(["org.apache.cordova.media"], "3.2.0", "3.0.0").wait(), ["org.apache.cordova.AudioHandler"]);
 		});
 
@@ -140,7 +140,7 @@ describe("cordova-migration-service", () => {
 				}
 			});
 
-			let service: IFrameworkMigrationService = testInjector.resolve(cordovaMigrationService.CordovaMigrationService);
+			let service: ICordovaMigrationService = testInjector.resolve(cordovaMigrationService.CordovaMigrationService);
 			assert.deepEqual(service.migratePlugins(["org.apache.cordova.sqlite"], "3.5.0", "3.7.0").wait(), ["org.apache.cordova.sqlite@1.0.2"]);
 		});
 
@@ -161,7 +161,7 @@ describe("cordova-migration-service", () => {
 				}
 			});
 
-			let service: IFrameworkMigrationService = testInjector.resolve(cordovaMigrationService.CordovaMigrationService);
+			let service: ICordovaMigrationService = testInjector.resolve(cordovaMigrationService.CordovaMigrationService);
 			assert.deepEqual(service.migratePlugins(["org.apache.cordova.AudioHandler"], "3.0.0", "3.4.0").wait(), ["org.apache.cordova.NewMedia"]);
 		});
 
@@ -182,7 +182,7 @@ describe("cordova-migration-service", () => {
 				}
 			});
 
-			let service: IFrameworkMigrationService = testInjector.resolve(cordovaMigrationService.CordovaMigrationService);
+			let service: ICordovaMigrationService = testInjector.resolve(cordovaMigrationService.CordovaMigrationService);
 			assert.deepEqual(service.migratePlugins(["org.apache.cordova.NewMedia"], "3.4.0", "3.0.0").wait(), ["org.apache.cordova.AudioHandler"]);
 		});
 	});


### PR DESCRIPTION
When the project is migrated we have to update tns_modules directory and .abproject with the new version of the project. Add new NativeScriptMigrationService and use it with dynamic call to upgrade the project. In case an error occurs during migration, rollback the migration. In case current project version is not supported, we have to break the migration. Oboslete versions can still be build, but we cannot migrate them.
Download NativeScript migration data during prepublish. Make sure to save supportedVersion in format - DisplayName(string) and Version(string).
You can change the version by using: `$ appbuilder prop set FrameworkVersion 1.0.1` (or 0.10.0) or `$ appbuilder mobileFramework set 1.0.1`
You can list valid versions by using `$ appbuilder prop print FramworkVersion --validValue` or `$ appbuilder mobileFramework`

Implements http://teampulse.telerik.com/view#item/292172