### PR TITLE
Add latest or default plugin versions

### DIFF
--- a/docs/man_pages/lib-management/plugin-add.md
+++ b/docs/man_pages/lib-management/plugin-add.md
@@ -3,9 +3,11 @@ plugin add
 
 Usage | Synopsis
 ------|-------
-List plugins | `$ appbuilder plugin add --available [--debug] [--release]`    
+List plugins | `$ appbuilder plugin add --available [--debug] [--release]`
 Add plugins | `$ appbuilder plugin add <Name or ID> [--debug] [--release]`
 Add a specific version of a plugin | `$ appbuilder plugin add <Name or ID>@<Version> [--debug] [--release]`
+Add latest version of a plugin | `$ appbuilder plugin add <Name or ID> --latest [--debug] [--release]`
+Add default version of a plugin | `$ appbuilder plugin add <Name or ID> --default [--debug] [--release]`
 
 Enables a core, integrated or verified plugin for your project. <% if(isHtml) { %>If the plugin has plugin variables, the Telerik AppBuilder CLI shows an interactive prompt to let you set values for each plugin variable.<% } %>
 <% if(isConsole) { %>
@@ -21,6 +23,8 @@ WARNING: This command is not applicable to NativeScript projects. To view the co
 * `--available` - Lists all plugins that you can enable in your project.
 * `--debug` - Enables the specified plugin for the Debug build configuration only. If `--available` is set, lists all plugins that you can enable for the Debug build configuration.
 * `--release` - Enables the specified plugin for the Release build configuration only. If `--available` is set, lists all plugins that you can enable for the Release build configuration.
+* `--latest` - Enables the latest version of the specified plugin.
+* `--default` - Enables the default version of the specified plugin.
 
 ### Attributes
 * `<Name or ID>` is the name or ID of the plugin as listed by `$ appbuilder plugin add --available`

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -501,8 +501,26 @@ interface IBasicPluginInformation {
 	version: string;
 }
 
+/**
+ * Extends Server's MarketplacePluginVersionsData interface.
+ */
+interface IMarketplacePluginVersionsData extends Server.MarketplacePluginVersionsData {
+	/**
+	 * The version of the plugin, that is marked as default. This version may not be the latest version.
+	 */
+	DefaultVersion: string;
+	/**
+	 * Id of the plugin.
+	 */
+	Identifier: string;
+	/**
+	 * The framework that is required in order to work with this plugin.
+	 */
+	Framework: string;
+}
+
 interface IMarketplacePlugin extends IPlugin {
-	pluginVersionsData: Server.MarketplacePluginVersionsData;
+	pluginVersionsData: IMarketplacePluginVersionsData;
 }
 
 interface ITypeScriptCompilerOptions {
@@ -601,4 +619,5 @@ interface IOptions extends ICommonOptions {
 	sendPush: boolean;
 	sendEmail: boolean;
 	group: string[];
+	default: boolean;
 }

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -18,7 +18,6 @@ export class Options extends commonOptionsLibPath.OptionsBase {
 			provision: { type: OptionType.String  },
 			template: { type: OptionType.String, alias: "t" },
 			deploy: { type: OptionType.String },
-			device: { type: OptionType.String },
 			saveTo: { type: OptionType.String},
 			client: { type: OptionType.String },
 			available: { type: OptionType.Boolean },
@@ -34,7 +33,8 @@ export class Options extends commonOptionsLibPath.OptionsBase {
 			publish: { type: OptionType.Boolean },
 			sendPush: { type: OptionType.Boolean },
 			sendEmail: { type: OptionType.Boolean },
-			group: { type: OptionType.Array } 
+			group: { type: OptionType.Array },
+			default: {type: OptionType.Boolean}
 		},
 		path.join($hostInfo.isWindows ? process.env.LocalAppData : path.join(osenv.home(), ".local/share"), "Telerik", "BlackDragon", ".appbuilder-cli"),
 			$errors, $staticConfig);

--- a/lib/plugins-data.ts
+++ b/lib/plugins-data.ts
@@ -80,7 +80,7 @@ export class MarketplacePluginData extends CordovaPluginData {
 	private static TELERIK_PUBLISHER_NAME = "Telerik plugins";
 	private static TELERIK_PARTNER_PUBLISHER_NAME = "Telerik partner plugins";
 
-	constructor(public pluginVersionsData: Server.MarketplacePluginVersionsData,
+	constructor(public pluginVersionsData: IMarketplacePluginVersionsData,
 		public data: Server.MarketplacePluginData,
 		$project: Project.IProject,
 		$projectConstants: Project.IProjectConstants) {

--- a/lib/services/marketplace-plugins-service.ts
+++ b/lib/services/marketplace-plugins-service.ts
@@ -14,7 +14,7 @@ export class MarketplacePluginsService implements ICordovaPluginsService {
 		return this.$server.cordova.getMarketplacePluginsData(this.$project.projectData.Framework);
 	}
 
-	public createPluginData(plugin: Server.MarketplacePluginVersionsData): IMarketplacePlugin[] { // DefaultVersion, Identifier, Versions
+	public createPluginData(plugin: IMarketplacePluginVersionsData): IMarketplacePlugin[] { // DefaultVersion, Identifier, Versions
 		return _.map(plugin.Versions, (pluginVersionData) => new PluginsDataLib.MarketplacePluginData(plugin, pluginVersionData, this.$project, this.$projectConstants));
 	}
 }

--- a/lib/services/plugins-service.ts
+++ b/lib/services/plugins-service.ts
@@ -126,12 +126,7 @@ export class PluginsService implements IPluginsService {
 
 			let pluginToAdd = this.getPluginByName(pluginName);
 			if(pluginToAdd.type === pluginsDataLib.PluginType.MarketplacePlugin) {
-				let versions = this.getPluginVersions(pluginName);
-				if(version && !_.any(versions, v => v.value === version)) {
-					this.$errors.failWithoutHelp("Invalid version %s. The valid versions are: %s", version, versions.map(v => v.value).join(", "));
-				} else if(!version) {
-					version = this.promptForVersion(pluginName, versions).wait();
-				}
+				version = this.selectPluginVersion(version, pluginToAdd).wait();
 			}
 
 			this.configurePlugin(pluginName, version).wait();
@@ -487,6 +482,11 @@ export class PluginsService implements IPluginsService {
 				if(!_.any(versions, v => v.value === version)) {
 					this.$errors.failWithoutHelp("Invalid version %s. The valid versions are: %s.", version, versions.map(v => v.value).join(", "));
 				}
+			} else if(this.$options.latest) {
+				// server returns the versions in descending order
+				version = _.first(versions).value;
+			} else if(this.$options.default) {
+				version = (<IMarketplacePlugin>plugin).pluginVersionsData.DefaultVersion;
 			} else {
 				if(options && options.excludeCurrentVersion) {
 					let currentVersionIndex = _.findIndex(versions,(v) => v.value === plugin.data.Version);


### PR DESCRIPTION
Add support for installing the latest plugin version. The command is: `$ appbuilder plugin add toast --latest`. This will install the latest available version of Toast plugin.
Add support for installing the default plugin version. The command is: `$ appbuilder plugin add toast --default`. This will install the default version of Toast plugin.
As on the server MarketplacePluginVersionsData has three more properties, which are not generated in our server-api, implement IMarketplacePluginVersionsData interface, that extends this class and add the properties there.

http://teampulse.telerik.com/view#item/292306