### PR TITLE
Allow migration of NativeScript projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ npm-debug.log
 node_modules
 resources/App_Resources
 resources/Cordova
+resources/NativeScript
 resources/ItemTemplates
 resources/ProjectTemplates
 resources/json-schemas

--- a/docs/man_pages/project/configuration/mobileframework-set.md
+++ b/docs/man_pages/project/configuration/mobileframework-set.md
@@ -5,17 +5,16 @@ Usage | Synopsis
 ------|-------
 General | `$ appbuilder mobileframework set <Version> [--path <Directory>]`
 
-Sets the selected Apache Cordova version for the project and updates the enabled core or integrated plugins to match it.
+<% if(isHtml) { %>Sets the selected framework version for the project.<% } %>
 
 <% if(isConsole)  { %>
-<% if(isNativeScript)  { %>
-WARNING: This command is not applicable to NativeScript projects. To view the complete help for this command, run `$ appbuilder help mobileframework set`
-<% } %>
+<% if(isCordova) { %>Sets the selected Apache Cordova version for the project and updates the enabled core or integrated plugins to match it.<% } %>
+<% if(isNativeScript)  { %>Sets the selected NativeScript version for the project.<% } %>
 <% if(isMobileWebsite)  { %>
 WARNING: This command is not applicable to mobile website projects. To view the complete help for this command, run `$ appbuilder help mobileframework set`
 <% } %>
 <% } %>
-<% if((isConsole && isCordova) || isHtml) { %>
+<% if((isConsole && (isCordova || isNativeScript)) || isHtml) { %>
 ### Options
 * `--path` - Specifies the directory that contains the project. If not specified, the project is searched for in the current directory and all directories above it.
 
@@ -25,7 +24,6 @@ WARNING: This command is not applicable to mobile website projects. To view the 
 <% if(isHtml) { %> 
 ### Command Limitations
 
-* You cannot run this command on NativeScript projects.
 * You cannot run this command on mobile website projects.
 
 ### Related Commands

--- a/docs/man_pages/project/configuration/mobileframework.md
+++ b/docs/man_pages/project/configuration/mobileframework.md
@@ -5,29 +5,23 @@ Usage | Synopsis
 ------|-------
 General | `$ appbuilder mobileframework [<Command>] [--path <Directory>]`
 
-Lists all supported versions of Apache Cordova.
+<% if(isHtml) { %>Lists all supported versions of the framework.<% } %>
 
-<% if(isConsole) { %>
-<% if(isNativeScript)  { %>
-WARNING: This command and its extended commands are not applicable to NativeScript projects. To view the complete help for this command, run `$ appbuilder help mobileframework`
-<% } %>
-<% if(isMobileWebsite)  { %>
+<% if(isConsole && isMobileWebsite) { %>
 WARNING: This command and its extended commands are not applicable to mobile website projects. To view the complete help for this command, run `$ appbuilder help mobileframework`
 <% } %>
-<% } %>
-<% if((isConsole && isCordova) || isHtml) { %>
+<% if((isConsole && (isCordova || isNativeScript)) || isHtml) { %>
 ### Options
 * `--path` - Specifies the directory that contains the project. If not specified, the project is searched for in the current directory and all directories above it.
 
 ### Attributes
 
 `<Command>` extends the `mobileframework` command. You can set the following values for this attribute.
-* `set` - Sets the selected framework version for the project and updates the plugins according to the new version.
+* `set` -Sets the selected framework version for the project.
 <% } %>
 <% if(isHtml) { %> 
 ### Command Limitations
 
-* You cannot run this command on NativeScript projects.
 * You cannot run this command on mobile website projects.
 
 ### Related Commands

--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -24,6 +24,7 @@ $injector.require("marketplacePluginsService", "./services/marketplace-plugins-s
 $injector.require("pluginsService", "./services/plugins-service");
 
 $injector.require("cordovaMigrationService", "./services/cordova-migration-service");
+$injector.require("nativeScriptMigrationService", "./services/nativescript-migration-service");
 $injector.require("samplesService", "./services/samples-service");
 $injector.requireCommand("sample|*list", "./commands/samples");
 $injector.requireCommand("sample|clone", "./commands/samples");

--- a/lib/commands/dev/prepackage.ts
+++ b/lib/commands/dev/prepackage.ts
@@ -4,12 +4,13 @@
 import Future = require("fibers/future");
 
 export class PrePackageCommand implements ICommand {
-	constructor(private $cordovaMigrationService: ICordovaMigrationService,
+	constructor(private $cordovaMigrationService: IFrameworkMigrationService,
 		private $jsonSchemaLoader: IJsonSchemaLoader,
 		private $logger: ILogger,
 		private $resourceDownloader: IResourceDownloader,
 		private $serviceProxy: Server.IServiceProxy,
-		private $templatesService: ITemplatesService) { }
+		private $templatesService: ITemplatesService,
+		private $nativeScriptMigrationService: IFrameworkMigrationService) { }
 
 	public disableAnalytics = true;
 
@@ -27,12 +28,13 @@ export class PrePackageCommand implements ICommand {
 			this.$jsonSchemaLoader.downloadSchemas().wait();
 			this.$logger.info("Unpacking app resources.");
 			this.$templatesService.unpackAppResources().wait();
-			this.$logger.info("Downloading cordova migration data.");
-			this.$cordovaMigrationService.downloadCordovaMigrationData().wait();
-			//Cordova files have to be downloaded after cordova migration data so we know which cordova versions we support
+			this.$logger.info("Downloading Cordova migration data.");
+			this.$cordovaMigrationService.downloadMigrationData().wait();
+			// Cordova files have to be downloaded after cordova migration data so we know which cordova versions we support
 			this.$logger.info("Downloading cordova.js files.");
 			this.$resourceDownloader.downloadCordovaJsFiles().wait();
-
+			this.$logger.info("Downloading NativeScript migration data.")
+			this.$nativeScriptMigrationService.downloadMigrationData().wait();
 			this.$serviceProxy.setShouldAuthenticate(true);
 		}).future<void>()();
 	}

--- a/lib/commands/framework-versions/print-versions.ts
+++ b/lib/commands/framework-versions/print-versions.ts
@@ -2,22 +2,23 @@
 "use strict";
 
 export class PrintFrameworkVersionsCommand implements ICommand {
-	constructor(private $cordovaMigrationService: ICordovaMigrationService,
+	constructor(private $cordovaMigrationService: IFrameworkMigrationService,
+		private $nativeScriptMigrationService: IFrameworkMigrationService,
 		private $project: Project.IProject,
 		private $logger: ILogger,
-		private $errors: IErrors) { }
+		private $errors: IErrors,
+		private $projectConstants: Project.IProjectConstants) { }
 
 	public execute(args: string[]): IFuture<void> {
 		return (() => {
-			let supportedVersions: Server.FrameworkVersion[] = this.$cordovaMigrationService.getSupportedFrameworks().wait();
+			let migrationService = this.$project.projectData.Framework === this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova ? this.$cordovaMigrationService : this.$nativeScriptMigrationService;
+			let supportedVersions: IFrameworkVersion[] = migrationService.getSupportedFrameworks().wait();
 
-			if(this.$project.projectData) {
-				this.$logger.info("Your project is using version " + this.$cordovaMigrationService.getDisplayNameForVersion(this.$project.projectData["FrameworkVersion"]).wait());
-			}
+			this.$logger.info("Your project is using version " + migrationService.getDisplayNameForVersion(this.$project.projectData.FrameworkVersion).wait());
 
 			this.$logger.info("Supported versions are: ");
-			_.each(supportedVersions, (sv: Server.FrameworkVersion) => {
-				this.$logger.info(sv.DisplayName);
+			_.each(supportedVersions, (sv: IFrameworkVersion) => {
+				this.$logger.info(sv.displayName);
 			});
 		}).future<void>()();
 	}
@@ -26,7 +27,14 @@ export class PrintFrameworkVersionsCommand implements ICommand {
 
 	public canExecute(args: string[]): IFuture<boolean> {
 		return (() => {
-			this.$project.ensureCordovaProject();
+			if(args && args.length > 0) {
+				this.$errors.fail("This command does not accept parameters.");
+			}
+
+			this.$project.ensureProject();
+			if(!this.$project.capabilities.canChangeFrameworkVersion) {
+				this.$errors.failWithoutHelp(`This command is not applicable to ${this.$project.projectData.Framework} projects.`);
+			}
 
 			return true;
 		}).future<boolean>()();

--- a/lib/commands/framework-versions/set-version.ts
+++ b/lib/commands/framework-versions/set-version.ts
@@ -3,15 +3,10 @@
 
 export class SetFrameworkVersionCommand implements ICommand {
 	constructor(private $injector: IInjector,
-		private $cordovaMigrationService: ICordovaMigrationService,
 		private $project: Project.IProject) { }
 
 	public execute(args: string[]): IFuture<void> {
-		return (() => {
-			this.$cordovaMigrationService.onFrameworkVersionChanging(args[0]).wait();
-			this.$project.projectData["FrameworkVersion"] = args[0];
-			this.$project.saveProject().wait();
-		}).future<void>()();
+		return this.$project.updateProjectPropertyAndSave("set", "FrameworkVersion", args);
 	}
 
 	public allowedParameters: ICommandParameter[] = [this.$injector.resolve(MobileFrameworkCommandParameter)];
@@ -21,26 +16,34 @@ $injector.registerCommand("mobileframework|set", SetFrameworkVersionCommand);
 export class MobileFrameworkCommandParameter implements ICommandParameter {
 	private static VERSION_REGEX = new RegExp("^(\\d+\\.){2}\\d+$");
 
-	constructor(private $cordovaMigrationService: ICordovaMigrationService,
+	constructor(private $cordovaMigrationService: IFrameworkMigrationService,
 		private $project: Project.IProject,
-		private $errors: IErrors) { }
+		private $errors: IErrors,
+		private $nativeScriptMigrationService: IFrameworkMigrationService,
+		private $projectConstants: Project.IProjectConstants) { }
 
 	public mandatory = true;
 
 	public validate(value: string, errorMessage?: string): IFuture<boolean> {
 		return (() => {
-			this.$project.ensureCordovaProject();
+			this.$project.ensureProject();
+			if(!this.$project.capabilities.canChangeFrameworkVersion) {
+				this.$errors.failWithoutHelp(`You cannot change FrameworkVersion of '${this.$project.projectData.Framework}' project.`)
+			}
 
 			if(value.match(MobileFrameworkCommandParameter.VERSION_REGEX)) {
-				let supportedVersions = this.$cordovaMigrationService.getSupportedVersions().wait();
+				let supportedVersions: string[];
+				let migrationService = this.$project.projectData.Framework === this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova ? this.$cordovaMigrationService : this.$nativeScriptMigrationService;
+				supportedVersions = migrationService.getSupportedVersions().wait();
+
 				if(_.contains(supportedVersions, value)) {
 					return true;
 				}
 
-				this.$errors.fail("The value %s is not a supported version. Supported versions are: %s", value, supportedVersions);
+				this.$errors.failWithoutHelp(`The value ${value} is not a supported version. Supported versions are: ${supportedVersions.join(", ")}`);
 			}
 
-			this.$errors.fail("Version is not in correct format. Correct format is <Major>.<Minor>.<Patch>, for example '3.5.0'.");
+			this.$errors.failWithoutHelp("Version is not in correct format. Correct format is <Major>.<Minor>.<Patch>, for example '3.5.0'.");
 		}).future<boolean>()();
 	}
 }

--- a/lib/hooks/typescript-compilation.ts
+++ b/lib/hooks/typescript-compilation.ts
@@ -10,13 +10,11 @@ fiberBootstrap.run(() => {
 	let project: Project.IProject = $injector.resolve("project");
 	let $fs: IFileSystem = $injector.resolve("fs");
 	project.ensureProject();
-	let projectFiles = $fs.enumerateFilesInDirectorySync(project.getProjectDir().wait());
 
-	let typeScriptFiles = _.filter(projectFiles, file => path.extname(file) === ".ts");
-	let definitionFiles = _.filter(typeScriptFiles, file => _.endsWith(file, ".d.ts"));
-	if(typeScriptFiles.length > definitionFiles.length) { // We need this check because some of non-typescript templates(for example KendoUI.Strip) contain typescript definition files
+	let typeScriptFiles = project.getTypeScriptFiles().wait();
+	if(typeScriptFiles.typeScriptFiles.length > typeScriptFiles.definitionFiles.length) { // We need this check because some of non-typescript templates(for example KendoUI.Strip) contain typescript definition files
 		let typeScriptCompilationService = $injector.resolve("typeScriptCompilationService");
-		typeScriptCompilationService.initialize(typeScriptFiles, definitionFiles);
+		typeScriptCompilationService.initialize(typeScriptFiles.typeScriptFiles, typeScriptFiles.definitionFiles);
 		typeScriptCompilationService.compileAllFiles().wait();
 	}
 });

--- a/lib/project.ts
+++ b/lib/project.ts
@@ -630,6 +630,26 @@ export class Project implements Project.IProject {
 		}).future<void>()();
 	}
 
+	public isTypeScriptProject(): IFuture<boolean> {
+		return ((): boolean => { 
+			let typeScriptFiles = this.getTypeScriptFiles().wait();
+			
+			if(typeScriptFiles.typeScriptFiles.length > typeScriptFiles.definitionFiles.length) { // We need this check because some of non-typescript templates(for example KendoUI.Strip) contain typescript definition files
+				return true;
+			}
+			return false;
+		}).future<boolean>()();
+	}
+
+	public getTypeScriptFiles(): IFuture<Project.ITypeScriptFiles> {
+		return ((): Project.ITypeScriptFiles => {
+			let projectFiles = this.$fs.enumerateFilesInDirectorySync(this.getProjectDir().wait());
+			let typeScriptFiles = _.filter(projectFiles, file => path.extname(file) === ".ts");
+			let definitionFiles = _.filter(typeScriptFiles, file => _.endsWith(file, ".d.ts"));
+			return { definitionFiles: definitionFiles, typeScriptFiles: typeScriptFiles };
+		}).future<Project.ITypeScriptFiles>()();
+	}
+
 	private getProjectRelativePath(fullPath: string, projectDir: string): string {
 		projectDir = path.join(projectDir, path.sep);
 		if (!_.startsWith(fullPath, projectDir)) {

--- a/lib/project/cordova-project.ts
+++ b/lib/project/cordova-project.ts
@@ -42,7 +42,8 @@ export class CordovaProject extends frameworkProjectBaseLib.FrameworkProjectBase
 			updateKendo: true,
 			emulate: true,
 			publish: false,
-			uploadToAppstore: true
+			uploadToAppstore: true,
+			canChangeFrameworkVersion: true
 		};
 	}
 

--- a/lib/project/nativescript-project.ts
+++ b/lib/project/nativescript-project.ts
@@ -36,7 +36,8 @@ export class NativeScriptProject extends frameworkProjectBaseLib.FrameworkProjec
 			updateKendo: false,
 			emulate: true,
 			publish: false,
-			uploadToAppstore: true
+			uploadToAppstore: true,
+			canChangeFrameworkVersion: true
 		};
 	}
 

--- a/lib/project/project.d.ts
+++ b/lib/project/project.d.ts
@@ -43,6 +43,17 @@ declare module Project {
 		 * @param {string} platform Android, iOS or WP8
 		 */
 		checkSdkVersions(platform: string): void;
+		/**
+		* Checks if the project language is TypeScript by enumerating all files and checking if there are at least one TypeScript file (.ts), that is not definition file(.d.ts)
+		* @return {IFuture<boolean>} true when the project contains .ts files and false otherwise.
+		*/
+		isTypeScriptProject(): IFuture<boolean>;
+		
+		/**
+		 * Returns new object, containing all typeScript and all TypeScript definition files.
+		 * @return {IFuture<ITypeScriptFiles>} all typeScript and all TypeScript definition files.
+		 */
+		getTypeScriptFiles(): IFuture<ITypeScriptFiles>
 	}
 
 	interface IFrameworkProject {
@@ -128,5 +139,14 @@ declare module Project {
 		filepath: string;
 		templateFilepath: string;
 		helpText: string;
+	}
+	/**
+	 * Defines an object, containing all TypeScript files (.ts) within project and all TypeScript definition files (.d.ts).
+	 * TypeScript files are all files ending with .ts, so if there are any definition files, they will be placed in both
+	 * typeScript files and definitionFiles collections.
+	 */
+	interface ITypeScriptFiles {
+		definitionFiles: string[],
+		typeScriptFiles: string[]
 	}
 }

--- a/lib/project/web-site-project.ts
+++ b/lib/project/web-site-project.ts
@@ -35,7 +35,8 @@ export class MobileWebSiteProject extends frameworkProjectBaseLib.FrameworkProje
 			updateKendo: false,
 			emulate: false,
 			publish: true,
-			uploadToAppstore: false
+			uploadToAppstore: false,
+			canChangeFrameworkVersion: false
 		};
 	}
 

--- a/lib/resource-loader.ts
+++ b/lib/resource-loader.ts
@@ -34,7 +34,7 @@ class ResourceDownloader implements IResourceDownloader {
 	constructor(private $server: Server.IServer,
 		private $fs: IFileSystem,
 		private $resources: IResourceLoader,
-		private $cordovaMigrationService: ICordovaMigrationService,
+		private $cordovaMigrationService: IFrameworkMigrationService,
 		private $mobileHelper: Mobile.IMobileHelper) { }
 
 	public downloadCordovaJsFiles(): IFuture<void> {

--- a/lib/server-api.d.ts
+++ b/lib/server-api.d.ts
@@ -256,6 +256,9 @@ declare module Server{
 		importProvision(provision: any): IFuture<Server.ProvisionData>;
 		removeProvision(identifier: string): IFuture<void>;
 	}
+	interface INativescriptServiceContract{
+		migrate(solutionName: string, projectName: string, targetVersion: string): IFuture<Server.MigrationResult>;
+	}
 	interface BuildIssueData{
 		Code: string;
 		File: string;
@@ -621,6 +624,7 @@ declare module Server{
 		itmstransporter: Server.IItmstransporterServiceContract;
 		kendo: Server.IKendoServiceContract;
 		mobileprovisions: Server.IMobileprovisionsServiceContract;
+		nativescript: Server.INativescriptServiceContract;
 		build: Server.IBuildServiceContract;
 		projects: Server.IProjectsServiceContract;
 		packages: Server.IPackagesServiceContract;

--- a/lib/server-api.ts
+++ b/lib/server-api.ts
@@ -216,6 +216,13 @@ export class MobileprovisionsService implements Server.IMobileprovisionsServiceC
 		return this.$serviceProxy.call<void>('RemoveProvision', 'DELETE', ['api','mobileprovisions',encodeURI(identifier.replace(/\\/g, '/'))].join('/'), null, null, null);
 	}
 }
+export class NativescriptService implements Server.INativescriptServiceContract{
+	constructor(private $serviceProxy: Server.IServiceProxy){
+	}
+	public migrate(solutionName: string, projectName: string, targetVersion: string): IFuture<Server.MigrationResult>{
+		return this.$serviceProxy.call<Server.MigrationResult>('Migrate', 'POST', ['api','nativescript','migrate',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(projectName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'targetVersion': targetVersion }), 'application/json', null, null);
+	}
+}
 export class BuildService implements Server.IBuildServiceContract{
 	constructor(private $serviceProxy: Server.IServiceProxy){
 	}
@@ -516,6 +523,7 @@ export class ServiceContainer implements Server.IServer{
 	public itmstransporter: Server.IItmstransporterServiceContract = this.$injector.resolve(ItmstransporterService);
 	public kendo: Server.IKendoServiceContract = this.$injector.resolve(KendoService);
 	public mobileprovisions: Server.IMobileprovisionsServiceContract = this.$injector.resolve(MobileprovisionsService);
+	public nativescript: Server.INativescriptServiceContract = this.$injector.resolve(NativescriptService);
 	public build: Server.IBuildServiceContract = this.$injector.resolve(BuildService);
 	public projects: Server.IProjectsServiceContract = this.$injector.resolve(ProjectsService);
 	public packages: Server.IPackagesServiceContract = this.$injector.resolve(PackagesService);

--- a/lib/services/nativescript-migration-service.ts
+++ b/lib/services/nativescript-migration-service.ts
@@ -1,0 +1,149 @@
+///<reference path="../.d.ts"/>
+"use strict";
+
+import Future = require("fibers/future");
+import path = require("path");
+import helpers = require("./../helpers");
+
+export class NativeScriptMigrationService implements IFrameworkMigrationService {
+	private static TYPESCRIPT_ABBREVIATION = "TS";
+	private static JAVASCRIPT_ABBREVIATION = "JS";
+	private static SUPPORTED_LANGUAGES = [NativeScriptMigrationService.JAVASCRIPT_ABBREVIATION, NativeScriptMigrationService.TYPESCRIPT_ABBREVIATION];
+	private static REMOTE_NATIVESCRIPT_MIGRATION_DATA_FILENAME = "NativeScript.json";
+	private nativeScriptResourcesDir: string;
+	private nativeScriptMigrationFile: string;
+	private tnsModulesDirectoryPath: string;
+	private remoteNativeScriptResourcesPath: string;
+
+	private _nativeScriptMigrationData: INativeScriptMigrationData;
+	private get nativeScriptMigrationData(): IFuture<INativeScriptMigrationData> {
+		return ((): INativeScriptMigrationData => {
+			this._nativeScriptMigrationData = this._nativeScriptMigrationData || this.$fs.readJson(this.nativeScriptMigrationFile).wait();
+			return this._nativeScriptMigrationData;
+		}).future<INativeScriptMigrationData>()();
+	}
+
+	constructor(private $fs: IFileSystem,
+		private $server: Server.IServer,
+		private $errors: IErrors,
+		private $logger: ILogger,
+		private $project: Project.IProject,
+		private $resources: IResourceLoader,
+		private $config: IConfiguration,
+		private $httpClient: Server.IHttpClient) {
+			this.nativeScriptResourcesDir = this.$resources.resolvePath("NativeScript");
+			this.tnsModulesDirectoryPath = path.join(this.nativeScriptResourcesDir, "tns_modules");
+			this.remoteNativeScriptResourcesPath = `http://${this.$config.AB_SERVER}/appbuilder/Resources/NativeScript`;
+			this.nativeScriptMigrationFile =  path.join(this.nativeScriptResourcesDir, "nativeScript-migration-data.json");
+		}
+
+	public downloadMigrationData(): IFuture<void> {
+		return (() => {
+			this.$fs.deleteDirectory(this.nativeScriptResourcesDir).wait();
+			this.$fs.createDirectory(this.nativeScriptResourcesDir).wait();
+
+			// Make sure to download this file first, as data from it is used for fileDownloadFutures
+			this.downloadNativeScriptMigrationFile().wait();
+
+			let fileDownloadFutures = _(this.nativeScriptMigrationData.wait().supportedVersions)
+									.map(supportedVersion => _.map(NativeScriptMigrationService.SUPPORTED_LANGUAGES, language => this.downloadTnsModules(language, supportedVersion.version)))
+									.flatten<IFuture<void>>()
+									.value();
+			Future.wait(fileDownloadFutures);
+		}).future<void>()();
+	}
+
+	public getSupportedVersions(): IFuture<string[]> {
+		return ((): string[] => {
+			let migrationData = this.nativeScriptMigrationData.wait();
+			return _.map(migrationData.supportedVersions, supportedVersion => supportedVersion.version);
+		}).future<string[]>()();
+	}
+
+	public getSupportedFrameworks(): IFuture<IFrameworkVersion[]> {
+		return ((): IFrameworkVersion[] => {
+			let migrationData = this.nativeScriptMigrationData.wait();
+			return migrationData.supportedVersions;
+		}).future<IFrameworkVersion[]>()();
+	}
+
+	public getDisplayNameForVersion(version: string): IFuture<string>{
+		return ((): string => {
+			let framework = _.find(this.getSupportedFrameworks().wait(), (fw: IFrameworkVersion) => fw.version === version);
+			if(framework) {
+				return framework.displayName;
+			}
+
+			this.$errors.failWithoutHelp("Cannot find version %s in the supported versions.", version);
+		}).future<string>()();
+	}
+	
+	public onFrameworkVersionChanging(newVersion: string): IFuture<void> {
+		return (() => {
+			let projectDir = this.$project.getProjectDir().wait();
+			let tnsModulesProjectPath = path.join(projectDir, "app", "tns_modules");
+			let backupName = `${tnsModulesProjectPath}.backup`;
+			// Check if current version is supported one. We cannot migrate ObsoleteVersions
+			let currentFrameworkVersion = this.$project.projectData.FrameworkVersion;
+			if(!_.contains(this.getSupportedVersions().wait(), currentFrameworkVersion)) {
+				if(_.contains(this.getObsoleteVersions().wait(), currentFrameworkVersion)) {
+					this.$errors.failWithoutHelp(`You can still build your project, but you cannot migrate from version '${currentFrameworkVersion}'. Consider creating a new NativeScript project.`)
+				} else {
+					this.$errors.failWithoutHelp(`You cannot migrate from version ${currentFrameworkVersion}.`)
+				}
+			}
+
+			try {
+				this.$fs.rename(tnsModulesProjectPath, backupName).wait();
+				this.$fs.createDirectory(tnsModulesProjectPath).wait();
+				let projectType = this.$project.isTypeScriptProject().wait() ? NativeScriptMigrationService.TYPESCRIPT_ABBREVIATION : NativeScriptMigrationService.JAVASCRIPT_ABBREVIATION;
+				let pathToNewTnsModules = path.join(this.tnsModulesDirectoryPath, projectType, this.getFileNameByVersion(newVersion));
+				this.$fs.unzip(pathToNewTnsModules, tnsModulesProjectPath).wait();
+				this.$fs.deleteDirectory(backupName).wait();
+			} catch(err) {
+				this.$logger.trace("Error during migration. Trying to restore previous state.");
+				this.$logger.trace(err);
+				this.$fs.deleteDirectory(tnsModulesProjectPath).wait();
+				this.$fs.rename(backupName, tnsModulesProjectPath).wait();
+				this.$errors.failWithoutHelp("Error during migration. Restored original state of the project.");
+			}
+		}).future<void>()();
+	}
+
+	private downloadNativeScriptMigrationFile(): IFuture<void> {
+		return (() => {
+			let remoteFilePath = `${this.remoteNativeScriptResourcesPath}/${NativeScriptMigrationService.REMOTE_NATIVESCRIPT_MIGRATION_DATA_FILENAME}`;
+			this.downloadResourceFromServer(remoteFilePath, this.nativeScriptMigrationFile).wait();
+		}).future<void>()();
+		
+	}
+
+	private downloadTnsModules(language: string, version: string): IFuture<void> {
+		let fileName = this.getFileNameByVersion(version);
+		let remotePathUrl = `${this.remoteNativeScriptResourcesPath}/tns_modules/${language}/${fileName}`;
+		let filePath = path.join(this.tnsModulesDirectoryPath, language, fileName);
+		return this.downloadResourceFromServer(remotePathUrl, filePath);
+	}
+
+	private downloadResourceFromServer(remotePath: string, targetPath: string): IFuture<void> {
+		return (() => {
+			this.$fs.writeFile(targetPath, "").wait();
+			let file = this.$fs.createWriteStream(targetPath);
+			let fileEnd = this.$fs.futureFromEvent(file, "finish");
+			this.$logger.trace(`Downloading resource from server. Remote path is: '${remotePath}'. TargetPath is: '${targetPath}'.`)
+			this.$httpClient.httpRequest({ url:remotePath, pipeTo: file}).wait();
+			fileEnd.wait();
+		}).future<void>()();
+	}
+	private getFileNameByVersion(version: string): string {
+		return `${version}.zip`;
+	}
+	
+	private getObsoleteVersions(): IFuture<string[]> {
+		return ((): string[] => {
+			let migrationData = this.nativeScriptMigrationData.wait();
+			return _.map(migrationData.obsoleteVersions, obsoleteVersion => obsoleteVersion.version);
+		}).future<string[]>()();
+	}
+}
+$injector.register("nativeScriptMigrationService", NativeScriptMigrationService);

--- a/resources/project-properties-nativescript.json
+++ b/resources/project-properties-nativescript.json
@@ -1,6 +1,7 @@
 {
 	"FrameworkVersion": {
 		"description": "NativeScript framework version.",
-		"range": ["0.3.0", "0.3.1", "0.4.0", "0.4.2", "0.5.0"]
+		"dynamicRange": "#{nativeScriptMigrationService.getSupportedVersions}",
+		"onChanging": "#{nativeScriptMigrationService.onFrameworkVersionChanging}"
 	}
 }


### PR DESCRIPTION
When the project is migrated we have to update tns_modules directory and .abproject with the new version of the project. Add new NativeScriptMigrationService and use it with dynamic call to upgrade the project. In case an error occurs during migration, rollback the migration. In case current project version is not supported, we have to break the migration. Oboslete versions can still be build, but we cannot migrate them.
Download NativeScript migration data during prepublish. Make sure to save supportedVersion in format - DisplayName(string) and Version(string).
You can change the version by using: `$ appbuilder prop set FrameworkVersion 1.0.1` (or 0.10.0) or `$ appbuilder mobileFramework set 1.0.1`
You can list valid versions by using `$ appbuilder prop print FramworkVersion --validValue` or `$ appbuilder mobileFramework`

Add two new interfaces, one for NativeScriptMigration data and one describing Framework versions (with version and display name). They second one is used to unify the way we get supported framework versions in Cordova and NativeScript projects. Until now, we were calling the server to get the Cordova supported framework versions. In fact we can have this information stored in cordova-migration-data.json. Store it there and when we want to check the data, read the file. The same behavior is used for NativeScript.

Implements http://teampulse.telerik.com/view#item/292172