### PR TITLE
Set Description when creating new project

### DIFF
--- a/lib/project/framework-project-base.ts
+++ b/lib/project/framework-project-base.ts
@@ -19,6 +19,7 @@ export class FrameworkProjectBase implements Project.IFrameworkProjectBase {
 
 	public alterPropertiesForNewProjectBase(properties: any, projectName: string): void {
 		properties.DisplayName = projectName;
+		properties.Description = projectName;
 		let appid = this.$options.appid;
 		if(!this.$options.appid) {
 			appid = this.generateDefaultAppId(projectName);

--- a/test/resources/blank-Cordova.abproject
+++ b/test/resources/blank-Cordova.abproject
@@ -4,7 +4,7 @@
     ,"AppIdentifier": "com.telerik.Test"
     ,"DisplayName": "Test"
     ,"Author": ""
-    ,"Description": ""
+    ,"Description": "Test"
     ,"BundleVersion": "1.0"
     ,"AndroidVersionCode": "1"
     ,"iOSDeviceFamily": [

--- a/test/resources/blank-NativeScript.abproject
+++ b/test/resources/blank-NativeScript.abproject
@@ -4,7 +4,7 @@
     ,"AppIdentifier": "com.telerik.Test"
     ,"DisplayName": "Test"
     ,"Author": ""
-    ,"Description": ""
+    ,"Description": "Test"
     ,"BundleVersion": "1.0"
     ,"AndroidVersionCode": "1"
     ,"iOSDeviceFamily": [


### PR DESCRIPTION
When a new Cordova project is created, we have to set its Description to be equal to projectName. This is due to this change: https://github.com/Icenium/Ice/pull/3729
This will fix our unit tests.

> NOTE: The change on the server reflects only Cordova projects, but it will be changed to update NativeScript project's descriptions as well.
