### PR TITLE
Show only supported versions for Cordova

### DIFF
--- a/lib/services/cordova-migration-service.ts
+++ b/lib/services/cordova-migration-service.ts
@@ -124,7 +124,10 @@ export class CordovaMigrationService implements ICordovaMigrationService {
 			_.each(cliSupportedVersions, version => {
 				integratedPlugins[version] = json.IntegratedPlugins[version];
 			});
-			let supportedFrameworkVersion: IFrameworkVersion[] = _.map(json.SupportedFrameworkVersions, fv => { return {displayName: fv.DisplayName, version: this.parseMscorlibVersion(fv.Version)} });
+			let supportedFrameworkVersion: IFrameworkVersion[] = _(json.SupportedFrameworkVersions)
+				.map(fv => { return { displayName: fv.DisplayName, version: this.parseMscorlibVersion(fv.Version)} })
+				.filter(fv => _.contains(cliSupportedVersions, fv.version))
+				.value();
 			this._migrationData = new MigrationData(renamedPlugins, cliSupportedVersions, integratedPlugins, supportedFrameworkVersion);
 			this.$fs.writeJson(this.cordovaMigrationFile, this._migrationData).wait();
 		}).future<void>()();

--- a/test/resources/blank-NativeScript.abproject
+++ b/test/resources/blank-NativeScript.abproject
@@ -12,7 +12,7 @@
         "2"
     ]
     ,"iOSBackgroundMode": []
-    ,"FrameworkVersion": "0.10.0"
+    ,"FrameworkVersion": "1.0.1"
     ,"AndroidPermissions": [
         "android.permission.INTERNET"
      ]


### PR DESCRIPTION
`appbuilder mobileframework` lists the supported versions of Cordova framework. Currently our server supports Cordova 2.7.0 (marked as deprecated), but CLI requires at least 3.0.0. Executing the command `appbuilder mobileframework` insider Cordova project lists version 2.7.0. The problem is in the Cordova migration data file, where we are not filtering versions below 3.0.0. Fix this by filtering the versions and add save in the file only the supported versions.