### PR TITLE
Add 'public' option to AppManager upload command

### DIFF
--- a/docs/man_pages/publishing/appmanager-groups.md
+++ b/docs/man_pages/publishing/appmanager-groups.md
@@ -5,28 +5,18 @@ Usage | Synopsis
 ------|-------
 General | `$ appbuilder appmanager groups`
 
-Lists all available user groups from Telerik AppManager. <% if(isHtml) { %>If you have not managed distribution groups from [Telerik AppManager](https://platform.telerik.com/appmanager), a single 'Default Group' should be provided.
+Lists the distribution groups configured in your Telerik AppManager portal. If you have not configured any distribution groups in <% if(isHtml) { %>[<% } %>Telerik AppManager<% if(isHtml) { %>](https://platform.telerik.com/appmanager)<% } %>, this command returns `Default Group`.<% if(isHtml) { %> This group is created by default for all Telerik AppManager accounts.
 
-For more information about AppManager distribution groups, see [Adding AppManager Distribution Groups](http://docs.telerik.com/platform/appmanager/appmanager-portal/managing-groups/adding-distribution-group).<% } %>
-
-<% if(isConsole) { %>
-<% if(isMobileWebsite) { %>WARNING: This command is not applicable to mobile website projects. To view the complete help for this command, run `$ appbuilder help appmanager groups`<% } %>
-<% if(isNativeScript) { %>WARNING: This command is not applicable to NativeScript projects. To view the complete help for this command, run `$ appbuilder help appmanager groups` <% } %> 
-<% } %>
-<% if(isHtml) { %> 
-
-### Command Limitations
-
-* You cannot run this command on mobile website projects.
-* You cannot run this command on NativeScript projects.
+For more information about AppManager distribution groups, see [Adding Distribution Groups](http://docs.telerik.com/platform/appmanager/appmanager-portal/managing-groups/adding-distribution-group).
 
 ### Related Commands
 
 Command | Description
 ----------|----------
-[appmanager upload](appmanager.html) | Allows interaction with appmanager.
-[appmanager upload android](appmanager-upload-android.html) | Builds the project and uploads the application to Telerik AppManager.
-[appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
+[appmanager upload](appmanager.html) | Lets you work with Telerik AppManager.
+[appmanager upload android](appmanager-upload-android.html) | Builds the project for Android and uploads the application to Telerik AppManager.
+[appmanager upload ios](appmanager-upload-ios.html) | Builds the project for iOS and uploads the application to Telerik AppManager.
+[appmanager upload wp8](appmanager-upload-wp8.html) | Builds the project for Windows Phone and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.

--- a/docs/man_pages/publishing/appmanager-groups.md
+++ b/docs/man_pages/publishing/appmanager-groups.md
@@ -28,7 +28,7 @@ Command | Description
 [appmanager upload android](appmanager-upload-android.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
-[appstore](appstore.html) | Allows interaction with iTunes Connect.
+[appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.
 [certificate](certificate.html) | Lists all configured certificates for code signing iOS and Android applications with index and name.

--- a/docs/man_pages/publishing/appmanager-livesync.md
+++ b/docs/man_pages/publishing/appmanager-livesync.md
@@ -42,7 +42,7 @@ Command | Description
 [appmanager upload](appmanager.html) | Allows interaction with appmanager.
 [appmanager upload android](appmanager-upload-android.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
-[appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
+[appmanager groups](appmanager-groups.html) | Lists the distribution groups configured in your Telerik AppManager portal.
 [appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.

--- a/docs/man_pages/publishing/appmanager-livesync.md
+++ b/docs/man_pages/publishing/appmanager-livesync.md
@@ -43,7 +43,7 @@ Command | Description
 [appmanager upload android](appmanager-upload-android.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
-[appstore](appstore.html) | Allows interaction with iTunes Connect.
+[appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.
 [certificate](certificate.html) | Lists all configured certificates for code signing iOS and Android applications with index and name.

--- a/docs/man_pages/publishing/appmanager-upload-android.md
+++ b/docs/man_pages/publishing/appmanager-upload-android.md
@@ -35,7 +35,7 @@ Command | Description
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
-[appstore](appstore.html) | Allows interaction with iTunes Connect.
+[appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.
 [certificate](certificate.html) | Lists all configured certificates for code signing iOS and Android applications with index and name.

--- a/docs/man_pages/publishing/appmanager-upload-android.md
+++ b/docs/man_pages/publishing/appmanager-upload-android.md
@@ -3,9 +3,10 @@ appmanager upload android
 
 Usage | Synopsis
 ------|-------
-General | `$ appbuilder appmanager upload android [--certificate <Certificate ID>] [--download] [--publish] [--send-email] [--send-push] [--group [<Group ID>]]*`   
+Upload your app without publishing | `$ appbuilder appmanager upload android [--certificate <Certificate ID>] [--download]`
+Upload and publish your app | `$ appbuilder appmanager upload android [--certificate <Certificate ID>] [--download] --publish [--public] [--send-email] [--send-push] [--group <Group ID> [--group <Group ID>]*]`   
 
-Builds the project for Android and uploads the application to Telerik AppManager. <% if(isHtml) { %>After the upload completes, you need to go to your app in [Telerik AppManager](https://platform.telerik.com/appmanager), manually configure it for distribution and publish it.<% } %> 
+Builds the project for Android and uploads the application to Telerik AppManager. <% if(isHtml) { %>If you have not set the `--publish` switch, after the upload completes, you need to go to your app in [Telerik AppManager](https://platform.telerik.com/appmanager), manually configure it for distribution and publish it.<% } %> 
 <% if(isConsole && isMobileWebsite) { %>
 WARNING: This command is not applicable to mobile website projects. To view the complete help for this command, run `$ appbuilder help appmanager upload android`
 <% } %>
@@ -13,10 +14,11 @@ WARNING: This command is not applicable to mobile website projects. To view the 
 ### Options
 * `--certificate` - Sets the certificate that you want to use for code signing your Android app. You can set a certificate by index or name. <% if(isHtml) { %>To list available certificates, run `$ appbuilder certificate`<% } %> 
 * `--download` - If set, downloads the application package to the root of the project.
-* `--publish` - If set, the application package will be automatically published and visible for the members of its distribution groups. To add distribution groups, use `--groups` option.
-* `--send-email` - If set, an email with the link to the app will be send to all eligible users.
-* `--send-push` - If set, push notifications will be send to all registered devices in the groups, assigned to the published app.
-* `--group` - Sets the distribution groups of the application. You can set groups by index or name. <% if(isHtml) { %>To list available groups, run `$ appbuilder appmanager groups`<% } %>
+* `--publish` - If set, after the upload completes, automatically publishes the application package for the members of its distribution groups. You can set additional distribution groups with the `--groups` option.
+* `--public` - If set, the published application will be available for download without requiring AppManager user credentials.
+* `--send-email` - If set, after publishing your app, Telerik AppManager sends an email with the link to the app to the distribution groups, assigned to the published app.<% if(isHtml) { %> This option is applicable only when the `--publish` switch is set.<% } %> 
+* `--send-push` - If set, after publishing your app, Telerik AppManager sends a push notification that a new version is available to all registered devices in the distribution groups, assigned to the published app.<% if(isHtml) { %> This option is applicable only when the `--publish` switch is set.<% } %>
+* `--group` - Assigns additional distribution groups for the application. You can set multiple groups by specifying the `--group` option multiple times. You can set a group by index or name. <% if(isHtml) { %>To list the available groups, run `$ appbuilder appmanager groups`<br/>This option is applicable only when the `--publish` switch is set.<% } %>
 
 ### Attributes
 * `<Certificate ID>` is the index or name of the certificate as listed by `$ appbuilder certificate`.
@@ -26,15 +28,17 @@ WARNING: This command is not applicable to mobile website projects. To view the 
 ### Command Limitations
 
 * You cannot run this command on mobile website projects.
+* The `--send-email`, `--send-push` and `--group` options are applicable only when the `--publish` switch is set.
 
 ### Related Commands
 
 Command | Description
 ----------|----------
-[appmanager upload](appmanager.html) | Allows interaction with appmanager.
+[appmanager upload](appmanager.html) | Lets you work with Telerik AppManager.
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
+[appmanager upload wp8](appmanager-upload-wp8.html) | Builds the project for Windows Phone and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
-[appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
+[appmanager groups](appmanager-groups.html) | Lists the distribution groups configured in your Telerik AppManager portal.
 [appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.

--- a/docs/man_pages/publishing/appmanager-upload-ios.md
+++ b/docs/man_pages/publishing/appmanager-upload-ios.md
@@ -37,7 +37,7 @@ Command | Description
 [appmanager upload android](appmanager-upload-android.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
-[appstore](appstore.html) | Allows interaction with iTunes Connect.
+[appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.
 [certificate](certificate.html) | Lists all configured certificates for code signing iOS and Android applications with index and name.

--- a/docs/man_pages/publishing/appmanager-upload-ios.md
+++ b/docs/man_pages/publishing/appmanager-upload-ios.md
@@ -3,9 +3,10 @@ appmanager upload ios
 
 Usage | Synopsis
 ------|-------
-General | `$ appbuilder appmanager upload ios [--certificate <Certificate ID>] [--provision <Provision ID>] [--download] [--publish] [--send-email] [--send-push] [--group [<Group ID>]]*`
+Upload your app without publishing | `$ appbuilder appmanager upload ios [--certificate <Certificate ID>] [--provision <Provision ID>] [--download]`
+Upload and publish your app |  `$ appbuilder appmanager upload ios [--certificate <Certificate ID>] [--provision <Provision ID>] [--download] --publish [--public] [--send-email] [--send-push] [--group <Group ID> [--group <Group ID>]*]`
 
-Builds the project for iOS and uploads the application to Telerik AppManager. <% if(isHtml) { %>After the upload completes, you need to go to your app in [Telerik AppManager](https://platform.telerik.com/appmanager), manually configure it for distribution and publish it.<% } %> 
+Builds the project for iOS and uploads the application to Telerik AppManager. <% if(isHtml) { %>If you have not set the `--publish` switch, after the upload completes, you need to go to your app in [Telerik AppManager](https://platform.telerik.com/appmanager), manually configure it for distribution and publish it.<% } %> 
 <% if(isConsole && isMobileWebsite) { %>
 WARNING: This command is not applicable to mobile website projects. To view the complete help for this command, run `$ appbuilder help appmanager upload ios`
 <% } %>
@@ -14,10 +15,11 @@ WARNING: This command is not applicable to mobile website projects. To view the 
 * `--certificate` - Sets the certificate that you want to use for code signing your iOS app. You can set a certificate by index or name. <% if(isHtml) { %>To list available certificates, run `$ appbuilder certificate`<% } %> 
 * `--provision` - Sets the provisioning profile that you want to use for code signing your iOS app. You can set a provisioning profile by index or name.<% if(isHtml) { %>To list available provisioning profiles, run `$ appbuilder provision`<% } %>  
 * `--download` - If set, downloads the application package to the root of the project.
-* `--publish` - If set, the application package will be automatically published and visible for the members of its distribution groups. To add distribution groups, use `--groups` option.
-* `--send-email` - If set, an email with the link to the app will be send to all eligible users.
-* `--send-push` - If set, push notifications will be send to all registered devices in the groups, assigned to the published app.
-* `--group` - Sets the distribution groups of the application. You can set groups by index or name. <% if(isHtml) { %>To list available groups, run `$ appbuilder appmanager groups`<% } %>
+* `--publish` - If set, after the upload completes, automatically publishes the application package for the members of its distribution groups. You can set additional distribution groups with the `--groups` option.
+* `--public` - If set, the published application will be available for download without requiring AppManager user credentials.
+* `--send-email` - If set, after publishing your app, Telerik AppManager sends an email with the link to the app to the distribution groups, assigned to the published app.<% if(isHtml) { %> This option is applicable only when the `--publish` switch is set.<% } %> 
+* `--send-push` - If set, after publishing your app, Telerik AppManager sends a push notification that a new version is available to all registered devices in the distribution groups, assigned to the published app.<% if(isHtml) { %> This option is applicable only when the `--publish` switch is set.<% } %>
+* `--group` - Assigns additional distribution groups for the application. You can set multiple groups by specifying the `--group` option multiple times. You can set a group by index or name. <% if(isHtml) { %>To list the available groups, run `$ appbuilder appmanager groups`<br/>This option is applicable only when the `--publish` switch is set.<% } %>
 
 ### Attributes
 * `<Certificate ID>` is the index or name of the certificate as listed by `$ appbuilder certificate`
@@ -28,15 +30,16 @@ WARNING: This command is not applicable to mobile website projects. To view the 
 ### Command Limitations
 
 * You cannot run this command on mobile website projects.
+* The `--send-email`, `--send-push` and `--group` options are applicable only when the `--publish` switch is set.
 
 ### Related Commands
 
 Command | Description
 ----------|----------
-[appmanager upload](appmanager.html) | Allows interaction with appmanager.
-[appmanager upload android](appmanager-upload-android.html) | Builds the project and uploads the application to Telerik AppManager.
+[appmanager upload](appmanager.html) | Lets you work with Telerik AppManager.
+[appmanager upload android](appmanager-upload-android.html) | Builds the project for Android and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
-[appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
+[appmanager groups](appmanager-groups.html) | Lists the distribution groups configured in your Telerik AppManager portal.
 [appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.

--- a/docs/man_pages/publishing/appmanager-upload-wp8.md
+++ b/docs/man_pages/publishing/appmanager-upload-wp8.md
@@ -39,7 +39,7 @@ Command | Description
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
-[appstore](appstore.html) | Allows interaction with iTunes Connect.
+[appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.
 [certificate](certificate.html) | Lists all configured certificates for code signing iOS and Android applications with index and name.

--- a/docs/man_pages/publishing/appmanager-upload-wp8.md
+++ b/docs/man_pages/publishing/appmanager-upload-wp8.md
@@ -3,9 +3,10 @@ appmanager upload wp8
 
 Usage | Synopsis
 ------|-------
-General | `$ appbuilder appmanager upload wp8 [--download] [--publish] [--send-email] [--send-push] [--group [<Group ID>]]*`   
+Upload your app without publishing | `$ appbuilder appmanager upload wp8 [--download]`
+Upload and publish your app | `$ appbuilder appmanager upload wp8 [--download] --publish [--public] [--send-email] [--send-push] [--group <Group ID> [--group <Group ID>]*]`   
 
-Builds the project for Windows Phone and uploads the application to Telerik AppManager. <% if(isHtml) { %>After the upload completes, you need to go to your app in [Telerik AppManager](https://platform.telerik.com/appmanager), manually configure it for distribution and publish it.<% } %> 
+Builds the project for Windows Phone and uploads the application to Telerik AppManager. <% if(isHtml) { %>If you have not set the `--publish` switch, after the upload completes, you need to go to your app in [Telerik AppManager](https://platform.telerik.com/appmanager), manually configure it for distribution and publish it.<% } %> 
 <% if(isConsole) { %>
 <% if(isMobileWebsite) { %>
 WARNING: This command is not applicable to mobile website projects. To view the complete help for this command, run `$ appbuilder help appmanager upload wp8`
@@ -17,10 +18,11 @@ WARNING: This command is not applicable to NativeScript projects. To view the co
 <% if((isConsole && isCordova) || isHtml) { %>
 ### Options
 * `--download` - If set, downloads the application package to the root of the project.
-* `--publish` - If set, the application package will be automatically published and visible for the members of its distribution groups. To add distribution groups, use `--groups` option.
-* `--send-email` - If set, an email with the link to the app will be send to all eligible users.
-* `--send-push` - If set, push notifications will be send to all registered devices in the groups, assigned to the published app.
-* `--group` - Sets the distribution groups of the application. You can set groups by index or name. <% if(isHtml) { %>To list available groups, run `$ appbuilder appmanager groups`<% } %>
+* `--publish` - If set, after the upload completes, automatically publishes the application package for the members of its distribution groups. You can set additional distribution groups with the `--groups` option.
+* `--public` - If set, the published application will be available for download without requiring AppManager user credentials.
+* `--send-email` - If set, after publishing your app, Telerik AppManager sends an email with the link to the app to the distribution groups, assigned to the published app.<% if(isHtml) { %> This option is applicable only when the `--publish` switch is set.<% } %> 
+* `--send-push` - If set, after publishing your app, Telerik AppManager sends a push notification that a new version is available to all registered devices in the distribution groups, assigned to the published app.<% if(isHtml) { %> This option is applicable only when the `--publish` switch is set.<% } %>
+* `--group` - Assigns additional distribution groups for the application. You can set multiple groups by specifying the `--group` option multiple times. You can set a group by index or name. <% if(isHtml) { %>To list the available groups, run `$ appbuilder appmanager groups`<br/>This option is applicable only when the `--publish` switch is set.<% } %>
 
 ### Attributes
 * `<Group ID>` is the index or name of the group as listed by `$ appbuilder appmanager groups`.
@@ -30,6 +32,7 @@ WARNING: This command is not applicable to NativeScript projects. To view the co
 
 * You cannot run this command on mobile website projects.
 * You cannot run this command on NativeScript projects.
+* The `--send-email`, `--send-push` and `--group` options are applicable only when the `--publish` switch is set.
 
 ### Related Commands
 
@@ -38,7 +41,10 @@ Command | Description
 [appmanager upload](appmanager.html) | Allows interaction with appmanager.
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
-[appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
+[appmanager upload](appmanager.html) | Lets you work with Telerik AppManager.
+[appmanager upload ios](appmanager-upload-ios.html) | Builds the project for iOS and uploads the application to Telerik AppManager.
+[appmanager livesync](appmanager-livesync.html) | Publishes a new update of your application in Telerik AppManager.
+[appmanager groups](appmanager-groups.html) | Lists the distribution groups configured in your Telerik AppManager portal.
 [appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.

--- a/docs/man_pages/publishing/appmanager-upload.md
+++ b/docs/man_pages/publishing/appmanager-upload.md
@@ -30,7 +30,7 @@ Command | Description
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
-[appstore](appstore.html) | Allows interaction with iTunes Connect.
+[appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.
 [certificate](certificate.html) | Lists all configured certificates for code signing iOS and Android applications with index and name.

--- a/docs/man_pages/publishing/appmanager-upload.md
+++ b/docs/man_pages/publishing/appmanager-upload.md
@@ -29,7 +29,7 @@ Command | Description
 [appmanager upload android](appmanager-upload-android.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
-[appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
+[appmanager groups](appmanager-groups.html) | Lists the distribution groups configured in your Telerik AppManager portal.
 [appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.

--- a/docs/man_pages/publishing/appmanager.md
+++ b/docs/man_pages/publishing/appmanager.md
@@ -32,7 +32,7 @@ Command | Description
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
-[appstore](appstore.html) | Allows interaction with iTunes Connect.
+[appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.
 [certificate](certificate.html) | Lists all configured certificates for code signing iOS and Android applications with index and name.

--- a/docs/man_pages/publishing/appmanager.md
+++ b/docs/man_pages/publishing/appmanager.md
@@ -31,7 +31,7 @@ Command | Description
 [appmanager upload android](appmanager-upload-android.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
-[appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
+[appmanager groups](appmanager-groups.html) | Lists the distribution groups configured in your Telerik AppManager portal.
 [appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.

--- a/docs/man_pages/publishing/appstore-list.md
+++ b/docs/man_pages/publishing/appstore-list.md
@@ -20,7 +20,7 @@ Command | Description
 [appmanager upload android](appmanager-upload-android.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
-[appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
+[appmanager groups](appmanager-groups.html) | Lists the distribution groups configured in your Telerik AppManager portal.
 [appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.
 [certificate](certificate.html) | Lists all configured certificates for code signing iOS and Android applications with index and name.

--- a/docs/man_pages/publishing/appstore-list.md
+++ b/docs/man_pages/publishing/appstore-list.md
@@ -21,7 +21,7 @@ Command | Description
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
-[appstore](appstore.html) | Allows interaction with iTunes Connect.
+[appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.
 [certificate](certificate.html) | Lists all configured certificates for code signing iOS and Android applications with index and name.
 [certificate create-self-signed](certificate-create-self-signed.html) | Creates a self-signed certificate for code signing Android applications.

--- a/docs/man_pages/publishing/appstore-upload.md
+++ b/docs/man_pages/publishing/appstore-upload.md
@@ -35,7 +35,7 @@ Command | Description
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
-[appstore](appstore.html) | Allows interaction with iTunes Connect.
+[appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [certificate](certificate.html) | Lists all configured certificates for code signing iOS and Android applications with index and name.
 [certificate create-self-signed](certificate-create-self-signed.html) | Creates a self-signed certificate for code signing Android applications.

--- a/docs/man_pages/publishing/appstore-upload.md
+++ b/docs/man_pages/publishing/appstore-upload.md
@@ -34,7 +34,7 @@ Command | Description
 [appmanager upload android](appmanager-upload-android.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
-[appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
+[appmanager groups](appmanager-groups.html) | Lists the distribution groups configured in your Telerik AppManager portal.
 [appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [certificate](certificate.html) | Lists all configured certificates for code signing iOS and Android applications with index and name.

--- a/docs/man_pages/publishing/appstore.md
+++ b/docs/man_pages/publishing/appstore.md
@@ -21,7 +21,7 @@ Command | Description
 [appmanager upload android](appmanager-upload-android.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
-[appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
+[appmanager groups](appmanager-groups.html) | Lists the distribution groups configured in your Telerik AppManager portal.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.
 [certificate](certificate.html) | Lists all configured certificates for code signing iOS and Android applications with index and name.

--- a/docs/man_pages/publishing/certificate-create-self-signed.md
+++ b/docs/man_pages/publishing/certificate-create-self-signed.md
@@ -25,7 +25,7 @@ Command | Description
 [appmanager upload android](appmanager-upload-android.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
-[appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
+[appmanager groups](appmanager-groups.html) | Lists the distribution groups configured in your Telerik AppManager portal.
 [appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.

--- a/docs/man_pages/publishing/certificate-create-self-signed.md
+++ b/docs/man_pages/publishing/certificate-create-self-signed.md
@@ -26,7 +26,7 @@ Command | Description
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
-[appstore](appstore.html) | Allows interaction with iTunes Connect.
+[appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.
 [certificate](certificate.html) | Lists all configured certificates for code signing iOS and Android applications with index and name.

--- a/docs/man_pages/publishing/certificate-export.md
+++ b/docs/man_pages/publishing/certificate-export.md
@@ -23,7 +23,7 @@ Command | Description
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
-[appstore](appstore.html) | Allows interaction with iTunes Connect.
+[appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.
 [certificate](certificate.html) | Lists all configured certificates for code signing iOS and Android applications with index and name.

--- a/docs/man_pages/publishing/certificate-export.md
+++ b/docs/man_pages/publishing/certificate-export.md
@@ -22,7 +22,7 @@ Command | Description
 [appmanager upload android](appmanager-upload-android.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
-[appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
+[appmanager groups](appmanager-groups.html) | Lists the distribution groups configured in your Telerik AppManager portal.
 [appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.

--- a/docs/man_pages/publishing/certificate-import.md
+++ b/docs/man_pages/publishing/certificate-import.md
@@ -20,7 +20,7 @@ Command | Description
 [appmanager upload android](appmanager-upload-android.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
-[appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
+[appmanager groups](appmanager-groups.html) | Lists the distribution groups configured in your Telerik AppManager portal.
 [appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.

--- a/docs/man_pages/publishing/certificate-import.md
+++ b/docs/man_pages/publishing/certificate-import.md
@@ -21,7 +21,7 @@ Command | Description
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
-[appstore](appstore.html) | Allows interaction with iTunes Connect.
+[appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.
 [certificate](certificate.html) | Lists all configured certificates for code signing iOS and Android applications with index and name.

--- a/docs/man_pages/publishing/certificate-remove.md
+++ b/docs/man_pages/publishing/certificate-remove.md
@@ -21,7 +21,7 @@ Command | Description
 [appmanager upload android](appmanager-upload-android.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
-[appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
+[appmanager groups](appmanager-groups.html) | Lists the distribution groups configured in your Telerik AppManager portal.
 [appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.

--- a/docs/man_pages/publishing/certificate-remove.md
+++ b/docs/man_pages/publishing/certificate-remove.md
@@ -22,7 +22,7 @@ Command | Description
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
-[appstore](appstore.html) | Allows interaction with iTunes Connect.
+[appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.
 [certificate](certificate.html) | Lists all configured certificates for code signing iOS and Android applications with index and name.

--- a/docs/man_pages/publishing/certificate-request-create.md
+++ b/docs/man_pages/publishing/certificate-request-create.md
@@ -21,7 +21,7 @@ Command | Description
 [appmanager upload android](appmanager-upload-android.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
-[appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
+[appmanager groups](appmanager-groups.html) | Lists the distribution groups configured in your Telerik AppManager portal.
 [appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.

--- a/docs/man_pages/publishing/certificate-request-create.md
+++ b/docs/man_pages/publishing/certificate-request-create.md
@@ -22,7 +22,7 @@ Command | Description
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
-[appstore](appstore.html) | Allows interaction with iTunes Connect.
+[appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.
 [certificate](certificate.html) | Lists all configured certificates for code signing iOS and Android applications with index and name.

--- a/docs/man_pages/publishing/certificate-request-download.md
+++ b/docs/man_pages/publishing/certificate-request-download.md
@@ -23,7 +23,7 @@ Command | Description
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
-[appstore](appstore.html) | Allows interaction with iTunes Connect.
+[appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.
 [certificate](certificate.html) | Lists all configured certificates for code signing iOS and Android applications with index and name.

--- a/docs/man_pages/publishing/certificate-request-download.md
+++ b/docs/man_pages/publishing/certificate-request-download.md
@@ -22,7 +22,7 @@ Command | Description
 [appmanager upload android](appmanager-upload-android.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
-[appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
+[appmanager groups](appmanager-groups.html) | Lists the distribution groups configured in your Telerik AppManager portal.
 [appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.

--- a/docs/man_pages/publishing/certificate-request-remove.md
+++ b/docs/man_pages/publishing/certificate-request-remove.md
@@ -19,7 +19,7 @@ Command | Description
 [appmanager upload android](appmanager-upload-android.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
-[appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
+[appmanager groups](appmanager-groups.html) | Lists the distribution groups configured in your Telerik AppManager portal.
 [appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.

--- a/docs/man_pages/publishing/certificate-request-remove.md
+++ b/docs/man_pages/publishing/certificate-request-remove.md
@@ -20,7 +20,7 @@ Command | Description
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
-[appstore](appstore.html) | Allows interaction with iTunes Connect.
+[appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.
 [certificate](certificate.html) | Lists all configured certificates for code signing iOS and Android applications with index and name.

--- a/docs/man_pages/publishing/certificate-request.md
+++ b/docs/man_pages/publishing/certificate-request.md
@@ -24,7 +24,7 @@ Command | Description
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
-[appstore](appstore.html) | Allows interaction with iTunes Connect.
+[appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.
 [certificate](certificate.html) | Lists all configured certificates for code signing iOS and Android applications with index and name.

--- a/docs/man_pages/publishing/certificate-request.md
+++ b/docs/man_pages/publishing/certificate-request.md
@@ -23,7 +23,7 @@ Command | Description
 [appmanager upload android](appmanager-upload-android.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
-[appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
+[appmanager groups](appmanager-groups.html) | Lists the distribution groups configured in your Telerik AppManager portal.
 [appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.

--- a/docs/man_pages/publishing/certificate.md
+++ b/docs/man_pages/publishing/certificate.md
@@ -24,7 +24,7 @@ Command | Description
 [appmanager upload android](appmanager-upload-android.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
-[appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
+[appmanager groups](appmanager-groups.html) | Lists the distribution groups configured in your Telerik AppManager portal.
 [appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.

--- a/docs/man_pages/publishing/certificate.md
+++ b/docs/man_pages/publishing/certificate.md
@@ -25,7 +25,7 @@ Command | Description
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
-[appstore](appstore.html) | Allows interaction with iTunes Connect.
+[appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.
 [certificate create-self-signed](certificate-create-self-signed.html) | Creates a self-signed certificate for code signing Android applications.

--- a/docs/man_pages/publishing/provision-import.md
+++ b/docs/man_pages/publishing/provision-import.md
@@ -19,7 +19,7 @@ Command | Description
 [appmanager upload android](appmanager-upload-android.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
-[appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
+[appmanager groups](appmanager-groups.html) | Lists the distribution groups configured in your Telerik AppManager portal.
 [appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.

--- a/docs/man_pages/publishing/provision-import.md
+++ b/docs/man_pages/publishing/provision-import.md
@@ -20,7 +20,7 @@ Command | Description
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
-[appstore](appstore.html) | Allows interaction with iTunes Connect.
+[appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.
 [certificate](certificate.html) | Lists all configured certificates for code signing iOS and Android applications with index and name.

--- a/docs/man_pages/publishing/provision-remove.md
+++ b/docs/man_pages/publishing/provision-remove.md
@@ -20,7 +20,7 @@ Command | Description
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
-[appstore](appstore.html) | Allows interaction with iTunes Connect.
+[appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.
 [certificate](certificate.html) | Lists all configured certificates for code signing iOS and Android applications with index and name.

--- a/docs/man_pages/publishing/provision.md
+++ b/docs/man_pages/publishing/provision.md
@@ -27,7 +27,7 @@ Command | Description
 [appmanager upload ios](appmanager-upload-ios.html) | Builds the project and uploads the application to Telerik AppManager.
 [appmanager livesync](appmanager-livesync.html) | Publish a new update of your application in Telerik AppManager.
 [appmanager groups](appmanager-groups.html) | Lists all available user groups from Telerik AppManager.
-[appstore](appstore.html) | Allows interaction with iTunes Connect.
+[appstore](appstore.html) | Lets you work with your iTunes Connect account.
 [appstore list](appstore-list.html) | Lists all application records in iTunes Connect.
 [appstore upload](appstore-upload.html) | Builds the project and uploads the application to iTunes Connect.
 [certificate](certificate.html) | Lists all configured certificates for code signing iOS and Android applications with index and name.

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -657,6 +657,7 @@ interface IOptions extends ICommonOptions {
 	verified: boolean;
 	latest: boolean;
 	publish: boolean;
+	public: boolean;
 	sendPush: boolean;
 	sendEmail: boolean;
 	group: string[];

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -31,6 +31,7 @@ export class Options extends commonOptionsLibPath.OptionsBase {
 			latest: { type: OptionType.Boolean },
 			verified: { type: OptionType.Boolean },
 			publish: { type: OptionType.Boolean },
+			public: { type: OptionType.Boolean },
 			sendPush: { type: OptionType.Boolean },
 			sendEmail: { type: OptionType.Boolean },
 			group: { type: OptionType.Array },

--- a/lib/server-api.d.ts
+++ b/lib/server-api.d.ts
@@ -442,8 +442,13 @@ declare module Server{
 		Name: string;
 		Id: string;
 	}
+	interface UploadedAppData{
+		InstallUrl: string;
+		Id: string;
+	}
 	interface PublishSettings{
 		IsPublished: boolean;
+		IsPublic: boolean;
 		NotifyByPush: boolean;
 		NotifyByEmail: boolean;
 		Groups: string[];
@@ -459,7 +464,7 @@ declare module Server{
 	interface ITamServiceContract{
 		verifyStoreCreated(): IFuture<void>;
 		getGroups(): IFuture<Server.TamGroupData[]>;
-		uploadApplication(solutionName: string, projectName: string, relativePackagePath: string, settings: Server.PublishSettings): IFuture<void>;
+		uploadApplication(solutionName: string, projectName: string, relativePackagePath: string, settings: Server.PublishSettings): IFuture<Server.UploadedAppData>;
 		uploadPatch(solutionName: string, projectName: string, patchData: Server.PatchData): IFuture<void>;
 		getAccountStatus(): IFuture<Server.FeatureStatus>;
 	}

--- a/lib/server-api.ts
+++ b/lib/server-api.ts
@@ -374,8 +374,8 @@ export class TamService implements Server.ITamServiceContract{
 	public getGroups(): IFuture<Server.TamGroupData[]>{
 		return this.$serviceProxy.call<Server.TamGroupData[]>('GetGroups', 'GET', ['api','tam','groups'].join('/'), 'application/json', null, null);
 	}
-	public uploadApplication(solutionName: string, projectName: string, relativePackagePath: string, settings: Server.PublishSettings): IFuture<void>{
-		return this.$serviceProxy.call<void>('UploadApplication', 'POST', ['api','tam','applications',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(projectName.replace(/\\/g, '/')),encodeURI(relativePackagePath.replace(/\\/g, '/'))].join('/'), null, [{name: 'settings', value: JSON.stringify(settings), contentType: 'application/json'}], null);
+	public uploadApplication(solutionName: string, projectName: string, relativePackagePath: string, settings: Server.PublishSettings): IFuture<Server.UploadedAppData>{
+		return this.$serviceProxy.call<Server.UploadedAppData>('UploadApplication', 'POST', ['api','tam','applications',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(projectName.replace(/\\/g, '/')),encodeURI(relativePackagePath.replace(/\\/g, '/'))].join('/'), 'application/json', [{name: 'settings', value: JSON.stringify(settings), contentType: 'application/json'}], null);
 	}
 	public uploadPatch(solutionName: string, projectName: string, patchData: Server.PatchData): IFuture<void>{
 		return this.$serviceProxy.call<void>('UploadPatch', 'POST', ['api','tam',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(projectName.replace(/\\/g, '/')),'patches'].join('/'), null, [{name: 'patchData', value: JSON.stringify(patchData), contentType: 'application/json'}], null);

--- a/lib/services/appmanager-service.ts
+++ b/lib/services/appmanager-service.ts
@@ -55,6 +55,7 @@ class AppManagerService implements IAppManagerService {
 
 			let publishSettings: Server.PublishSettings = {
 				IsPublished: this.$options.publish,
+				IsPublic: this.$options.public,
 				NotifyByPush: this.$options.sendPush,
 				NotifyByEmail: this.$options.sendEmail,
 				Groups: []
@@ -62,6 +63,10 @@ class AppManagerService implements IAppManagerService {
 
 			if (this.$options.group) {
 				publishSettings.Groups = this.findGroups(this.$options.group).wait();
+			}
+
+			if(!this.$options.publish && this.$options.public) {
+				this.$logger.warn("You have not set the --publish switch. Your app will become publicly available after you publish it manually in Telerik AppManager.");
 			}
 
 			if(!this.$options.publish && this.$options.sendEmail) {
@@ -72,8 +77,13 @@ class AppManagerService implements IAppManagerService {
 				this.$logger.warn("You have not set the --publish switch. Your users will not receive a push notification.");
 			}
 
-			this.$server.tam.uploadApplication(projectName, projectName, projectPath, publishSettings).wait();
+			let uploadedAppData: Server.UploadedAppData = this.$server.tam.uploadApplication(projectName, projectName, projectPath, publishSettings).wait();
 			this.$logger.info("Successfully uploaded package.");
+
+			if(this.$options.publish && this.$options.public){
+				this.$logger.info("Your app has been published successfully and is now available to download and install from: %s", uploadedAppData.InstallUrl);
+			}
+
 			this.openAppManagerStore();
 		}).future<void>()();
 	}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "appbuilder",
   "preferGlobal": true,
-  "version": "2.9.3",
+  "version": "2.10.0",
   "author": "Telerik <support@telerik.com>",
   "description": "command line interface to Telerik AppBuilder",
   "bin": {


### PR DESCRIPTION
AppManager now supports public app distribution. 

Public option is suitable if your application already has built-in authentication mechanism or if you want to grant anonymous access to your app.AppManager user credentials will not be required to download the app.

Use private option (public not set) if you want AppManager to restrict the access to your application. AppManager user credentials will be required to download the app (the usual flow, only users in the groups can download the app)