### PR TITLE
Update CorePlugins in all config files

### DIFF
--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -214,6 +214,19 @@ interface IProjectPropertiesService {
 	 * @throws Error when the modified data cannot be validated with the respective JSON schema. In this case the modification is not saved to the file. 
 	 */
 	removeProjectProperty(dataToBeUpdated: IProjectData, property: string, projectData?: IProjectData) : IProjectData;
+
+	/**
+	 * Updates CorePlugins property value in all configurations.
+	 * @param {IProjectData} projectData The project data commonly written in .abproject.
+	 * @param {IDictionary<IProjectData>} configurationSpecificData Dictionary with all configuration specific data. 
+	 * @param {string} mode Type of operation which should be executed with the property.
+	 * @param {Array<any>} newValue The new value that should be used for CorePlugins modification.
+	 * @param {string[]} configurationsSpecifiedByUser The configurations which the user want to modify.
+	 * @return {IFuture<void>}
+	 * @throws Error when the modified data cannot be validated with the respective JSON schema. In this case the modification is not saved to the file.
+	 * @throws Error when the different CorePlugins are enabled in projectData and any configuration specific data.
+	 */
+	updateCorePlugins(projectData: IProjectData, configurationSpecificData: IDictionary<IProjectData>, mode: string, newValue: Array<any>, configurationsSpecifiedByUser: string[]): IFuture<void>
 }
 
 interface IServerConfigurationData {

--- a/lib/project.ts
+++ b/lib/project.ts
@@ -325,32 +325,21 @@ export class Project implements Project.IProject {
 	public updateProjectPropertyAndSave(mode: string, propertyName: string, propertyValues: string[]): IFuture<void> {
 		return (() => {
 			this.ensureProject();
-			let debugConfigName = this.$projectConstants.DEBUG_CONFIGURATION_NAME;
-			let releaseConfigName = this.$projectConstants.RELEASE_CONFIGURATION_NAME;
+			let projectConfigurations = _.keys(this.configurationSpecificData);
 			let normalizedPropertyName = this.$projectPropertiesService.normalizePropertyName(propertyName, this.projectData);
-
 			if(normalizedPropertyName === this.$projectConstants.APPIDENTIFIER_PROPERTY_NAME) {
 				this.$jsonSchemaValidator.validatePropertyUsingBuildSchema(normalizedPropertyName, propertyValues[0]);
 			}
 
-			let configurations = this.getConfigurationsSpecifiedByUser();
-			if(configurations.length) {
-				if(normalizedPropertyName !== this.$projectConstants.CORE_PLUGINS_PROPERTY_NAME){
-					this.$errors.failWithoutHelp("You cannot use this property in specific configuration.");
-				}
-
-				_.each(configurations, configuration => {
-					this.$projectPropertiesService.updateProjectProperty(this.projectData, this.configurationSpecificData[configuration], mode, normalizedPropertyName, propertyValues).wait();
-					this.printProjectProperty(normalizedPropertyName, configuration).wait();
-					this.saveProject(this.getProjectDir().wait(), [configuration]).wait();
-				});
+			if(normalizedPropertyName === this.$projectConstants.CORE_PLUGINS_PROPERTY_NAME) {
+				this.$projectPropertiesService.updateCorePlugins(this.projectData, this.configurationSpecificData, mode, propertyValues, this.getConfigurationsSpecifiedByUser()).wait();
 			} else {
 				this.$projectPropertiesService.updateProjectProperty(this.projectData, undefined, mode, normalizedPropertyName, propertyValues).wait();
 				_.each(this.configurationSpecificData, configSpecificData => this.$projectPropertiesService.removeProjectProperty(configSpecificData, normalizedPropertyName, this.projectData));
-				
-				this.printProjectProperty(normalizedPropertyName).wait();
-				this.saveProject(this.getProjectDir().wait()).wait();
 			}
+			
+			this.saveProject(this.getProjectDir().wait(), projectConfigurations).wait();
+			this.printProjectProperty(normalizedPropertyName).wait();
 		}).future<void>()();
 	}
 
@@ -374,6 +363,7 @@ export class Project implements Project.IProject {
 					} else {
 						// '$ appbuilder prop print <PropName>' called inside project dir
 						if(_.has(mergedProjectData, normalizedPropertyName)) {
+							this.$logger.write(`The value of ${normalizedPropertyName} is: `);
 							this.$logger.out(mergedProjectData[normalizedPropertyName]);
 						} else if(this.hasConfigurationSpecificDataForProperty(normalizedPropertyName)) {
 							this.printConfigurationSpecificDataForProperty(normalizedPropertyName);

--- a/lib/services/project-properties-service.ts
+++ b/lib/services/project-properties-service.ts
@@ -61,22 +61,20 @@ export class ProjectPropertiesService implements IProjectPropertiesService {
 		return dataToBeUpdated;
 	}
 
-	private validateProjectData(projectData: IProjectData, configurationSpecificData?: IProjectData): void {
-		let dataToValidate = Object.create(null);
-		_.extend(dataToValidate, projectData);
-		if(configurationSpecificData) {
-			_.extend(dataToValidate, configurationSpecificData);
-		}
-		this.$jsonSchemaValidator.validate(dataToValidate);
-	}
-
-	private notifyPropertyChanged(framework: string, propertyName: string, propertyValue: any): IFuture<void> {
+	public updateCorePlugins(projectData: IProjectData, configurationSpecificData: IDictionary<IProjectData>, mode: string, newValue: Array<any>, configurationsSpecifiedByUser: string[]): IFuture<void> {
 		return ((): void => {
-			let projectSchema = this.$jsonSchemaValidator.tryResolveValidationSchema(framework);
-			let propData = projectSchema[propertyName];
-			if(propData && propData.onChanging) {
-				this.$injector.dynamicCall(propData.onChanging, [propertyValue]).wait();
+			this.moveCorePluginsToConfigurationSpecificData(projectData, configurationSpecificData);
+
+			if(configurationsSpecifiedByUser.length === 0) {
+				configurationsSpecifiedByUser = _.keys(configurationSpecificData);
 			}
+
+			_.each(configurationsSpecifiedByUser, configuration => {
+				this.updateProjectProperty(projectData, configurationSpecificData[configuration], mode, this.$projectConstants.CORE_PLUGINS_PROPERTY_NAME, newValue).wait();
+			});
+
+			// check if CorePlugins in both configurations are the same
+			this.tryMovingCorePluginsToProjectData(projectData, configurationSpecificData);
 		}).future<void>()();
 	}
 
@@ -258,6 +256,79 @@ export class ProjectPropertiesService implements IProjectPropertiesService {
 
 			return properties;
 		}).future<any>()();
+	}
+
+	private notifyPropertyChanged(framework: string, propertyName: string, propertyValue: any): IFuture<void> {
+		return ((): void => {
+			let projectSchema = this.$jsonSchemaValidator.tryResolveValidationSchema(framework);
+			let propData = projectSchema[propertyName];
+			if(propData && propData.onChanging) {
+				this.$injector.dynamicCall(propData.onChanging, [propertyValue]).wait();
+			}
+		}).future<void>()();
+	}
+
+	private moveCorePluginsToConfigurationSpecificData(projectData: IProjectData, configurationSpecificData:  IDictionary<IProjectData>): void {
+		if(projectData.CorePlugins && projectData.CorePlugins.length > 0) {
+			_.each(configurationSpecificData, (configurationData: IProjectData, configuration: string) => {
+				this.$logger.trace(`Move CorePlugins from project data to '${configuration}' configuration.`);
+				if(configurationData.CorePlugins && configurationData.CorePlugins.length > 0 && _.difference(configurationData.CorePlugins, projectData.CorePlugins).length !== 0) {
+					this.$errors.failWithoutHelp(`CorePlugins are defined in both '${this.$projectConstants.PROJECT_FILE}' and '.${configuration}${this.$projectConstants.PROJECT_FILE}'. Remove them from one of the files and try again.`);
+				}
+				configurationData.CorePlugins = projectData.CorePlugins;
+			});
+		}
+		delete projectData.CorePlugins;
+	}
+
+	private validateAllProjectData(projectData: IProjectData, configurationSpecificData:IDictionary<IProjectData>): void {
+		let projectConfigurations = _.keys(configurationSpecificData);
+		_.each(projectConfigurations, configuration => {
+			this.validateProjectData(projectData, configurationSpecificData[configuration]);
+		});
+
+		this.validateProjectData(projectData);
+	}
+
+	private validateProjectData(projectData: IProjectData, configurationSpecificData?: IProjectData): void {
+		let dataToValidate = Object.create(null);
+		_.extend(dataToValidate, projectData);
+		if(configurationSpecificData) {
+			_.extend(dataToValidate, configurationSpecificData);
+		}
+		this.$jsonSchemaValidator.validate(dataToValidate);
+	}
+
+	private tryMovingCorePluginsToProjectData(projectData: IProjectData, configurationSpecificData: IDictionary<IProjectData>): void {
+		if(this.shouldMoveCorePluginsToProjectData(configurationSpecificData)) {
+			this.$logger.trace("Moving CorePlugins from configuration specific data to project data.");
+			projectData.CorePlugins = _(configurationSpecificData)
+									.values()
+									.first()
+									.CorePlugins;
+			_.each(configurationSpecificData, (configurationData: IProjectData, configuration: string) => {
+				this.$logger.trace(`Removing property CorePlugins from '${configuration}' configuration.`)
+				delete configurationData.CorePlugins;
+			});
+
+			this.validateAllProjectData(projectData, configurationSpecificData);
+		}
+	}
+
+	private shouldMoveCorePluginsToProjectData(configurationSpecificData: IDictionary<IProjectData>): boolean {
+		let corePluginsInConfigs = _.map(configurationSpecificData, configData => configData.CorePlugins);
+		let corePluginsLenghtsInConfigs = _(corePluginsInConfigs)
+					.map(c => c.length)
+					.uniq()
+					.value();
+		let differencesBetweenPluginsInConfigs = _.difference.apply(null, corePluginsInConfigs);
+		// Check if the lengths of core plugins in all configuration files are the same.
+		if(corePluginsLenghtsInConfigs.length === 1 && differencesBetweenPluginsInConfigs.length === 0) {
+			this.$logger.trace("No difference between CorePlugins in each configuration detected. CorePlugins should be moved to project data.");
+			return true;
+		}
+		this.$logger.trace("There's difference between CorePlugins in configuration files. CorePlugins cannot be moved to project data.");
+		return false;
 	}
 }
 $injector.register("projectPropertiesService", ProjectPropertiesService);

--- a/test/project.ts
+++ b/test/project.ts
@@ -680,6 +680,263 @@ describe("project unit tests", () => {
 			}, configSpecificData);
 		});
 	});
+	describe("updateCorePlugins", () => {
+		describe("modifies CorePlugins in configuration specific data, when it is specified", () => {
+			let configSpecificData: IDictionary<any>;
+			let projectData: IProjectData;
+			
+			beforeEach(() => {
+				projectData = getProjectData();
+				configSpecificData = {
+					debug: {
+						CorePlugins: ["org.apache.cordova.battery-status",
+										"org.apache.cordova.camera",
+										"org.apache.cordova.contacts"]
+					},
+					release: {
+						CorePlugins: ["org.apache.cordova.battery-status",
+										"org.apache.cordova.camera",
+										"org.apache.cordova.geolocation"]
+					}
+				};
+			});
+
+			it("adds CorePlugins to configuration specfic data when it is specified", () => {
+				projectProperties.updateCorePlugins(projectData, configSpecificData, "add", ["org.apache.cordova.file"], ["debug"]).wait();
+				assert.deepEqual(undefined, projectData.CorePlugins);
+	
+				assert.deepEqual(["org.apache.cordova.battery-status",
+	 								"org.apache.cordova.camera",
+	 								"org.apache.cordova.contacts",
+									"org.apache.cordova.file"],
+								configSpecificData["debug"].CorePlugins);
+	
+				assert.deepEqual(["org.apache.cordova.battery-status",
+	 								"org.apache.cordova.camera",
+	 								"org.apache.cordova.geolocation"],
+								configSpecificData["release"].CorePlugins);
+			});
+
+			it("removes CorePlugin from debug configuration data when it is specified", () => {
+				projectProperties.updateCorePlugins(projectData, configSpecificData, "del", ["org.apache.cordova.camera"], ["debug"]).wait();
+				assert.deepEqual(undefined, projectData.CorePlugins);
+	
+				assert.deepEqual(["org.apache.cordova.battery-status",
+	 								"org.apache.cordova.contacts"],
+								configSpecificData["debug"].CorePlugins);
+	
+				assert.deepEqual(["org.apache.cordova.battery-status",
+	 								"org.apache.cordova.camera",
+	 								"org.apache.cordova.geolocation"],
+								configSpecificData["release"].CorePlugins);
+			});
+
+			it("sets CorePlugins to debug configuration when it is specified", () => {
+				projectProperties.updateCorePlugins(projectData, configSpecificData, "set", ["org.apache.cordova.file"], ["debug"]).wait();
+				assert.deepEqual(undefined, projectData.CorePlugins);
+	
+				assert.deepEqual(["org.apache.cordova.file"],
+								configSpecificData["debug"].CorePlugins);
+	
+				assert.deepEqual(["org.apache.cordova.battery-status",
+	 								"org.apache.cordova.camera",
+	 								"org.apache.cordova.geolocation"],
+								configSpecificData["release"].CorePlugins);
+			});
+		});
+
+		describe("moves CorePlugins to projectData when they are the same in config files", () => {
+			it("after prop add", () => {
+				let configSpecificData: IDictionary<any> = {
+						debug: {
+							CorePlugins: ["org.apache.cordova.battery-status"]
+						},
+						release: {
+							CorePlugins: ["org.apache.cordova.battery-status",
+											"org.apache.cordova.geolocation"]
+						}
+				};
+				let projectData = getProjectData();
+				projectProperties.updateCorePlugins(projectData, configSpecificData, "add", ["org.apache.cordova.geolocation"], ["debug"]).wait();
+				assert.deepEqual(["org.apache.cordova.battery-status",
+									"org.apache.cordova.geolocation"],
+								projectData.CorePlugins);
+	
+				assert.deepEqual(undefined, configSpecificData["debug"].CorePlugins);
+				assert.deepEqual(undefined, configSpecificData["release"].CorePlugins);
+			});
+
+			it("after prop set", () => {
+				let configSpecificData: IDictionary<any> = {
+						debug: {
+							CorePlugins: ["org.apache.cordova.battery-status"]
+						},
+						release: {
+							CorePlugins: ["org.apache.cordova.geolocation"]
+						}
+				};
+				let projectData = getProjectData();
+				projectProperties.updateCorePlugins(projectData, configSpecificData, "set", ["org.apache.cordova.geolocation"], ["debug"]).wait();
+				assert.deepEqual(["org.apache.cordova.geolocation"], projectData.CorePlugins);
+	
+				assert.deepEqual(undefined, configSpecificData["debug"].CorePlugins);
+				assert.deepEqual(undefined, configSpecificData["release"].CorePlugins);
+			});
+			
+			it("after prop rm", () => {
+				let configSpecificData: IDictionary<any> = {
+						debug: {
+							CorePlugins: ["org.apache.cordova.battery-status",
+											"org.apache.cordova.geolocation"]
+						},
+						release: {
+							CorePlugins: ["org.apache.cordova.geolocation"]
+						}
+				};
+				let projectData = getProjectData();
+				projectProperties.updateCorePlugins(projectData, configSpecificData, "del", ["org.apache.cordova.battery-status"], ["debug"]).wait();
+				assert.deepEqual(["org.apache.cordova.geolocation"], projectData.CorePlugins);
+	
+				assert.deepEqual(undefined, configSpecificData["debug"].CorePlugins);
+				assert.deepEqual(undefined, configSpecificData["release"].CorePlugins);
+			});
+		});
+		
+		describe("moves CorePlugins to config specific data when it is modified", () => {
+			let configSpecificData: IDictionary<any>;
+			let projectData: IProjectData;
+			beforeEach(() => {
+				projectData = getProjectData();
+				projectData.CorePlugins = ["org.apache.cordova.battery-status"];
+				configSpecificData = {
+					debug: {},
+					release: {}
+				};
+			});
+
+			it("after prop add", () => {
+				projectProperties.updateCorePlugins(projectData, configSpecificData, "add", ["org.apache.cordova.geolocation"], ["debug"]).wait();
+				assert.deepEqual(undefined,	projectData.CorePlugins);
+				assert.deepEqual(["org.apache.cordova.battery-status",
+									"org.apache.cordova.geolocation"], configSpecificData["debug"].CorePlugins);
+				assert.deepEqual(["org.apache.cordova.battery-status"], configSpecificData["release"].CorePlugins);
+			});
+
+			it("after prop set", () => {
+				projectProperties.updateCorePlugins(projectData, configSpecificData, "set", ["org.apache.cordova.geolocation"], ["debug"]).wait();
+				assert.deepEqual(undefined, projectData.CorePlugins);
+	
+				assert.deepEqual(["org.apache.cordova.geolocation"], configSpecificData["debug"].CorePlugins);
+				assert.deepEqual(["org.apache.cordova.battery-status"], configSpecificData["release"].CorePlugins);
+			});
+			
+			it("after prop rm", () => {
+				projectProperties.updateCorePlugins(projectData, configSpecificData, "del", ["org.apache.cordova.battery-status"], ["debug"]).wait();
+				assert.deepEqual(undefined, projectData.CorePlugins);
+	
+				assert.deepEqual([], configSpecificData["debug"].CorePlugins);
+				assert.deepEqual(["org.apache.cordova.battery-status"], configSpecificData["release"].CorePlugins);
+			});
+		});
+		
+		describe("modifies CorePlugins in configuration specific data, even if it is NOT specified when CorePlugins are different in the configurations", () => {
+			let configSpecificData: IDictionary<any>;
+			let projectData: IProjectData;
+			
+			beforeEach(() => {
+				projectData = getProjectData();
+				configSpecificData = {
+					debug: {
+						CorePlugins: ["org.apache.cordova.battery-status",
+										"org.apache.cordova.camera",
+										"org.apache.cordova.contacts"]
+					},
+					release: {
+						CorePlugins: ["org.apache.cordova.battery-status",
+										"org.apache.cordova.camera",
+										"org.apache.cordova.geolocation"]
+					}
+				};
+			});
+
+			it("adds CorePlugins to configuration specfic data", () => {
+				projectProperties.updateCorePlugins(projectData, configSpecificData, "add", ["org.apache.cordova.file"], []).wait();
+				assert.deepEqual(undefined, projectData.CorePlugins);
+	
+				assert.deepEqual(["org.apache.cordova.battery-status",
+	 								"org.apache.cordova.camera",
+	 								"org.apache.cordova.contacts",
+									"org.apache.cordova.file"],
+								configSpecificData["debug"].CorePlugins);
+	
+				assert.deepEqual(["org.apache.cordova.battery-status",
+	 								"org.apache.cordova.camera",
+	 								"org.apache.cordova.geolocation",
+									"org.apache.cordova.file"],
+								configSpecificData["release"].CorePlugins);
+			});
+
+			it("removes CorePlugin from all configurations", () => {
+				projectProperties.updateCorePlugins(projectData, configSpecificData, "del", ["org.apache.cordova.camera"], []).wait();
+				assert.deepEqual(undefined, projectData.CorePlugins);
+	
+				assert.deepEqual(["org.apache.cordova.battery-status",
+	 								"org.apache.cordova.contacts"],
+								configSpecificData["debug"].CorePlugins);
+	
+				assert.deepEqual(["org.apache.cordova.battery-status",
+	 								"org.apache.cordova.geolocation"],
+								configSpecificData["release"].CorePlugins);
+			});
+
+			it("sets CorePlugins to both configurations when it is specified", () => {
+				projectProperties.updateCorePlugins(projectData, configSpecificData, "set", ["org.apache.cordova.file"], []).wait();
+				assert.deepEqual(["org.apache.cordova.file"], projectData.CorePlugins);
+	
+				assert.deepEqual(undefined,
+								configSpecificData["debug"].CorePlugins);
+	
+				assert.deepEqual(undefined,
+								configSpecificData["release"].CorePlugins);
+			});
+		});
+		
+		it("throws exception when different CorePlugins are part of both .abproject and any config specific file", () => {
+			let projectData = getProjectData();
+			projectData.CorePlugins = ["org.apache.cordova.battery-status"]
+			configSpecificData = {
+				debug: {
+					CorePlugins: ["org.apache.cordova.contacts"]
+				},
+				release: {
+					CorePlugins: ["org.apache.cordova.camera"]
+				}
+			};
+			assert.throws(() => projectProperties.updateCorePlugins(projectData, configSpecificData, "add", ["org.apache.cordova.file"], []).wait());
+			assert.deepEqual(["org.apache.cordova.battery-status"], projectData.CorePlugins);
+			assert.deepEqual(["org.apache.cordova.contacts"], configSpecificData["debug"].CorePlugins);
+			assert.deepEqual(["org.apache.cordova.camera"], configSpecificData["release"].CorePlugins);
+		});
+
+		it("does not throw exception when the same CorePlugins are part of both .abproject and any config specific file", () => {
+			let projectData = getProjectData();
+			projectData.CorePlugins = ["org.apache.cordova.battery-status"]
+			configSpecificData = {
+				debug: {
+					CorePlugins: ["org.apache.cordova.battery-status"]
+				},
+				release: {
+					CorePlugins: ["org.apache.cordova.battery-status"]
+				}
+			};
+			projectProperties.updateCorePlugins(projectData, configSpecificData, "add", ["org.apache.cordova.file"], []).wait();
+			assert.deepEqual(["org.apache.cordova.battery-status",
+								"org.apache.cordova.file"],
+							projectData.CorePlugins);
+			assert.deepEqual(undefined, configSpecificData["debug"].CorePlugins);
+			assert.deepEqual(undefined, configSpecificData["release"].CorePlugins);
+		});
+	});
 });
 
 describe("project unit tests (canonical paths)", () => {


### PR DESCRIPTION
Old PR -> https://github.com/Icenium/icenium-cli/pull/1068

CorePlugins could be part of .debug.abproject, .release.abproject and .abproject. Make sure `prop` related commands will do the same as our UI Clients:
* When CorePlugins in debug and release are the same, move them to .abproject.
* When a plugin is added/removed for only one configuration, move all plugins to configuration specific files and modify the one, specified by user.
* When prop set is used without configuration flag (--debug or --release), remove the CorePlugins from configuration specific files and set them in .abproject.
* When Core Plugins are different in each configuration and user had not specified configuration flag for operation, execute it on all available configs.
* When different plugins are available in .abproject and any configuration specific file, throw error as we are not sure which of the operations to execute.

Add unit tests for this behavior.
http://teampulse.telerik.com/view#item/285810