### PR TITLE
Add LivePatch to available plugins

### DIFF
--- a/lib/services/cordova-plugins.ts
+++ b/lib/services/cordova-plugins.ts
@@ -22,6 +22,23 @@ export class CordovaPluginsService implements ICordovaPluginsService {
 		this.configure();
 		return this.search(keywords);
 	}
+	
+	// HACK: Information for this plugin is never returned from the server, so keep it here.
+	// TODO: Remove the LivePatch HACK when the server returns correct results.
+	private livePatchPlugin: any = {
+		"Name": "Telerik AppManager LiveSync",
+		"Identifier": "com.telerik.LivePatch",
+		"Version": "1.0.0",
+		"Description": "This plugin adds Telerik AppManager LiveSync functionality",
+		"Url": "",
+		"Assets": [],
+		"Platforms": [
+			"Android",
+			"iOS",
+			"WP8"
+		],
+		"Variables": []
+	};
 
 	public search(keywords: string[]): IBasicPluginInformation[] {
 		let future = new Future<IBasicPluginInformation[]>();
@@ -102,8 +119,11 @@ export class CordovaPluginsService implements ICordovaPluginsService {
 	}
 
 	public getAvailablePlugins(): IFuture<Server.CordovaPluginData[]> {
-		this.$project.ensureCordovaProject();
-		return this.$server.cordova.getPlugins(this.$project.projectData.FrameworkVersion);
+		return ((): Server.CordovaPluginData[] => {
+			this.$project.ensureCordovaProject();
+			// TODO: Remove the LivePatch HACK when the server returns correct results.
+			return this.$server.cordova.getPlugins(this.$project.projectData.FrameworkVersion).wait().concat([<Server.CordovaPluginData>this.livePatchPlugin])
+		}).future<Server.CordovaPluginData[]>()();
 	}
 
 	public createPluginData(plugin: Server.CordovaPluginData): IPlugin[] {

--- a/test/plugins-service.ts
+++ b/test/plugins-service.ts
@@ -451,7 +451,9 @@ describe("plugins-service", () => {
 		let availablePlugins = service.getAvailablePlugins();
 
 		// Only cordovaPlugins are counted, availableMarketplacePlugins cannot fetched, but we still receive correct data for other plugins
-		assert.equal(2, availablePlugins.length);
+		// assert.equal(2, availablePlugins.length);
+		// HACK - when LivePatch plugin is working correctly, remove the line below and use the assert above.
+		assert.equal(3, availablePlugins.length);
 	});
 	describe("isPluginInstalled returns correct results", () => {
 		let installedMarketplacePlugins = [{


### PR DESCRIPTION
Currently our server never returns information about LivePatch plugin. As a workaround - add the information in getAvailablePlugins. This way you can add the plugin. In case you try publishing LivePatch (`$ appbuilder appmanager livesync android` for example), the server will check if you are able to use this feature and will fail in case you are not.

Remove the HACK when server is working correctly.
http://teampulse.telerik.com/view#item/292698