### PR TITLE
Add LivePatch to available plugins

### DIFF
--- a/test/plugins-service.ts
+++ b/test/plugins-service.ts
@@ -451,7 +451,9 @@ describe("plugins-service", () => {
 		let availablePlugins = service.getAvailablePlugins();
 
 		// Only cordovaPlugins are counted, availableMarketplacePlugins cannot fetched, but we still receive correct data for other plugins
-		assert.equal(2, availablePlugins.length);
+		// assert.equal(2, availablePlugins.length);
+		// HACK - when LivePatch plugin is working correctly, remove the line below and use the assert above.
+		assert.equal(3, availablePlugins.length);
 	});
 	describe("isPluginInstalled returns correct results", () => {
 		let installedMarketplacePlugins = [{


### PR DESCRIPTION
Currently our server never returns information about LivePatch plugin. As a workaround - add the information in getAvailablePlugins. This way you can add the plugin. In case you try publishing LivePatch (`$ appbuilder appmanager livesync android` for example), the server will check if you are able to use this feature and will fail in case you are not.

Remove the HACK when server is working correctly.
http://teampulse.telerik.com/view#item/292698