### PR TITLE
Show more descriptive error for obsolete {N} projects

### DIFF
--- a/lib/commands/framework-versions/print-versions.ts
+++ b/lib/commands/framework-versions/print-versions.ts
@@ -13,8 +13,8 @@ export class PrintFrameworkVersionsCommand implements ICommand {
 		return (() => {
 			let migrationService = this.$project.projectData.Framework === this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova ? this.$cordovaMigrationService : this.$nativeScriptMigrationService;
 			let supportedVersions: IFrameworkVersion[] = migrationService.getSupportedFrameworks().wait();
-
-			this.$logger.info("Your project is using version " + migrationService.getDisplayNameForVersion(this.$project.projectData.FrameworkVersion).wait());
+			let projectFrameworkVersion = migrationService.getDisplayNameForVersion(this.$project.projectData.FrameworkVersion).wait();
+			this.$logger.info(`Your project is using version ${projectFrameworkVersion}`);
 
 			this.$logger.info("Supported versions are: ");
 			_.each(supportedVersions, (sv: IFrameworkVersion) => {


### PR DESCRIPTION
When project is using obsolete NativeScript version and user tries to execute **$ appbuilder mobileframework** inside project dir, an error message is shown: "Cannot find version <v> in the supported versions." Change this to explanation that the current version is obsolete and the project cannot be migrated, but we can still build it.

Fixes http://teampulse.telerik.com/view#item/292936