### PR TITLE
Get all supported sb commands from .schema.json instead calling screenBuilder's listGenerators endpoint

### DIFF
--- a/config/dependency-config.json
+++ b/config/dependency-config.json
@@ -4,6 +4,7 @@
 	},
 	"generators": [{
 		"name": "generator-kendo-ui-mobile",
-		"version": "0.0.7"
+		"version": "0.0.7",
+		"alias": "H"
 	}]
 }

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -341,7 +341,9 @@ interface IDependencyConfig {
 
 interface IAppScaffoldingConfig extends IDependencyConfig { }
 
-interface IGeneratorConfig extends IDependencyConfig { }
+interface IGeneratorConfig extends IDependencyConfig {
+	alias: string; 
+}
 
 interface IExtensionsServiceBase {
 	getExtensionVersion(packageName: string): string;


### PR DESCRIPTION
Fixes http://teampulse.telerik.com/view#item/292965