### PR TITLE
Add LivePatch plugin to release only

### DIFF
--- a/lib/services/plugins-service.ts
+++ b/lib/services/plugins-service.ts
@@ -144,7 +144,7 @@ export class PluginsService implements IPluginsService {
 				if(this.$project.configurations.length === 1 && _.contains(this.$project.configurations, forbiddenConfig)) {
 					this.$errors.failWithoutHelp(`You cannot enable plugin ${pluginName} in ${forbiddenConfig} configuration.`);
 				}
-				configurations = [forbiddenConfig];
+				configurations = _.without(this.$project.configurations, forbiddenConfig);
 			}
 			
 			this.configurePlugin(pluginName, version, configurations).wait();


### PR DESCRIPTION
Currently LivePatch plugin is added to debug config instead of release. This is due to mistake in the code, which is setting configurations variable to be the forbiddenConfig. Fix this code.