### PR TITLE
Migrate App_Resources directory in {N} projects

### DIFF
--- a/lib/project/project-constants.ts
+++ b/lib/project/project-constants.ts
@@ -11,6 +11,8 @@ export class ProjectConstants implements Project.IProjectConstants {
 	public CORDOVA_PLUGIN_VARIABLES_PROPERTY_NAME = "CordovaPluginVariables";
 	public APPIDENTIFIER_PROPERTY_NAME = "AppIdentifier";
 	public EXPERIMENTAL_TAG = "Experimental";
+	public NATIVESCRIPT_APP_RESOURCES_DIR_NAME = "App_Resources";
+	public NATIVESCRIPT_APP_DIR_NAME = "app";
 
 	public TARGET_FRAMEWORK_IDENTIFIERS = {
 		Cordova: "Cordova",

--- a/lib/project/project.d.ts
+++ b/lib/project/project.d.ts
@@ -126,6 +126,8 @@ declare module Project {
 		TARGET_FRAMEWORK_IDENTIFIERS: ITargetFrameworkIdentifiers;
 		APPIDENTIFIER_PROPERTY_NAME: string;
 		EXPERIMENTAL_TAG: string;
+		NATIVESCRIPT_APP_RESOURCES_DIR_NAME: string;
+		NATIVESCRIPT_APP_DIR_NAME: string;
 	}
 
 	interface ITargetFrameworkIdentifiers {


### PR DESCRIPTION
App_Resources directory of NativeScript projects should be part of app directory. In 0.10.0, this directory was on the same level as app directory. Make sure to move it under app directory during project migration.
When checking all platform assets, make sure to update correct App_Resources directory. If the project is not 0.9.0 and ther's no App_Resources directory inside app directory, check for existing of App_Resources in the upper level and modify the App_Resoureces there.

Part of http://teampulse.telerik.com/view#item/293294