### PR TITLE
Use correct App_Resources

### DIFF
--- a/lib/commands/dev/prepackage.ts
+++ b/lib/commands/dev/prepackage.ts
@@ -26,8 +26,6 @@ export class PrePackageCommand implements ICommand {
 			this.$templatesService.downloadItemTemplates().wait();
 			this.$logger.info("Downloading project schemas.");
 			this.$jsonSchemaLoader.downloadSchemas().wait();
-			this.$logger.info("Unpacking app resources.");
-			this.$templatesService.unpackAppResources().wait();
 			this.$logger.info("Downloading Cordova migration data.");
 			this.$cordovaMigrationService.downloadMigrationData().wait();
 			// Cordova files have to be downloaded after cordova migration data so we know which cordova versions we support
@@ -35,6 +33,8 @@ export class PrePackageCommand implements ICommand {
 			this.$resourceDownloader.downloadCordovaJsFiles().wait();
 			this.$logger.info("Downloading NativeScript migration data.")
 			this.$nativeScriptMigrationService.downloadMigrationData().wait();
+			this.$logger.info("Unpacking app resources.");
+			this.$templatesService.unpackAppResources().wait();
 			this.$serviceProxy.setShouldAuthenticate(true);
 		}).future<void>()();
 	}

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -310,11 +310,11 @@ interface IPackageDownloadViewModel {
 }
 
 interface IResourceLoader {
-	appResourcesDir: string;
 	resolvePath(path: string): string;
 	openFile(path: string): any;
 	readJson(path: string): IFuture<any>;
 	buildCordovaJsFilePath(version: string, platform: string): string;
+	getPathToAppResources(framework: string): string;
 }
 
 interface IResourceDownloader {

--- a/lib/project/cordova-project.ts
+++ b/lib/project/cordova-project.ts
@@ -141,11 +141,11 @@ export class CordovaProject extends frameworkProjectBaseLib.FrameworkProjectBase
 			let platforms = this.$mobileHelper.platformNames;
 			_.each(platforms, (platform: string) => this.ensureCordovaJs(platform, projectDir, frameworkVersion).wait());
 
-			let appResourcesDir = this.$resources.appResourcesDir;
+			let appResourcesDir = this.$resources.getPathToAppResources(this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova);
 			let appResourceFiles = this.$fs.enumerateFilesInDirectorySync(appResourcesDir);
 			appResourceFiles.forEach((appResourceFile) => {
 				let relativePath = path.relative(appResourcesDir, appResourceFile);
-				let targetFilePath = path.join(projectDir, relativePath);
+				let targetFilePath = path.join(projectDir, this.$projectConstants.APP_RESOURCES_DIR_NAME, relativePath);
 				this.$logger.trace("Checking app resources: %s must match %s", appResourceFile, targetFilePath);
 				if (!this.$fs.exists(targetFilePath).wait()) {
 					this.printAssetUpdateMessage();

--- a/lib/project/nativescript-project.ts
+++ b/lib/project/nativescript-project.ts
@@ -105,18 +105,18 @@ export class NativeScriptProject extends frameworkProjectBaseLib.FrameworkProjec
 
 	public ensureAllPlatformAssets(projectDir: string, frameworkVersion: string): IFuture<void> {
 		return (() => {
-			let appResourcesDir = this.$resources.appResourcesDir;
+			let appResourcesDir = this.$resources.getPathToAppResources(this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript);
 			let appResourceFiles = this.$fs.enumerateFilesInDirectorySync(appResourcesDir);
 			// In 0.10.0 original template, App_Resources directory is not included in app directory.
 			let appResourcesHolderDirectory = path.join(projectDir, this.$projectConstants.NATIVESCRIPT_APP_DIR_NAME);
 			if(semver.eq(frameworkVersion, "0.9.0")  
-				|| (!this.$fs.exists(path.join(appResourcesHolderDirectory, this.$projectConstants.NATIVESCRIPT_APP_RESOURCES_DIR_NAME)).wait() 
-				&& this.$fs.exists(path.join(projectDir, this.$projectConstants.NATIVESCRIPT_APP_RESOURCES_DIR_NAME)).wait())) {
+				|| (!this.$fs.exists(path.join(appResourcesHolderDirectory, this.$projectConstants.APP_RESOURCES_DIR_NAME)).wait() 
+				&& this.$fs.exists(path.join(projectDir, this.$projectConstants.APP_RESOURCES_DIR_NAME)).wait())) {
 				appResourcesHolderDirectory = projectDir;
 			}
 			appResourceFiles.forEach((appResourceFile) => {
 				let relativePath = path.relative(appResourcesDir, appResourceFile);
-				let targetFilePath = path.join(appResourcesHolderDirectory, relativePath);
+				let targetFilePath = path.join(appResourcesHolderDirectory,this.$projectConstants.APP_RESOURCES_DIR_NAME, relativePath);
 				this.$logger.trace("Checking app resources: %s must match %s", appResourceFile, targetFilePath);
 				if (!this.$fs.exists(targetFilePath).wait()) {
 					this.printAssetUpdateMessage();

--- a/lib/project/project-constants.ts
+++ b/lib/project/project-constants.ts
@@ -11,7 +11,7 @@ export class ProjectConstants implements Project.IProjectConstants {
 	public CORDOVA_PLUGIN_VARIABLES_PROPERTY_NAME = "CordovaPluginVariables";
 	public APPIDENTIFIER_PROPERTY_NAME = "AppIdentifier";
 	public EXPERIMENTAL_TAG = "Experimental";
-	public NATIVESCRIPT_APP_RESOURCES_DIR_NAME = "App_Resources";
+	public APP_RESOURCES_DIR_NAME = "App_Resources";
 	public NATIVESCRIPT_APP_DIR_NAME = "app";
 
 	public TARGET_FRAMEWORK_IDENTIFIERS = {

--- a/lib/project/project.d.ts
+++ b/lib/project/project.d.ts
@@ -126,7 +126,7 @@ declare module Project {
 		TARGET_FRAMEWORK_IDENTIFIERS: ITargetFrameworkIdentifiers;
 		APPIDENTIFIER_PROPERTY_NAME: string;
 		EXPERIMENTAL_TAG: string;
-		NATIVESCRIPT_APP_RESOURCES_DIR_NAME: string;
+		APP_RESOURCES_DIR_NAME: string;
 		NATIVESCRIPT_APP_DIR_NAME: string;
 	}
 

--- a/lib/resource-loader.ts
+++ b/lib/resource-loader.ts
@@ -6,7 +6,8 @@ import helpers = require("./helpers");
 import util = require("util");
 
 export class ResourceLoader implements IResourceLoader {
-	constructor(private $fs: IFileSystem) { }
+	constructor(private $fs: IFileSystem, 
+		private $projectConstants: Project.IProjectConstants) { }
 
 	resolvePath(resourcePath: string): string {
 		return path.join(__dirname, "../resources", resourcePath);
@@ -20,12 +21,12 @@ export class ResourceLoader implements IResourceLoader {
 		return this.$fs.readJson(this.resolvePath(resourcePath));
 	}
 
-	public get appResourcesDir(): string {
-		return this.resolvePath("App_Resources");
-	}
-
 	public buildCordovaJsFilePath(version: string, platform: string): string {
 		return path.join(this.resolvePath("Cordova"), version, util.format("cordova.%s.js", platform).toLowerCase());
+	}
+
+	public getPathToAppResources(framework: string) {
+		return path.join(this.resolvePath(framework), this.$projectConstants.APP_RESOURCES_DIR_NAME);
 	}
 }
 $injector.register("resources", ResourceLoader);

--- a/lib/services/nativescript-migration-service.ts
+++ b/lib/services/nativescript-migration-service.ts
@@ -89,8 +89,8 @@ export class NativeScriptMigrationService implements IFrameworkMigrationService 
 
 			let projectDir = this.$project.getProjectDir().wait();
 			let tnsModulesProjectPath = path.join(projectDir, this.$projectConstants.NATIVESCRIPT_APP_DIR_NAME, "tns_modules");
-			let appResourcesRequiredPath = path.join(projectDir, this.$projectConstants.NATIVESCRIPT_APP_DIR_NAME, this.$projectConstants.NATIVESCRIPT_APP_RESOURCES_DIR_NAME);
-			let appResourcesObsoletePath = path.join(projectDir, this.$projectConstants.NATIVESCRIPT_APP_RESOURCES_DIR_NAME);
+			let appResourcesRequiredPath = path.join(projectDir, this.$projectConstants.NATIVESCRIPT_APP_DIR_NAME, this.$projectConstants.APP_RESOURCES_DIR_NAME);
+			let appResourcesObsoletePath = path.join(projectDir, this.$projectConstants.APP_RESOURCES_DIR_NAME);
 			let backupName = `${tnsModulesProjectPath}.backup`;
 			let shouldRollBackAppResources = false;
 			// Check if current version is supported one. We cannot migrate ObsoleteVersions


### PR DESCRIPTION
Currently we have App_Resources in our resources folder. It is created on dev-prepackage command by extracting App_Resources directory from Cordova.Blank template. Now we need App_Resources for NativeScript projects. With the new templates, the App_Resources folder is under app folder of {N} templates. In order to handle this, I've modified templatesService unpackAppResources to extract cordova and ns App_Resources.
Move App_Resources folder to be under Cordova and NativeScript directories. Also with the old code, we had App_Resources/App_Resources/Android..., now we have Cordova/App_Resources/Android...
Change the name of NATIVESCRIPT_APP_RESOURCES_DIR_NAME to APP_RESOURCES_DIR_NAME as this name is not specific for NativeScript projects.
Replace appResourcesDir property of resources with two new properties - cordovaAppResourcesDir and nativeScriptAppResourcesDir.
Inside prepackage, move the logic for unpacking app resources to be at the end as cordova migration data and nativescript migration data are deleting the directory where app resources are extracted.
Fixes http://teampulse.telerik.com/view#item/293506