### PR TITLE
Filter plugins not supported for projects Cordova version

### DIFF
--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -519,14 +519,6 @@ interface IPluginsService {
 	 * @return {IBasicPluginInformation}            Basic information about the plugin
 	 */
 	getPluginBasicInformation(pluginName: string): IBasicPluginInformation;
-	/**
-	 * Checks wether a plugin is supported for a specific framework version
-	 * @param  {string}  plugin           The name of the plugin
-	 * @param  {string}  version          The plugin's version
-	 * @param  {string}  frameworkVersion The framework's version
-	 * @return {boolean}                  true if the plugin is supported, false otherwise
-	 */
-	isPluginSupported(plugin: string, version: string, frameworkVersion: string): boolean;
 }
 
 interface IPlugin {

--- a/lib/services/cordova-migration-service.ts
+++ b/lib/services/cordova-migration-service.ts
@@ -215,7 +215,7 @@ export class CordovaMigrationService implements ICordovaMigrationService {
 
 			this.$logger.info("Migrating to Cordova version %s", versionDisplayName);
 			let oldVersion = this.$project.projectData.FrameworkVersion;
-
+			let availablePlugins = this.$pluginsService.getAvailablePlugins();
 			this.invalidMarketplacePlugins = _(this.$project.configurations)
 				.map(configuration => <string[]>this.$project.getProperty("CorePlugins", configuration))
 				.union()
@@ -223,7 +223,7 @@ export class CordovaMigrationService implements ICordovaMigrationService {
 				.unique()
 				.filter((plugin: string) => {
 					let pluginBasicInformation = this.$pluginsService.getPluginBasicInformation(plugin);
-					return _.contains(plugin, '@') && !this.$pluginsService.isPluginSupported(pluginBasicInformation.name, pluginBasicInformation.version, newVersion)
+					return _.contains(plugin, '@') && !_.any(availablePlugins, pl => pl.data.Identifier.toLowerCase() === pluginBasicInformation.name.toLowerCase() && pl.data.Version === pluginBasicInformation.version)
 				})
 				.value();
 				

--- a/test/cordova-migration-service.ts
+++ b/test/cordova-migration-service.ts
@@ -21,7 +21,7 @@ testInjector.register("pluginsService", {
 			version: '1.0.0'
 		}
 	},
-	getPluginVersions: (pluginName: string) => {
+	getPluginVersions: (plugin: IPlugin) => {
 		return [{
 			name: '1.0.0',
 			value: '1.0.0',
@@ -29,7 +29,7 @@ testInjector.register("pluginsService", {
 		}]
 	},
 	removePlugin: (pluginName: string) => {return (() => { }).future<void>()() },
-	isPluginSupported: (plugin: string, version: string, migrationVersion: string) => { return true;}
+	isPluginSupported: (plugin: IPlugin, version: string, migrationVersion: string) => { return true;}
 });
 testInjector.register("project", {});
 testInjector.register("projectConstants", {});

--- a/test/project.ts
+++ b/test/project.ts
@@ -128,12 +128,22 @@ function createTestInjector(): IInjector {
 				version: '1.0.0'
 			}
 		},
-		getPluginVersions: (pluginName: string) => {
+		getPluginVersions: (plugin: IPlugin) => {
 			return [{
 				name: '1.0.0',
 				value: '1.0.0',
 				minCordova: '3.0.0'
 			}]
+		},
+		getAvailablePlugins: () => {
+			return [
+				{
+					data: {
+					Identifier: "Name",
+					Version: '1.0.0'
+					}
+				}
+			]
 		}
 	});
 	testInjector.register("projectPropertiesService", projectPropertiesService.ProjectPropertiesService);


### PR DESCRIPTION
In case plugin requires Cordova 3.5.0, but current project targets 3.2.0, adding such plugin will break the build. Prevent this by removing such plugins from getAvailablePlugins result. This will also hide the plugin from `appbuilder plugin --available` output.
Add unit tests for the result of getAvailablePlugins and for livePatch plugin.

Fixes http://teampulse.telerik.com/view#item/292103