### PR TITLE
Fix test command in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "appbuilder": "./bin/appbuilder.js"
   },
   "scripts": {
-    "test": "node_modules/.bin/istanbul cover node_modules/.bin/_mocha -- --ui mocha-fibers --recursive --reporter spec-xunit-file --require test/test-bootstrap.js --timeout 15000 test/",
+    "test": "node_modules/.bin/istanbul cover node_modules/mocha/bin/_mocha -- --ui mocha-fibers --recursive --reporter spec-xunit-file --require test/test-bootstrap.js --timeout 15000 test/",
     "postinstall": "node postinstall.js",
     "preuninstall": "node preuninstall.js",
     "prepublish": "node prepublish.js"


### PR DESCRIPTION
Currently our unit tests cannot be started on Windows as the .bin/_mocha file is shell script and some of its symbols cannot be resolved. Replace the call with call to javascript file.