### PR TITLE
Pass CordovaPluginVariables on the command line

### DIFF
--- a/docs/man_pages/lib-management/plugin-add.md
+++ b/docs/man_pages/lib-management/plugin-add.md
@@ -8,6 +8,8 @@ Add plugins | `$ appbuilder plugin add <Name or ID> [--debug] [--release]`
 Add a specific version of a plugin | `$ appbuilder plugin add <Name or ID>@<Version> [--debug] [--release]`
 Add latest version of a plugin | `$ appbuilder plugin add <Name or ID> --latest [--debug] [--release]`
 Add default version of a plugin | `$ appbuilder plugin add <Name or ID> --default [--debug] [--release]`
+Add plugin and specify plugin variables | `$ appbuilder plugin add <Name or ID> [--var.<variable_id> <variable value> [--var.<variable_id> <variable value>]*>]`
+Add plugin and specify plugin variables per configuration | `$ appbuilder plugin add <Name or ID> [--var.<configuration>.<variable_id> <variable value> [--var.<configuration>.<variable_id> <variable value>]*>]`
 
 Enables a core, integrated or verified plugin for your project. <% if(isHtml) { %>If the plugin has plugin variables, the Telerik AppBuilder CLI shows an interactive prompt to let you set values for each plugin variable.<% } %>
 <% if(isConsole) { %>
@@ -25,6 +27,11 @@ WARNING: This command is not applicable to NativeScript projects. To view the co
 * `--release` - Enables the specified plugin for the Release build configuration only. If `--available` is set, lists all plugins that you can enable for the Release build configuration.
 * `--latest` - Enables the latest version of the specified plugin.
 * `--default` - Enables the default version of the specified plugin.
+* `--var` - Sets the value for specified plugin variable. The following rules are applied when parsing the `--var` option:
+	* `--var.<variableName> <value>` - sets variable `<variableName>` to `<value>` in all configurations.
+	* `--var.<configuration>.<variableName> <value>` - sets variable `<variableName>` to `<value>` for specified configuration.
+	* `--var.<configuration>.<variableName> <configValue> --var.<variableName> <value>` - sets variable `<variableName>` to `<configValue>` for specified configuration and to `<value>` for all other configurations.
+	* If plugin requires two plugin variables, but you pass only one with `--var` option, you will be prompted to select value for the other one.
 
 ### Attributes
 * `<Name or ID>` is the name or ID of the plugin as listed by `$ appbuilder plugin add --available`

--- a/docs/man_pages/lib-management/plugin-configure.md
+++ b/docs/man_pages/lib-management/plugin-configure.md
@@ -4,6 +4,8 @@ plugin configure
 Usage | Synopsis
 ------|-------
 General | `$ appbuilder plugin configure <Name or ID> [--debug] [--release]`
+Specify plugin variables | `$ appbuilder plugin configure <Name or ID> [--var.<variable_id> <variable value> [--var.<variable_id> <variable value>]*>]`
+Specify plugin variables per configuration | `$ appbuilder plugin configure <Name or ID> [--var.<configuration>.<variable_id> <variable value> [--var.<configuration>.<variable_id> <variable value>]*>]`
 
 Configures plugin variables for the selected core, integrated or verified plugin.
 <% if(isConsole) { %>
@@ -18,9 +20,15 @@ WARNING: This command is not applicable to NativeScript projects. To view the co
 ### Options
 * `--debug` - Sets the plugin variable for the Debug build configuration only. 
 * `--release` - Sets the plugin variable for the Release build configuration only.
+* `--var` - Sets the value for specified plugin variable. The following rules are applied when parsing the `--var` option:
+	* `--var.<variableName> <value>` - sets variable `<variableName>` to `<value>` in all configurations.
+	* `--var.<configuration>.<variableName> <value>` - sets variable `<variableName>` to `<value>` for specified configuration.
+	* `--var.<configuration>.<variableName> <configValue> --var.<variableName> <value>` - sets variable `<variableName>` to `<configValue>` for specified configuration and to `<value>` for all other configurations.
+	* If plugin requires two plugin variables, but you pass only one with `--var` option, you will be prompted to select value for the other one.
 
 ### Attributes
 * `<Name or ID>` is the name or ID of the plugin as listed by `$ appbuilder plugin`
+
 <% } %>
 <% if(isHtml) { %> 
 ### Command Limitations

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -686,6 +686,7 @@ interface IOptions extends ICommonOptions {
 	sendEmail: boolean;
 	group: string[];
 	default: boolean;
+	var: Object;
 }
 
 /**

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -35,7 +35,8 @@ export class Options extends commonOptionsLibPath.OptionsBase {
 			sendPush: { type: OptionType.Boolean },
 			sendEmail: { type: OptionType.Boolean },
 			group: { type: OptionType.Array },
-			default: {type: OptionType.Boolean}
+			default: {type: OptionType.Boolean},
+			var: {type: OptionType.Object}
 		},
 		path.join($hostInfo.isWindows ? process.env.LocalAppData : path.join(osenv.home(), ".local/share"), "Telerik", "BlackDragon", ".appbuilder-cli"),
 			$errors, $staticConfig);


### PR DESCRIPTION
When you want to automate plugin add, there's no way to automate the process of adding CordovaPluginVariables and prompter is shown for each of them. In order to simplify this, add `var` dashed option, which should work in the following way:
* `$ appbuilder plugin add dropbox --var.APP_KEY 1 --var.APP_SECRET 2` - sets the plugin variables APP_KEY to 1 and APP_SECRET to 2 in all configurations
* `$ appbuilder plugin add dropbox --var.debug.APP_KEY 1 --var.debug.APP_SECRET 2 --var.release.APP_KEY 3 --var.release.APP_SECRET 4` - in .debug.abproject sets APP_KEY to 1 and APP_SECRET to 2 and in .release.abproject sets APP_KEY to 3 and APP_SECRET to 4
* `$ appbuilder plugin add dropbox --var.APP_KEY 1 --var.APP_SECRET 2  --var.debug.APP_KEY 3` - in .debug.abproject sets APP_KEY to 3 and APP_SECRET to 2 and in .release.abproject sets APP_KEY to 1 and APP_SECRET to 4 - when plugin variable is passed both with config and without config, the value for config is used for the respective configuration, the other value is used for all other values.
* `$ appbuilder plugin add dropbox --var.APP_KEY 1` - sets APP_KEY to 1 in all configurations, and prompts user for APP_SECRET for all configurations
* `$ appbuilder plugin add dropbox --var.APP_KEY 1 --var.debug.APP_SECRET 2` - sets APP_KEY to 1 in all configurations, APP_SECRET to 2 in debug config and prompts user for APP_SECRET value for release configuration

Also keys passed to --var will work no matter of the casing, for example --var.DeBuG.App_KeY is treated the same way as --var.debug.APP_KEY and will be used to set APP_KEY in debug configuration to passed value.

Added unit tests for the described scenarios.

http://teampulse.telerik.com/view#item/292387