### PR TITLE
Launch simulator after creating a ScreenBuilder project

### DIFF
--- a/docs/man_pages/project/creation/create-screenbuilder.md
+++ b/docs/man_pages/project/creation/create-screenbuilder.md
@@ -3,13 +3,14 @@ create screenbuilder
 
 Usage | Synopsis
 ------|-------
-General | `$ appbuilder create screenbuilder <App name> [--path <Directory>] [--appid <App ID>]`
+General | `$ appbuilder create screenbuilder <App name> [--path <Directory>] [--appid <App ID>] [--no-simulator]`
 
 Creates a new project for hybrid development with Screen Builder. <% if(isHtml) { %>Screen Builder lets you create a new project customized with navigation, home view and user interface skin. Later you can run the Screen Builder commands on this project to further customize it by adding application views, connecting to data sources, creating user registration and sign-in and adding forms, lists and fields.<% } %> 
 
 ### Options
 * `--path` - Specifies the directory where you want to create the project, if different from the current directory. The directory must be empty.
 * `--appid` - Sets the application identifier for your app. If not specified, the application identifier is set to `com.telerik.<App name>`. 
+* `--no-simulator` - If set, the Telerik AppBuilder CLI does not launch he device simulator after the project is created successfully. 
 
 ### Attributes
 * `<App name>` is the name of the application. The maximum length is 30 characters. You can use only the following characters: A-Z, a-z, 0-9, underscore (_), dot (.), hyphen (-) and space ( ).

--- a/docs/man_pages/project/creation/create.md
+++ b/docs/man_pages/project/creation/create.md
@@ -11,7 +11,7 @@ Create with Screen Builder | `$ appbuilder create screenbuilder <App Name>` OR `
 Creates a project for hybrid, native or mobile website development. If `screenbuilder` and `<Type>` are not specified, creates a new project for hybrid development with Screen Builder.
 
 ### Attributes
-* `screenbuilder` - Creates a new project for hybrid development with Screen Builder. You can later run the Screen Builder commands for project development on this project.
+* `screenbuilder` - Creates a new project for hybrid development with Screen Builder and launches the device simulator afterwards. You can later run the Screen Builder commands for project development on this project.
 * `<Type>` extends the `create` command. You can set the following values for this attribute. 
 	* `hybrid` - Creates a new project from an **Apache Cordova** template.
 	* `native` - Creates a new project from a **NativeScript** template.

--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -79,6 +79,9 @@ $injector.require("cordovaSimulatorService", "./services/project-simulator-servi
 $injector.require("nativeScriptSimulatorService", "./services/project-simulator-service");
 $injector.require("mobileWebsiteSimulatorService", "./services/project-simulator-service");
 
+$injector.require("simulatorPlatformServices", "./services/simulatorPlatformServices");
+$injector.require("simulatorService", "./services/simulatorService");
+
 $injector.require("project", "./project");
 $injector.require("cordovaProject", "./project/cordova-project");
 $injector.require("nativeScriptProject", "./project/nativescript-project");

--- a/lib/commands/debug.ts
+++ b/lib/commands/debug.ts
@@ -30,7 +30,7 @@ export class DebugCommand implements ICommand {
 			this.$loginManager.ensureLoggedIn().wait();
 			this.$project.ensureProject();
 
-			let debuggerPackageName = this.$debuggerPlatformServices.getPackageName();
+			let debuggerPackageName = this.$debuggerPlatformServices.packageName;
 			this.debuggerPath = this.$serverExtensionsService.getExtensionPath(debuggerPackageName);
 			this.$serverExtensionsService.prepareExtension(debuggerPackageName, this.ensureDebuggerIsNotRunning.bind(this)).wait();
 
@@ -116,7 +116,7 @@ class WinDebuggerPlatformServices extends  BaseDebuggerPlatformServices implemen
 		super($sharedUserSettingsFileService, $sharedUserSettingsService, $errors, $logger, $dispatcher);
 	}
 
-	public getPackageName(): string {
+	public get packageName(): string {
 		return WinDebuggerPlatformServices.PACKAGE_NAME_WIN;
 	}
 
@@ -151,7 +151,7 @@ class DarwinDebuggerPlatformServices extends BaseDebuggerPlatformServices implem
 		super($sharedUserSettingsFileService, $sharedUserSettingsService, $errors, $logger, $dispatcher);
 	}
 
-	public getPackageName(): string {
+	public get packageName(): string {
 		return DarwinDebuggerPlatformServices.PACKAGE_NAME_OSX;
 	}
 

--- a/lib/commands/project/create.ts
+++ b/lib/commands/project/create.ts
@@ -39,7 +39,9 @@ export class CreateCommand extends ProjectCommandBaseLib.ProjectCommandBase {
 				this.$screenBuilderService.installAppDependencies(screenBuilderOptions).wait();
 
 				this.$project.initializeProjectFromExistingFiles(this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova, projectPath, projectName).wait();
-				this.$simulatorService.launchSimulator().wait();
+				if (this.$options.simulator) {
+					this.$simulatorService.launchSimulator().wait();
+				}
 			} catch(err) {
 				this.$fs.deleteDirectory(projectPath).wait();
 				throw err;

--- a/lib/commands/project/create.ts
+++ b/lib/commands/project/create.ts
@@ -1,7 +1,6 @@
 ///<reference path="../../.d.ts"/>
 "use strict";
 
-import Future = require("fibers/future");
 import path = require("path");
 import util = require("util");
 
@@ -13,6 +12,7 @@ export class CreateCommand extends ProjectCommandBaseLib.ProjectCommandBase {
 		private $nameCommandParameter: ICommandParameter,
 		$project: Project.IProject,
 		private $projectConstants: Project.IProjectConstants,
+		private $simulatorService: ISimulatorService,
 		private $screenBuilderService: IScreenBuilderService,
 		private $options: IOptions) {
 		super($errors, $project);
@@ -39,6 +39,7 @@ export class CreateCommand extends ProjectCommandBaseLib.ProjectCommandBase {
 				this.$screenBuilderService.installAppDependencies(screenBuilderOptions).wait();
 
 				this.$project.initializeProjectFromExistingFiles(this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova, projectPath, projectName).wait();
+				this.$simulatorService.launchSimulator().wait();
 			} catch(err) {
 				this.$fs.deleteDirectory(projectPath).wait();
 				throw err;

--- a/lib/commands/simulate.ts
+++ b/lib/commands/simulate.ts
@@ -1,42 +1,19 @@
 ///<reference path="../.d.ts"/>
 "use strict";
 
-import os = require("os");
-import path = require("path");
-import Future = require("fibers/future");
-
 export class SimulateCommand implements ICommand {
 	private projectData: IProjectData;
-	private simulatorPath: string;
 
 	constructor(private $errors: IErrors,
-		private $logger: ILogger,
-		private $loginManager: ILoginManager,
-		private $platformMigrator: Project.IPlatformMigrator,
-		private $processInfo: IProcessInfo,
 		private $project: Project.IProject,
-		private $projectSimulatorService: IProjectSimulatorService,
-		private $serverExtensionsService: IServerExtensionsService,
+		private $simulatorService: ISimulatorService,
 		private $simulatorPlatformServices: IExtensionPlatformServices,
-		private $staticConfig: IStaticConfig,
-		private $analyticsService: IAnalyticsService,
 		private $hostCapabilities: IHostCapabilities) {
 			this.projectData = $project.projectData;
 	}
 
 	public execute(args: string[]): IFuture<void> {
-		return (() => {
-
-			this.$loginManager.ensureLoggedIn().wait();
-
-			let simulatorPackageName = this.$simulatorPlatformServices.getPackageName();
-			this.simulatorPath = this.$serverExtensionsService.getExtensionPath(simulatorPackageName);
-			this.$serverExtensionsService.prepareExtension(simulatorPackageName, this.ensureSimulatorIsNotRunning.bind(this)).wait();
-
-			this.$platformMigrator.ensureAllPlatformAssets().wait();
-
-			this.runSimulator(simulatorPackageName).wait();
-		}).future<void>()();
+		return this.$simulatorService.launchSimulator();
 	}
 
 	allowedParameters: ICommandParameter[] = [];
@@ -54,95 +31,5 @@ export class SimulateCommand implements ICommand {
 
 		return this.$simulatorPlatformServices.canRunApplication();
 	}
-
-	private ensureSimulatorIsNotRunning(): IFuture<void> {
-		return (() => {
-			this.$logger.info(); // HACK - display simulator downloading indicator correctly
-			let isRunning = this.$processInfo.isRunning(this.$simulatorPlatformServices.executableName).wait();
-			if (isRunning) {
-				this.$errors.failWithoutHelp("AppBuilder Simulator is currently running and cannot be updated." + os.EOL +
-					"Close it and run $ appbuilder simulate again.");
-			}
-		}).future<void>()();
-	}
-
-	private runSimulator(simulatorPackageName: string): IFuture<void> {
-		return (() => {
-			this.$logger.info("Starting simulator...");
-
-			let simulatorParams = [
-				"--path", this.$project.getProjectDir().wait(),
-				"--assemblypaths", this.simulatorPath,
-				"--isfeaturetrackingenabled", this.$analyticsService.isEnabled().wait().toString(),
-				"--analyticsaccountcode", this.$staticConfig.ANALYTICS_API_KEY
-			];
-
-			simulatorParams = simulatorParams.concat(this.$projectSimulatorService.getSimulatorParams(simulatorPackageName).wait());
-
-			this.$simulatorPlatformServices.runApplication(this.simulatorPath, simulatorParams);
-		}).future<void>()();
-	}
 }
 $injector.registerCommand("simulate", SimulateCommand);
-
-class WinSimulatorPlatformServices implements IExtensionPlatformServices {
-	private static PACKAGE_NAME_WIN: string = "Telerik.BlackDragon.Client.Mobile.Tools.Package";
-	private static EXECUTABLE_NAME_WIN = "Icenium.Simulator.exe";
-
-	constructor(private $childProcess: IChildProcess,
-				private $hostInfo: IHostInfo) { }
-
-	public getPackageName(): string {
-		return WinSimulatorPlatformServices.PACKAGE_NAME_WIN;
-	}
-
-	public get executableName(): string {
-		return WinSimulatorPlatformServices.EXECUTABLE_NAME_WIN;
-	}
-
-	public runApplication(applicationPath: string, applicationParams: string[]) {
-		let simulatorBinary = path.join(applicationPath, WinSimulatorPlatformServices.EXECUTABLE_NAME_WIN);
-		this.$childProcess.spawn(simulatorBinary, applicationParams,
-			{ stdio: "ignore", detached: true }).unref();
-	}
-
-	public canRunApplication(): IFuture<boolean> {
-		return this.$hostInfo.isDotNet40Installed("Unable to start the simulator. Verify that you have installed .NET 4.0 or later and try again.");
-	}
-}
-
-class MacSimulatorPlatformServices implements IExtensionPlatformServices {
-	private static PACKAGE_NAME_MAC: string = "Telerik.BlackDragon.Client.Mobile.Tools.Mac.Package";
-	private static EXECUTABLE_NAME_MAC = "AppBuilder Simulator";
-	private static EXECUTABLE_NAME_MAC_APP = MacSimulatorPlatformServices.EXECUTABLE_NAME_MAC + ".app";
-
-	constructor(private $childProcess: IChildProcess) { }
-
-	public getPackageName() : string {
-		return MacSimulatorPlatformServices.PACKAGE_NAME_MAC;
-	}
-
-	public get executableName(): string {
-		return MacSimulatorPlatformServices.EXECUTABLE_NAME_MAC;
-	}
-
-	public runApplication(applicationPath: string, applicationParams: string[]) {
-		let simulatorBinary = path.join(applicationPath, MacSimulatorPlatformServices.EXECUTABLE_NAME_MAC_APP);
-		let commandLine = [simulatorBinary, '--args'].concat(applicationParams);
-		this.$childProcess.spawn('open', commandLine,
-			{ stdio:  ["ignore", "ignore", "ignore"], detached: true }).unref();
-	}
-
-	public canRunApplication(): IFuture<boolean> {
-		return (() => true).future<boolean>()();
-	}
-}
-
-let hostInfo = $injector.resolve("hostInfo");
-if(hostInfo.isWindows) {
-	$injector.register("simulatorPlatformServices", WinSimulatorPlatformServices);
-} else if(hostInfo.isDarwin) {
-	$injector.register("simulatorPlatformServices", MacSimulatorPlatformServices);
-} else {
-	$injector.register("simulatorPlatformServices", {});
-}

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -742,3 +742,14 @@ interface IWebView {
 	pluginIdentifier?: string;
 	default?: boolean;
 }
+
+/**
+ * Service for interaction with the simulator
+ */
+interface ISimulatorService {
+	/**
+	 * Used to start simulator
+	 * @return {IFuture<void>}
+	 */
+	launchSimulator(): IFuture<void>;
+}

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -690,6 +690,7 @@ interface IOptions extends ICommonOptions {
 	default: boolean;
 	var: Object;
 	answers: string;
+	simulator: boolean;
 }
 
 /**

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -277,7 +277,7 @@ interface IServerConfiguration {
 }
 
 interface IExtensionPlatformServices {
-	getPackageName() : string;
+	packageName : string;
 	executableName: string;
 	runApplication(applicationPath: string, applicationParams: string[]): void;
 	canRunApplication(): IFuture<boolean>;

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -36,7 +36,8 @@ export class Options extends commonOptionsLibPath.OptionsBase {
 			group: { type: OptionType.Array },
 			default: {type: OptionType.Boolean},
 			var: {type: OptionType.Object},
-			answers: { type: OptionType.String }
+			answers: { type: OptionType.String },
+			simulator: { type: OptionType.Boolean, default: true}
 		},
 		path.join($hostInfo.isWindows ? process.env.LocalAppData : path.join(osenv.home(), ".local/share"), "Telerik", "BlackDragon", ".appbuilder-cli"),
 			$errors, $staticConfig);

--- a/lib/project.ts
+++ b/lib/project.ts
@@ -168,7 +168,7 @@ export class Project implements Project.IProject {
 
 	public getProjectDir(): IFuture<string> {
 		return (() => {
-			if(this.cachedProjectDir !== "") {
+			if(this.cachedProjectDir) {
 				return this.cachedProjectDir;
 			}
 			this.cachedProjectDir = null;

--- a/lib/services/simulatorPlatformServices.ts
+++ b/lib/services/simulatorPlatformServices.ts
@@ -1,0 +1,64 @@
+import path = require("path");
+import Future = require("fibers/future");
+
+class WinSimulatorPlatformServices implements IExtensionPlatformServices {
+	private static PACKAGE_NAME_WIN: string = "Telerik.BlackDragon.Client.Mobile.Tools.Package";
+	private static EXECUTABLE_NAME_WIN = "Icenium.Simulator.exe";
+
+	constructor(private $childProcess: IChildProcess,
+				private $hostInfo: IHostInfo) { }
+
+	public getPackageName(): string {
+		return WinSimulatorPlatformServices.PACKAGE_NAME_WIN;
+	}
+
+	public get executableName(): string {
+		return WinSimulatorPlatformServices.EXECUTABLE_NAME_WIN;
+	}
+
+	public runApplication(applicationPath: string, applicationParams: string[]): void {
+		let simulatorBinary = path.join(applicationPath, WinSimulatorPlatformServices.EXECUTABLE_NAME_WIN);
+		this.$childProcess.spawn(simulatorBinary, applicationParams,
+			{ stdio: "ignore", detached: true }).unref();
+	}
+
+	public canRunApplication(): IFuture<boolean> {
+		return this.$hostInfo.isDotNet40Installed("Unable to start the simulator. Verify that you have installed .NET 4.0 or later and try again.");
+	}
+}
+
+class MacSimulatorPlatformServices implements IExtensionPlatformServices {
+	private static PACKAGE_NAME_MAC: string = "Telerik.BlackDragon.Client.Mobile.Tools.Mac.Package";
+	private static EXECUTABLE_NAME_MAC = "AppBuilder Simulator";
+	private static EXECUTABLE_NAME_MAC_APP = MacSimulatorPlatformServices.EXECUTABLE_NAME_MAC + ".app";
+
+	constructor(private $childProcess: IChildProcess) { }
+
+	public getPackageName() : string {
+		return MacSimulatorPlatformServices.PACKAGE_NAME_MAC;
+	}
+
+	public get executableName(): string {
+		return MacSimulatorPlatformServices.EXECUTABLE_NAME_MAC;
+	}
+
+	public runApplication(applicationPath: string, applicationParams: string[]): void {
+		let simulatorBinary = path.join(applicationPath, MacSimulatorPlatformServices.EXECUTABLE_NAME_MAC_APP);
+		let commandLine = [simulatorBinary, '--args'].concat(applicationParams);
+		this.$childProcess.spawn('open', commandLine,
+			{ stdio:  ["ignore", "ignore", "ignore"], detached: true }).unref();
+	}
+
+	public canRunApplication(): IFuture<boolean> {
+		return (() => true).future<boolean>()();
+	}
+}
+
+let hostInfo = $injector.resolve("hostInfo");
+if(hostInfo.isWindows) {
+	$injector.register("simulatorPlatformServices", WinSimulatorPlatformServices);
+} else if(hostInfo.isDarwin) {
+	$injector.register("simulatorPlatformServices", MacSimulatorPlatformServices);
+} else {
+	$injector.register("simulatorPlatformServices", {});
+}

--- a/lib/services/simulatorPlatformServices.ts
+++ b/lib/services/simulatorPlatformServices.ts
@@ -1,5 +1,4 @@
 import path = require("path");
-import Future = require("fibers/future");
 
 class WinSimulatorPlatformServices implements IExtensionPlatformServices {
 	private static PACKAGE_NAME_WIN: string = "Telerik.BlackDragon.Client.Mobile.Tools.Package";
@@ -8,7 +7,7 @@ class WinSimulatorPlatformServices implements IExtensionPlatformServices {
 	constructor(private $childProcess: IChildProcess,
 				private $hostInfo: IHostInfo) { }
 
-	public getPackageName(): string {
+	public get packageName(): string {
 		return WinSimulatorPlatformServices.PACKAGE_NAME_WIN;
 	}
 
@@ -34,7 +33,7 @@ class MacSimulatorPlatformServices implements IExtensionPlatformServices {
 
 	constructor(private $childProcess: IChildProcess) { }
 
-	public getPackageName() : string {
+	public get packageName() : string {
 		return MacSimulatorPlatformServices.PACKAGE_NAME_MAC;
 	}
 
@@ -54,7 +53,7 @@ class MacSimulatorPlatformServices implements IExtensionPlatformServices {
 	}
 }
 
-let hostInfo = $injector.resolve("hostInfo");
+let hostInfo: IHostInfo = $injector.resolve("hostInfo");
 if(hostInfo.isWindows) {
 	$injector.register("simulatorPlatformServices", WinSimulatorPlatformServices);
 } else if(hostInfo.isDarwin) {

--- a/lib/services/simulatorService.ts
+++ b/lib/services/simulatorService.ts
@@ -1,0 +1,62 @@
+///<reference path="../.d.ts"/>
+"use strict";
+
+import os = require("os");
+
+export class SimulatorService implements ISimulatorService {
+	private simulatorPath: string;
+	
+	constructor(private $errors: IErrors,
+		private $logger: ILogger,
+		private $loginManager: ILoginManager,
+		private $platformMigrator: Project.IPlatformMigrator,
+		private $processInfo: IProcessInfo,
+		private $project: Project.IProject,
+		private $projectSimulatorService: IProjectSimulatorService,
+		private $serverExtensionsService: IServerExtensionsService,
+		private $simulatorPlatformServices: IExtensionPlatformServices,
+		private $staticConfig: IStaticConfig,
+		private $analyticsService: IAnalyticsService) {
+	}
+
+	public launchSimulator(): IFuture<void> {
+		this.$loginManager.ensureLoggedIn().wait();
+
+		let simulatorPackageName = this.$simulatorPlatformServices.getPackageName();
+		this.simulatorPath = this.$serverExtensionsService.getExtensionPath(simulatorPackageName);
+		this.$serverExtensionsService.prepareExtension(simulatorPackageName, this.ensureSimulatorIsNotRunning.bind(this)).wait();
+
+		this.$platformMigrator.ensureAllPlatformAssets().wait();
+
+		return this.runSimulator(simulatorPackageName);
+	}
+
+	private ensureSimulatorIsNotRunning(): IFuture<void> {
+		return (() => {
+			this.$logger.info(); // HACK - display simulator downloading indicator correctly
+			let isRunning = this.$processInfo.isRunning(this.$simulatorPlatformServices.executableName).wait();
+			if (isRunning) {
+				this.$errors.failWithoutHelp("AppBuilder Simulator is currently running and cannot be updated." + os.EOL +
+					"Close it and run $ appbuilder simulate again.");
+			}
+		}).future<void>()();
+	}
+
+	private runSimulator(simulatorPackageName: string): IFuture<void> {
+		return (() => {
+			this.$logger.info("Starting simulator...");
+
+			let simulatorParams = [
+				"--path", this.$project.getProjectDir().wait(),
+				"--assemblypaths", this.simulatorPath,
+				"--isfeaturetrackingenabled", this.$analyticsService.isEnabled().wait().toString(),
+				"--analyticsaccountcode", this.$staticConfig.ANALYTICS_API_KEY
+			];
+
+			simulatorParams = simulatorParams.concat(this.$projectSimulatorService.getSimulatorParams(simulatorPackageName).wait());
+
+			this.$simulatorPlatformServices.runApplication(this.simulatorPath, simulatorParams);
+		}).future<void>()();
+	}
+}
+$injector.register("simulatorService", SimulatorService);

--- a/lib/services/simulatorService.ts
+++ b/lib/services/simulatorService.ts
@@ -22,7 +22,7 @@ export class SimulatorService implements ISimulatorService {
 	public launchSimulator(): IFuture<void> {
 		this.$loginManager.ensureLoggedIn().wait();
 
-		let simulatorPackageName = this.$simulatorPlatformServices.getPackageName();
+		let simulatorPackageName = this.$simulatorPlatformServices.packageName;
 		this.simulatorPath = this.$serverExtensionsService.getExtensionPath(simulatorPackageName);
 		this.$serverExtensionsService.prepareExtension(simulatorPackageName, this.ensureSimulatorIsNotRunning.bind(this)).wait();
 

--- a/test/build-configurations.ts
+++ b/test/build-configurations.ts
@@ -164,7 +164,7 @@ function getProjectFileName(configuration: string) {
 function assertCorePluginsCount(configuration?: string) {
 	let testInjector = createTestInjector();
 	let projectConstants: Project.IProjectConstants = new projectConstantsLib.ProjectConstants();
-	let options = testInjector.resolve(optionsLib.Options);
+	let options = testInjector.resolve("options");
 	let project = testInjector.resolve("project");
 	let fs = testInjector.resolve("fs");
 

--- a/test/common-options.ts
+++ b/test/common-options.ts
@@ -30,7 +30,8 @@ function createTestInjector(): IInjector {
 	return testInjector;
 }
 
-function createOptions(testInjector: IInjector): IOptions {
+function createOptions(optionValues: any, testInjector: IInjector): IOptions {
+	yargs.options = () => { return <any>{ argv: optionValues } };
 	let options = testInjector.resolve(optionsPath.OptionsBase, { options: knownOpts, defaultProfileDir: "1" }); // Validation is triggered in options's constructor
 	return options;
 }
@@ -53,11 +54,7 @@ describe("common options", () => {
 	describe("validateOptions", () => {
 		it("breaks execution when option is not valid", () => {
 			isExecutionStopped = false;
-			yargs.argv = {
-				"pathr": "incorrect argument"
-			};
-			
-			let options = createOptions(testInjector);
+			let options = createOptions({pathr: "incorrect argument"}, testInjector);
 			options.validateOptions();
 
 			assert.isTrue(isExecutionStopped);
@@ -65,12 +62,9 @@ describe("common options", () => {
 
 		it("breaks execution when valid option does not have value", () => {
 			isExecutionStopped = false;
-			yargs.argv = {
-				// If you do not pass value to an option, it's automatically set as true.
-				"path": true
-			};
 
-			let options = createOptions(testInjector);
+			// If you do not pass value to an option, it's automatically set as true.
+			let options = createOptions({ path: true }, testInjector);
 			options.validateOptions();
 
 			assert.isTrue(isExecutionStopped);
@@ -78,11 +72,8 @@ describe("common options", () => {
 
 		it("does not break execution when valid option has correct value", () => {
 			isExecutionStopped = false;
-			yargs.argv = {
-				"path": "SomeDir"
-			};
 
-			let options = createOptions(testInjector);
+			let options = createOptions({ path: "SomeDir" }, testInjector);
 			options.validateOptions();
 
 			assert.isFalse(isExecutionStopped);
@@ -90,11 +81,9 @@ describe("common options", () => {
 
 		it("breaks execution when valid option has incorrect value", () => {
 			isExecutionStopped = false;
-			yargs.argv = {
-				"help": "Invalid string value" // help requires boolean value.
-			};
 
-			let options = createOptions(testInjector);
+			// help requires boolean value.
+			let options = createOptions({help: "Invalid string value" }, testInjector);
 			options.validateOptions();
 
 			assert.isTrue(isExecutionStopped);
@@ -102,11 +91,8 @@ describe("common options", () => {
 
 		it("breaks execution when valid option has empty string value", () => {
 			isExecutionStopped = false;
-			yargs.argv = {
-				"path": ""
-			};
 
-			let options = createOptions(testInjector);
+			let options = createOptions({ path: "" }, testInjector);
 			options.validateOptions();
 
 			assert.isTrue(isExecutionStopped);
@@ -114,11 +100,8 @@ describe("common options", () => {
 
 		it("breaks execution when valid option has value with spaces only", () => {
 			isExecutionStopped = false;
-			yargs.argv = {
-				"path": "  "
-			};
 
-			let options = createOptions(testInjector);
+			let options = createOptions({ path: "  " }, testInjector);
 			options.validateOptions();
 			
 			assert.isTrue(isExecutionStopped);
@@ -126,11 +109,8 @@ describe("common options", () => {
 
 		it("breaks execution when shorthand option is not valid", () => {
 			isExecutionStopped = false;
-			yargs.argv = {
-				"r": "incorrect shorthand"
-			};
 
-			let options = createOptions(testInjector);
+			let options = createOptions({ r: "incorrect shorthand" }, testInjector);
 			options.validateOptions();
 
 			assert.isTrue(isExecutionStopped);
@@ -138,11 +118,8 @@ describe("common options", () => {
 
 		it("does not break execution when valid shorthand option has correct value", () => {
 			isExecutionStopped = false;
-			yargs.argv = {
-				"v": true
-			};
 
-			let options = createOptions(testInjector);
+			let options = createOptions({ v: true }, testInjector);
 			options.validateOptions();
 
 			assert.isFalse(isExecutionStopped);
@@ -151,11 +128,9 @@ describe("common options", () => {
 
 		it("breaks execution when valid shorthand option has incorrect value", () => {
 			isExecutionStopped = false;
-			yargs.argv = {
-				"v": "invalid string value" // v requires boolean value
-			};
-
-			let options = createOptions(testInjector);
+ 
+ 			// v requires boolean value
+			let options = createOptions({ v: "invalid string value" }, testInjector);
 			options.validateOptions();
 
 			assert.isTrue(isExecutionStopped);
@@ -164,11 +139,8 @@ describe("common options", () => {
 		// all numbers are changed to strings before calling validateOptions
 		it("does not break execution when valid option has number value", () => {
 			isExecutionStopped = false;
-			yargs.argv = {
-				"path": "1"
-			};
 
-			let options = createOptions(testInjector);
+			let options = createOptions({ path: "1" }, testInjector);
 			options.validateOptions();
 
 			assert.isFalse(isExecutionStopped);
@@ -176,12 +148,8 @@ describe("common options", () => {
 
 		it("breaks execution when valid option has null value", () => {
 			isExecutionStopped = false;
-			yargs.argv = {
-				"path": ""
-			};
 
-			yargs.argv.path = null;
-			let options = createOptions(testInjector);
+			let options = createOptions({ path: null }, testInjector);
 			options.validateOptions();
 
 			assert.isTrue(isExecutionStopped);
@@ -189,12 +157,8 @@ describe("common options", () => {
 
 		it("breaks execution when valid option has undefined value", () => {
 			isExecutionStopped = false;
-			yargs.argv = {
-				"path": ""
-			};
 
-			yargs.argv.path = undefined;
-			let options = createOptions(testInjector);
+			let options = createOptions({ path: undefined }, testInjector);
 			options.validateOptions();
 
 			assert.isTrue(isExecutionStopped);
@@ -205,12 +169,12 @@ describe("common options", () => {
 		describe("validates dashed options correctly",() => {
 			it("does not break execution when dashed option with single dash is passed",() => {
 				isExecutionStopped = false;
-				yargs.argv = {
+				let optionValues = {
 					"profile-dir": "some dir",
-					"profileDir": "some dir"
+					profileDir: "some dir"
 				};
 
-				let options = createOptions(testInjector);
+				let options = createOptions(optionValues, testInjector);
 				options.validateOptions();
 				assert.isFalse(isExecutionStopped, "Dashed options should be validated in specific way. Make sure validation allows yargs specific behavior:" +
 					"Dashed options (profile-dir) are added to yargs.argv in two ways: profile-dir and profileDir");
@@ -218,12 +182,12 @@ describe("common options", () => {
 
 			it("does not break execution when dashed option with two dashes is passed",() => {
 				isExecutionStopped = false;
-				yargs.argv = {
+				let optionValues = {
 					"some-dashed-value": "some dir",
 					"someDashedValue": "some dir"
 				};
 
-				let options = createOptions(testInjector);
+				let options = createOptions(optionValues, testInjector);
 				options.validateOptions();
 				assert.isFalse(isExecutionStopped, "Dashed options should be validated in specific way. Make sure validation allows yargs specific behavior:" +
 					"Dashed options (some-dashed-value) are added to yargs.argv in two ways: some-dashed-value and someDashedValue");
@@ -231,12 +195,12 @@ describe("common options", () => {
 
 			it("does not break execution when dashed option with a lot of dashes is passed",() => {
 				isExecutionStopped = false;
-				yargs.argv = {
+				let optionValues = {
 					"a-b-c-d-e-f-g": "some dir",
 					"aBCDEFG": "some dir"
 				};
 
-				let options = createOptions(testInjector);
+				let options = createOptions(optionValues, testInjector);
 				options.validateOptions();
 
 				assert.isFalse(isExecutionStopped, "Dashed options should be validated in specific way. Make sure validation allows yargs specific behavior:" +
@@ -247,7 +211,7 @@ describe("common options", () => {
 });
 
 
-function createOptionsWithProfileDir(profileDir: string): IOptions {
+function createOptionsWithProfileDir(optionValues: any, profileDir: string): IOptions {
 	let knownOptions = {
 		"profile-dir": { type: optionType.String }
 	}
@@ -255,6 +219,8 @@ function createOptionsWithProfileDir(profileDir: string): IOptions {
 	let testInjector = new yok.Yok();
 	testInjector.register("errors", {});
 	testInjector.register("staticConfig", {});
+
+	yargs.options = () => { return <any>{ argv: optionValues } };
 	let options = testInjector.resolve(optionsPath.OptionsBase, { options: knownOptions, defaultProfileDir: profileDir });
 	return options;
 }
@@ -265,11 +231,12 @@ describe("common options profile-dir tests", () => {
 
 			let expectedProfileDir = "TestDir";
 			
-			yargs.argv = {};
-			yargs.argv["profile-dir"] = expectedProfileDir;
-			yargs.argv["profileDir"] = expectedProfileDir;
-			
-			let options = createOptionsWithProfileDir("");
+			let optionValues = {
+				"profile-dir": expectedProfileDir,
+				profileDir: expectedProfileDir
+			};
+
+			let options = createOptionsWithProfileDir(optionValues, "");
 			options.validateOptions();			
 			
 			assert.equal(options.profileDir, expectedProfileDir);
@@ -277,16 +244,18 @@ describe("common options profile-dir tests", () => {
 
 		it("sets default profile-dir when it is not passed on command line", () => {
 			let profileDir = "TestDir";
-			let options = createOptionsWithProfileDir("TestDir");
+			let options = createOptionsWithProfileDir({}, "TestDir");
 			options.validateOptions();
 			assert.equal(options.profileDir, profileDir);
 		});
 
 		it("uses profileDir from yargs when it exists", () => {
 			let expectedProfileDir = "TestDir";
-			
-			yargs.argv.profileDir = expectedProfileDir;			
-			let options = createOptionsWithProfileDir("");
+			let optionValues = {
+				profileDir: expectedProfileDir
+			};
+
+			let options = createOptionsWithProfileDir(optionValues, "");
 			options.validateOptions();
 			
 			assert.equal(options.profileDir, expectedProfileDir);


### PR DESCRIPTION
Includes some refactoring (introduction of a new service) , a minor bug fix (caching of the project directory) and an option to prevent simulator from launching
Implements [this story](http://teampulse.telerik.com/view#item/293551)
Merge after https://github.com/telerik/mobile-cli-lib/pull/365