### PR TITLE
Remove client option and fix analytics tracking

### DIFF
--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -669,7 +669,6 @@ interface IOptions extends ICommonOptions {
 	deploy: string;
 	device: string;
 	saveTo: string;
-	client: string;
 	available: boolean;
 	release: boolean;
 	debug: boolean;

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -19,7 +19,6 @@ export class Options extends commonOptionsLibPath.OptionsBase {
 			template: { type: OptionType.String, alias: "t" },
 			deploy: { type: OptionType.String },
 			saveTo: { type: OptionType.String},
-			client: { type: OptionType.String },
 			available: { type: OptionType.Boolean },
 			release: { type: OptionType.Boolean, alias: "r" },
 			debug: { type: OptionType.Boolean, alias: "d" },


### PR DESCRIPTION
Client option was used in analytics tracking only, but it has been replaced there, so we do not need it anymore.