### PR TITLE
Export projects from the cloud

### DIFF
--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -609,9 +609,11 @@ interface IProcessInfo {
 
 interface IRemoteProjectService {
 	makeTapServiceCall<T>(call: () => IFuture<T>): IFuture<T>;
-	getProjectProperties(projectName: string): IFuture<any>;
-	getProjects(): IFuture<Server.TapSolutionData[]>;
-	getProjectName(projectId: string): IFuture<string>;
+	getProjectProperties(solutionName: string, projectName: string): IFuture<any>;
+	getSolutions(): IFuture<Server.TapSolutionData[]>;
+	getProjectsForSolution(solutionName: string): IFuture<Server.IWorkspaceItemData[]>;
+	getSolutionName(solutionId: string): IFuture<string>;
+	getProjectName(solutionId: string, projectId: string): IFuture<string>;
 }
 
 interface IProjectSimulatorService {

--- a/lib/server-api.d.ts
+++ b/lib/server-api.d.ts
@@ -310,6 +310,7 @@ declare module Server{
 		Category: string;
 		Group: string;
 		Identifier: string;
+		Icon: string;
 		DownloadUri: string;
 		DefaultName: string;
 		ShortDescription: string;
@@ -322,6 +323,7 @@ declare module Server{
 		Category: string;
 		Group: string;
 		Identifier: string;
+		Icon: string;
 		DownloadUri: string;
 		DefaultName: string;
 		ShortDescription: string;
@@ -353,7 +355,7 @@ declare module Server{
 		getProjectTemplates(): IFuture<Server.ProjectTemplateData[]>;
 		getItemTemplates(): IFuture<Server.ItemTemplateData[]>;
 		exportSolution(solutionSpaceName: string, solutionName: string, skipMetadata: boolean, $resultStream: any): IFuture<void>;
-		getExportedSolution(solutionName: string, skipMetadata: boolean, $resultStream: any): IFuture<void>;
+		exportProject(solutionSpaceName: string, solutionName: string, projectName: string, skipMetadata: boolean, $resultStream: any): IFuture<void>;
 		importPackage(solutionName: string, projectName: string, parentIdentifier: string, archivePackage: any): IFuture<void>;
 		importProject(solutionName: string, projectName: string, package_: any): IFuture<void>;
 		importLocalProject(solutionName: string, projectName: string, bucketKey: string): IFuture<void>;

--- a/lib/server-api.ts
+++ b/lib/server-api.ts
@@ -245,8 +245,8 @@ export class ProjectsService implements Server.IProjectsServiceContract{
 	public exportSolution(solutionSpaceName: string, solutionName: string, skipMetadata: boolean, $resultStream: any): IFuture<void>{
 		return this.$serviceProxy.call<void>('ExportSolution', 'GET', ['api','projects','export',encodeURI(solutionSpaceName.replace(/\\/g, '/')),encodeURI(solutionName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'skipMetadata': skipMetadata }), 'application/octet-stream', null, $resultStream);
 	}
-	public getExportedSolution(solutionName: string, skipMetadata: boolean, $resultStream: any): IFuture<void>{
-		return this.$serviceProxy.call<void>('GetExportedSolution', 'GET', ['api','projects','export',encodeURI(solutionName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'skipMetadata': skipMetadata }), 'application/octet-stream', null, $resultStream);
+	public exportProject(solutionSpaceName: string, solutionName: string, projectName: string, skipMetadata: boolean, $resultStream: any): IFuture<void>{
+		return this.$serviceProxy.call<void>('ExportProject', 'GET', ['api','projects','export',encodeURI(solutionSpaceName.replace(/\\/g, '/')),encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(projectName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'skipMetadata': skipMetadata }), 'application/octet-stream', null, $resultStream);
 	}
 	public importPackage(solutionName: string, projectName: string, parentIdentifier: string, archivePackage: any): IFuture<void>{
 		return this.$serviceProxy.call<void>('ImportPackage', 'POST', ['api','projects','import',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(projectName.replace(/\\/g, '/')),encodeURI(parentIdentifier.replace(/\\/g, '/'))].join('/'), null, [{name: 'archivePackage', value: archivePackage, contentType: 'application/octet-stream'}], null);

--- a/lib/services/remote-projects-service.ts
+++ b/lib/services/remote-projects-service.ts
@@ -4,17 +4,17 @@
 import util = require("util");
 import path = require("path");
 import helpers = require("../helpers");
-import unzip = require("unzip");
 
 export class RemoteProjectService implements IRemoteProjectService {
 	private clientSolutions: Server.TapSolutionData[];
+	private clientProjectsPerSolution: IDictionary<Server.IWorkspaceItemData[]> = {};
 
 	constructor(private $server: Server.IServer,
 				private $userDataStore: IUserDataStore,
 				private $serviceProxy: Server.IServiceProxy,
 				private $errors: IErrors) { }
 
-	public  makeTapServiceCall<T>(call: () => IFuture<T>): IFuture<T> {
+	public makeTapServiceCall<T>(call: () => IFuture<T>): IFuture<T> {
 		return (() => {
 			let user = this.$userDataStore.getUser().wait();
 			let tenantId = user.tenant.id;
@@ -27,20 +27,33 @@ export class RemoteProjectService implements IRemoteProjectService {
 		}).future<T>()();
 	}
 
-	public getProjectName(projectId: string): IFuture<string> {
+	public getSolutionName(solutionId: string): IFuture<string> {
 		return ((): string => {
-			let clientSolutions = this.getProjects().wait();
+			let clientSolutions = this.getSolutions().wait();
 
-			let result = helpers.findByNameOrIndex(projectId, clientSolutions, (clientSolution: Server.TapSolutionData) => clientSolution.name);
+			let result = helpers.findByNameOrIndex(solutionId, clientSolutions, (clientSolution: Server.TapSolutionData) => clientSolution.name);
 			if(!result) {
-				this.$errors.fail("Could not find project named '%s' or was not given a valid index. List available projects with 'cloud list' command", projectId);
+				this.$errors.failWithoutHelp("Could not find solution named '%s' or was not given a valid index. List available solutions with 'cloud list' command", solutionId);
 			}
 
 			return result.name;
 		}).future<string>()();
 	}
+	
+	public getProjectName(solutionId: string, projectId: string): IFuture<string> {
+		return ((): string => {
+			let slnName = this.getSolutionName(solutionId).wait();
+			let clientProjects = this.getProjectsForSolution(slnName).wait();
+			let result = helpers.findByNameOrIndex(projectId, clientProjects, (clientProject: Server.IWorkspaceItemData) => clientProject.Name);
+			if(!result) {
+				this.$errors.failWithoutHelp("Could not find project named '%s' inside '%s' solution or was not given a valid index. List available solutions with 'cloud list' command", projectId, solutionId);
+			}
 
-	public getProjects(): IFuture<Server.TapSolutionData[]> {
+			return result.Name;
+		}).future<string>()();
+	}
+
+	public getSolutions(): IFuture<Server.TapSolutionData[]> {
 		return (() => {
 			if (!this.clientSolutions) {
 				let existingClientSolutions = this.makeTapServiceCall(() => this.$server.tap.getExistingClientSolutions()).wait();
@@ -51,17 +64,35 @@ export class RemoteProjectService implements IRemoteProjectService {
 		}).future<Server.TapSolutionData[]>()();
 	}
 
-	public getProjectProperties(projectName: string): IFuture<any> {
+	public getProjectProperties(solutionId: string, projectId: string): IFuture<any> {
 		return (() => {
-			let solutionData = this.getSolutionData(projectName).wait();
-			let properties = (<any>solutionData.Items[0])["Properties"];
+			let solutionName = this.getSolutionName(solutionId).wait();
+			let projectName = this.getProjectName(solutionName, projectId).wait();
+			let properties = (<any>this.getProjectData(solutionName, projectName).wait())["Properties"];
 			properties.ProjectName = projectName;
 			return properties;
 		}).future()();
 	}
 
+	public getProjectsForSolution(solutionName: string): IFuture<Server.IWorkspaceItemData[]> {
+		return ((): Server.IWorkspaceItemData[] => {
+			let slnName = this.getSolutionName(solutionName).wait();
+			if(!(this.clientProjectsPerSolution[slnName] && this.clientProjectsPerSolution[slnName].length > 0)) {
+				this.clientProjectsPerSolution[slnName] = _.sortBy(this.getSolutionData(slnName).wait().Items, project => project.Name);
+			}
+
+			return this.clientProjectsPerSolution[slnName];
+		}).future<Server.IWorkspaceItemData[]>()();
+	}
+
 	private getSolutionData(projectName: string): IFuture<Server.SolutionData> {
 		return this.makeTapServiceCall(() => this.$server.projects.getSolution(projectName, true));
+	}
+
+	private getProjectData(solutionName: string, projectName: string): IFuture<Server.IWorkspaceItemData> {
+		return (() => {
+			return _.find(this.getProjectsForSolution(solutionName).wait(), pr => pr.Name === projectName);
+		}).future<Server.IWorkspaceItemData>()();
 	}
 }
 $injector.register("remoteProjectService", RemoteProjectService);

--- a/lib/swagger/service-contract-generator.ts
+++ b/lib/swagger/service-contract-generator.ts
@@ -164,7 +164,7 @@ export class ServiceContractGenerator implements Server.IServiceContractGenerato
 		let enumBlock: Swagger.IBlock;
 		let typeName = this.tsTypeSystemHelpers.translate(allowableValues.valueType);
 		if (!this.pendingModels[typeName]) {
-			enumBlock = new codeEntityLib.Block(util.format("enum %s", typeName));
+			enumBlock = new codeEntityLib.Block(util.format("const enum %s", typeName));
 			_.each(allowableValues.values, (value: string) => enumBlock.writeLine(util.format("%s,", value)));
 		}
 		this.pendingModels[typeName] = enumBlock;

--- a/test/cloud-projects.ts
+++ b/test/cloud-projects.ts
@@ -1,0 +1,420 @@
+///<reference path=".d.ts"/>
+"use strict";
+
+import stubs = require("./stubs");
+import yok = require("../lib/common/yok");
+import optionsLib = require("../lib/options");
+import remoteProjectsServiceLib = require("../lib/services/remote-projects-service");
+import cloudProjectsCommandsLib = require("../lib/commands/cloud-projects");
+import projectConstantsLib = require("../lib/project/project-constants");
+import os = require("os");
+
+let assert = require("chai").assert;
+import Future = require("fibers/future");
+import util = require("util");
+
+export class LoggerStub implements ILogger {
+	public outOutput = "";
+	public infoOutput = "";
+	public warnOutput = "";
+			
+	constructor() {
+		// uncomment when debugging unit tests to print to the console
+		//this.setLevel("DEBUG");
+	}
+
+	setLevel(level: string): void {}
+	getLevel(): string { return undefined; }
+	fatal(formatStr: string, ...args:string[]): void {}
+	error(formatStr: string, ...args:string[]): void {}
+	warn(formatStr: string, ...args:string[]): void {
+		args.unshift(formatStr);
+		this.warnOutput += util.format.apply(null, args) + os.EOL;
+	}
+	info(formatStr: string, ...args:string[]): void {
+		args.unshift(formatStr);
+		this.infoOutput += util.format.apply(null, args) + os.EOL;
+	}
+	debug(formatStr: string, ...args:string[]): void {}
+	trace(formatStr: string, ...args:string[]): void {
+		// uncomment when debugging unit tests to print to the console
+		//args.unshift(formatStr);
+		//console.log(util.format.apply(null, args));
+	}
+
+	out(formatStr: string, ...args:string[]): void {
+		args.unshift(formatStr);
+		this.outOutput += util.format.apply(null, args) + os.EOL;
+	}
+
+	write(...args:string[]): void { }
+
+	prepare(item: any): string { return item; }
+
+	printInfoMessageOnSameLine(message: string): void { }
+	printMsgWithTimeout(message: string, timeout: number): IFuture<void> {
+		return null;
+	}
+}
+
+export class PrompterStub {
+	constructor(public promptSlnName: string, public promptPrjName: string) {}
+	public isPrompterCalled = false;
+	promptForChoice(promptMessage: string, choices: any[]): IFuture<any> {
+		this.isPrompterCalled = true;
+		if(promptMessage.indexOf("solution") === -1) {
+			assert.isTrue(_.contains(choices, this.promptPrjName))
+			return Future.fromResult(this.promptPrjName);
+		}
+
+		assert.isTrue(_.contains(choices, this.promptSlnName))
+		return Future.fromResult(this.promptSlnName);
+	}
+}
+
+function createTestInjector(promptSlnName?: string, promptPrjName?: string): IInjector {
+	let testInjector = new yok.Yok();
+
+	testInjector.register("errors", stubs.ErrorsStub);
+	testInjector.register("userDataStore", {
+		getUser: () =>  Future.fromResult({tenant: {id: "id"}}),
+	});
+	testInjector.register("serviceProxy", {
+		setSolutionSpaceName: (tenantId: string) => {}
+	});
+	testInjector.register("server", {
+		tap: {
+			getExistingClientSolutions: () => {
+				return Future.fromResult(
+				[{
+					"id": "id2",
+					"name": "Sln2",
+					"accountId": "accountId",
+					"workspaceId": "workspaceId2",
+					"description": "AppBuilder cross platform project"
+				},
+				{
+					"id": "id1",
+					"name": "Sln1",
+					"accountId": "accountId",
+					"workspaceId": "workspaceId1",
+					"description": "AppBuilder cross platform project"
+				},
+				{
+					"id": "id3",
+					"name": "Sln3",
+					"accountId": "accountId",
+					"workspaceId": "workspaceId3",
+					"description": "AppBuilder cross platform project"
+				}]);
+			}
+		}, 
+		projects: {
+			getSolution: (slnName: string, checkUpgradability: boolean) => {
+				if(slnName === "Sln1") {
+					return Future.fromResult({
+						"Name": "Sln1",
+						"Items": [
+							{
+								"Name": "BlankProj",
+								"RelativePath": "BlankProj",
+								"Items": [
+									{
+										"Type": "Content",
+										"Identifier": ".abignore"
+									}
+								],
+								"Properties": {
+									"ProjectName": "BlankProj",
+									"Framework": "Cordova"
+								}
+							},
+							{
+								"Name": "ABlankProjMobileTesting",
+								"RelativePath": "ABlankProjMobileTesting",
+								"Items": [
+									{
+										"Type": "Content",
+										"Identifier": ".abignore"
+									},
+									{
+										"Type": "Content",
+										"Identifier": "MobileTestingSuite1.js"
+									}
+								],
+								"Properties": {
+									"ProjectName": "ABlankProjMobileTesting",
+									"Framework": "MobileTesting"
+								},
+								"PerConfigurationProperties": {}
+							}
+						],
+						"IsUpgradeable": false
+					}); 
+				} else if (slnName === "Sln2") {
+					return Future.fromResult({
+						"Name": "Sln1",
+						"Items": [],
+						"IsUpgradeable": false
+					});
+				} else if(slnName === "Sln3") {
+					return Future.fromResult({
+						"Name": "Sln1",
+						"Items": [
+							{
+								"Name": "BlankProj",
+								"RelativePath": "BlankProj",
+								"Items": [
+									{
+										"Type": "Content",
+										"Identifier": ".abignore"
+									}
+								],
+								"Properties": {
+									"ProjectName": "BlankProj",
+									"Framework": "Cordova"
+								}
+							}
+						],
+						"IsUpgradeable": false
+					}); 
+				}
+			}, 
+			exportProject: (solutionSpaceName: string, solutionName: string, projectName: string, skipMetadata: boolean, $resultStream: any) => {
+				return Future.fromResult();
+			}
+		}
+	});
+	testInjector.register("fs", {
+		exists: (path: string) => {
+			if(path.indexOf("abproject") !== -1) {
+				return Future.fromResult(true);
+			} else {
+				return Future.fromResult(false);
+			}
+		},
+		createWriteStream: (path: string) => {},
+		unzip: (zipFile: string, destinationDir: string) => Future.fromResult(),
+	})
+	testInjector.register("remoteProjectService", remoteProjectsServiceLib.RemoteProjectService);
+	testInjector.register("projectConstants", projectConstantsLib.ProjectConstants);
+	testInjector.register("project", {
+		getNewProjectDir:() => "proj dir",
+		createProjectFile: (projectDir: string, properties: any) => Future.fromResult()
+	});
+	testInjector.register("prompter", new PrompterStub(promptSlnName, promptPrjName));
+	testInjector.register("logger", new LoggerStub());
+	return testInjector;
+}
+
+describe("cloud project commands", () => {
+	describe("export project command", () => {
+		let testInjector: IInjector;
+		let exportProjectCommand: ICommand;
+
+		describe("canExecute", () => {
+			beforeEach(() => {
+				testInjector = createTestInjector();
+				exportProjectCommand = testInjector.resolve(cloudProjectsCommandsLib.CloudExportProjectsCommand);
+			});
+
+			it("returns true when no arguments are specified", () => {
+				assert.isTrue(exportProjectCommand.canExecute([]).wait());
+			});
+
+			it("returns true when valid solution name is specified", () => {
+				assert.isTrue(exportProjectCommand.canExecute(["Sln1"]).wait());
+			});
+
+			it("returns true when valid solution name and project name are specified", () => {
+				assert.isTrue(exportProjectCommand.canExecute(["Sln1", "BlankProj"]).wait());
+			});
+
+			it("returns true when valid solution index is specified", () => {
+				assert.isTrue(exportProjectCommand.canExecute(["1"]).wait());
+			});
+
+			it("returns true when valid solution id and project name are specified", () => {
+				assert.isTrue(exportProjectCommand.canExecute(["1", "BlankProj"]).wait());
+			});
+
+			it("returns true when valid solution name and project id are specified", () => {
+				assert.isTrue(exportProjectCommand.canExecute(["Sln1", "2"]).wait());
+			});
+
+			it("returns true when valid solution id and project id are specified", () => {
+				assert.isTrue(exportProjectCommand.canExecute(["1", "2"]).wait());
+			});
+			
+			it("fails when more than two arguments are passed", () => {
+				assert.throws(() => exportProjectCommand.canExecute(["1", "2", "3"]).wait())
+			});
+		});
+
+		// in this tests we assume parameters are correct as commands service will verify them in canExecute method, which is called before this one
+		describe("еxecute", () => {
+			let logger: LoggerStub;
+
+			describe("successfully exports project when solution and project names are passed", () => {
+				beforeEach(() => {
+					testInjector = createTestInjector();
+					exportProjectCommand = testInjector.resolve(cloudProjectsCommandsLib.CloudExportProjectsCommand);
+					logger = testInjector.resolve("logger");
+					assert.equal("", logger.infoOutput);
+				});
+
+				afterEach(() => {
+					assert.isTrue(logger.infoOutput.indexOf("has been successfully exported") !== -1);
+				});
+
+				it("successfully exports project when solution name and project name are correct", () => {
+					exportProjectCommand.execute(["Sln1", "BlankProj"]).wait();
+				});
+
+				it("successfully exports project when solution id and project name are correct", () => {
+					exportProjectCommand.execute(["1", "BlankProj"]).wait();
+				});
+
+				it("successfully exports project when solution name and project id are correct", () => {
+					exportProjectCommand.execute(["Sln1", "2"]).wait();
+				});
+
+				it("successfully exports project when solution id and project id are correct", () => {
+					exportProjectCommand.execute(["1", "2"]).wait();
+				});
+			});
+			
+			describe("works correctly when only solution name is passed", () => {
+				beforeEach(() => {
+					testInjector = createTestInjector("Sln1", "BlankProj");
+					exportProjectCommand = testInjector.resolve(cloudProjectsCommandsLib.CloudExportProjectsCommand);
+					logger = testInjector.resolve("logger");
+					assert.equal("", logger.infoOutput);
+				});
+
+				it("successfully exports project when solution name is correct and there are more than one projects in solution", () => {
+					exportProjectCommand.execute(["Sln1"]).wait();
+					assert.isTrue(logger.infoOutput.indexOf("has been successfully exported") !== -1);
+				});
+
+				it("successfully exports project when solution name is correct and there is only one projects in solution", () => {
+					exportProjectCommand.execute(["Sln3"]).wait();
+					let prompter:PrompterStub = testInjector.resolve("prompter");
+					assert.isFalse(prompter.isPrompterCalled);
+					assert.isTrue(logger.infoOutput.indexOf("has been successfully exported") !== -1);
+				});
+				
+				it("throws error when solution does not have any projects", () => {
+					exportProjectCommand.execute(["Sln2"]).wait()
+					assert.isTrue(logger.warnOutput.indexOf("does not have any projects.") > 0);
+				});
+			});
+
+			it("works correctly when no arguments are passed", () => {
+					testInjector = createTestInjector("Sln1", "BlankProj");
+					exportProjectCommand = testInjector.resolve(cloudProjectsCommandsLib.CloudExportProjectsCommand);
+					exportProjectCommand.execute([]).wait();
+					logger = testInjector.resolve("logger");
+					assert.isTrue(logger.infoOutput.indexOf("has been successfully exported") !== -1);
+			});
+
+			describe("fails when project is already created", () => {
+				let project: Project.IProject;
+				let fs: IFileSystem;
+				beforeEach(() => {
+					testInjector = createTestInjector("Sln1", "BlankProj");
+					exportProjectCommand = testInjector.resolve(cloudProjectsCommandsLib.CloudExportProjectsCommand);
+					logger = testInjector.resolve("logger");
+					assert.equal("", logger.infoOutput);
+					project = testInjector.resolve("project");
+					fs = testInjector.resolve("fs");
+				});
+
+				it("fails when projectDir exists", () => {
+					fs.exists = (projectDir: string) => { return Future.fromResult(true);}
+					assert.throws(() => exportProjectCommand.execute(["Sln1", "BlankProj"]).wait());
+				});
+
+				it("fails when there's projectData", () => {
+					project.projectData = <any>{};
+					assert.throws(() => exportProjectCommand.execute(["Sln1", "BlankProj"]).wait());
+				});
+
+				it("warns when unable to create project file", () => {
+					fs.exists = (param: string) => Future.fromResult(false);
+					project.createProjectFile = (projectDir: string, properties: any) => {
+						let future = new Future<void>();
+						future.throw("error is raised");
+						return future;
+					}
+					logger = testInjector.resolve("logger");
+					exportProjectCommand.execute(["Sln1", "BlankProj"]).wait();
+					assert.isTrue(logger.warnOutput.indexOf("Couldn't create project file: error is raised") !== -1);
+				});
+			})
+		});
+	});
+
+	describe("list project command", () => {
+		let testInjector: IInjector;
+		let listProjectCommand: ICommand;
+		describe("command parameter works correctly", () => {
+			let commandParamter: ICommandParameter;
+			beforeEach(() => {
+				testInjector = createTestInjector("Sln1", "BlankProj");
+				listProjectCommand = testInjector.resolve(cloudProjectsCommandsLib.CloudListProjectsCommand);
+				commandParamter = listProjectCommand.allowedParameters[0];
+			});
+			
+			it("validate method returns true when valid solution name is passed", () => {
+				assert.isTrue(commandParamter.validate("Sln1").wait());
+			});
+
+			it("validate method returns true when valid solution id is passed", () => {
+				assert.isTrue(commandParamter.validate("1").wait());
+			});
+
+			it("validate method throws error when invalid solution name is passed", () => {
+				assert.throws(() => commandParamter.validate("Invalid name").wait());
+			});
+
+			it("validate method throws error when invalid solution id is passed", () => {
+				assert.throws(() => commandParamter.validate("100").wait());
+			});
+			
+			it("validate method returns false when validation value is not passed", () => {
+				assert.isFalse(commandParamter.validate(undefined).wait());
+			});
+		});
+
+		describe("lists projects", () => {
+			let logger: LoggerStub;
+			beforeEach(() => {
+				testInjector = createTestInjector("Sln1", "BlankProj");
+				listProjectCommand = testInjector.resolve(cloudProjectsCommandsLib.CloudListProjectsCommand);
+				logger = testInjector.resolve("logger");
+				assert.equal("", logger.outOutput);
+			});
+			
+			afterEach(() => {
+				let blankProjIndex = logger.outOutput.indexOf("BlankProj");
+				let aBlankPrjMobileTestingIndex = logger.outOutput.indexOf("ABlankProjMobileTesting") 
+				assert.isTrue(blankProjIndex !== -1);
+				assert.isTrue(aBlankPrjMobileTestingIndex !== -1);
+				assert.isTrue(aBlankPrjMobileTestingIndex < blankProjIndex);
+			});
+			
+			it("when solution name is passed", () => {
+				listProjectCommand.execute(["Sln1"]).wait();
+			});
+
+			it("when solution id is passed", () => {
+				listProjectCommand.execute(["1"]).wait();
+			});
+
+			it("when solution name is NOT passed", () => {
+				listProjectCommand.execute([]).wait();
+			});
+		});
+	});
+});

--- a/test/remote-projects-service.ts
+++ b/test/remote-projects-service.ts
@@ -1,0 +1,222 @@
+///<reference path=".d.ts"/>
+"use strict";
+
+import stubs = require("./stubs");
+import yok = require("../lib/common/yok");
+import optionsLib = require("../lib/options");
+import remoteProjectsServiceLib = require("../lib/services/remote-projects-service");
+
+let assert = require("chai").assert;
+import Future = require("fibers/future");
+import util = require("util");
+
+function createTestInjector(): IInjector {
+	let testInjector = new yok.Yok();
+	testInjector.register("errors", stubs.ErrorsStub);
+	testInjector.register("userDataStore", {
+		getUser: () =>  Future.fromResult({tenant: {id: "id"}}),
+	});
+	testInjector.register("serviceProxy", {
+		setSolutionSpaceName: (tenantId: string) => {}
+	});
+	testInjector.register("server", {
+		tap: {
+			getExistingClientSolutions: () => {
+				return Future.fromResult(
+				[{
+					"id": "id2",
+					"name": "Sln2",
+					"accountId": "accountId",
+					"workspaceId": "workspaceId2",
+					"description": "AppBuilder cross platform project"
+				},{
+					"id": "id1",
+					"name": "Sln1",
+					"accountId": "accountId",
+					"workspaceId": "workspaceId1",
+					"description": "AppBuilder cross platform project"
+				}]);
+			}
+		}, 
+		projects: {
+			getSolution: (projectName: string, checkUpgradability: boolean) => {
+				return Future.fromResult({
+					"Name": "Sln1",
+					"Items": [
+						{
+							"Name": "BlankProj",
+							"RelativePath": "BlankProj",
+							"Items": [
+								{
+									"Type": "Content",
+									"Identifier": ".abignore"
+								}
+							],
+							"Properties": {
+								"ProjectName": "BlankProj",
+								"Framework": "Cordova"
+							}
+						},
+						{
+							"Name": "ABlankProjMobileTesting",
+							"RelativePath": "ABlankProjMobileTesting",
+							"Items": [
+								{
+									"Type": "Content",
+									"Identifier": ".abignore"
+								},
+								{
+									"Type": "Content",
+									"Identifier": "MobileTestingSuite1.js"
+								}
+							],
+							"Properties": {
+								"ProjectName": "ABlankProjMobileTesting",
+								"Framework": "MobileTesting"
+							},
+							"PerConfigurationProperties": {}
+						}
+					],
+					"IsUpgradeable": false
+				});
+			}
+		}
+	});
+	return testInjector;
+}
+
+describe("remote project service", () => {
+	let testInjector: IInjector;
+		let remoteProjectService: IRemoteProjectService;
+		beforeEach(() => {
+			testInjector = createTestInjector();
+			remoteProjectService = testInjector.resolve(remoteProjectsServiceLib.RemoteProjectService);
+		});
+	
+	it("getSolutions returns correct sorted results", () => {
+		let solutions = remoteProjectService.getSolutions().wait();
+		let expectedResult = ["Sln1", "Sln2"];
+		assert.deepEqual(expectedResult, solutions.map(sln => sln.name));
+	});
+	
+	describe("getProjectsForSolution", () => {
+		it("fails when solution name does not exist", () => {
+			assert.throws( () => remoteProjectService.getProjectsForSolution("Invalid name").wait() );
+		});
+	
+		it("returns correct sorted result when name is correct", () => {
+			let projects = remoteProjectService.getProjectsForSolution("Sln1").wait();
+			let expectedResult = ["ABlankProjMobileTesting", "BlankProj"];
+			assert.deepEqual(expectedResult, projects.map(pr => pr.Name));
+		});
+
+		it("returns correct sorted result when passed index is correct", () => {
+			let projects = remoteProjectService.getProjectsForSolution("1").wait();
+			let expectedResult = ["ABlankProjMobileTesting", "BlankProj"];
+			assert.deepEqual(expectedResult, projects.map(pr => pr.Name));
+		});
+
+		it("fails when solution index is out of range", () => {
+			assert.throws( () => remoteProjectService.getProjectsForSolution("5").wait() );
+		});
+	});
+
+	describe("getProjectProperties", () => {
+		let expectedPropertiesResult = {
+			"ProjectName": "BlankProj",
+			"Framework": "Cordova"
+		};
+
+		it("fails when solution name is not correct", () => {
+			assert.throws( () => remoteProjectService.getProjectProperties("Invalid name", "BlankProj").wait() );
+		});
+
+		it("fails when solution index is not correct", () => {
+			assert.throws( () => remoteProjectService.getProjectProperties("5", "BlankProj").wait() );
+		});
+
+		it("fails when project name is not correct", () => {
+			assert.throws( () => remoteProjectService.getProjectProperties("Sln1", "Invalid name").wait() );
+		});
+
+		it("fails when project index is not correct", () => {
+			assert.throws( () => remoteProjectService.getProjectProperties("Sln1", "5").wait() );
+		});
+
+		it("returns correct properties when solution name and project name are correct", () => {
+			let properties = remoteProjectService.getProjectProperties("Sln1", "BlankProj").wait();
+			assert.deepEqual(expectedPropertiesResult, properties);
+		});
+
+		it("returns correct properties when solution id and project name are correct", () => {
+			let properties = remoteProjectService.getProjectProperties("1", "BlankProj").wait();
+			assert.deepEqual(expectedPropertiesResult, properties);
+		});
+
+		it("returns correct properties when solution name and project id are correct", () => {
+			let properties = remoteProjectService.getProjectProperties("Sln1", "2").wait();
+			assert.deepEqual(expectedPropertiesResult, properties);
+		});
+
+		it("returns correct properties when solution name and project id are correct", () => {
+			let properties = remoteProjectService.getProjectProperties("1", "2").wait();
+			assert.deepEqual(expectedPropertiesResult, properties);
+		});
+	});
+
+	describe("getSolutionName", () => {
+		let expectedResult = "Sln1";
+
+		it("fails when solution name is not correct", () => {
+			assert.throws( () => remoteProjectService.getSolutionName("Invalid name").wait() );
+		});
+
+		it("fails when solution index is not correct", () => {
+			assert.throws( () => remoteProjectService.getSolutionName("5").wait() );
+		});
+
+		it("returns correct name when solution name is correct", () => {
+			let properties = remoteProjectService.getSolutionName("Sln1").wait();
+			assert.deepEqual(expectedResult, properties);
+		});
+
+		it("returns correct name when solution name is correct", () => {
+			let properties = remoteProjectService.getSolutionName("1").wait();
+			assert.deepEqual(expectedResult, properties);
+		});
+	});
+	
+	describe("getProjectName", () => {
+		let expectedResult = "BlankProj";
+		it("fails when solution name is not correct", () => {
+			assert.throws( () => remoteProjectService.getProjectName("Invalid name", "BlankProj").wait() );
+		});
+
+		it("fails when solution index is not correct", () => {
+			assert.throws( () => remoteProjectService.getProjectName("5", "BlankProj").wait() );
+		});
+
+		it("fails when solution name is correct but project name is not", () => {
+			assert.throws( () => remoteProjectService.getProjectName("Sln1", "Invalid name").wait() );
+		});
+
+		it("fails when solution name is correct but project id is not", () => {
+			assert.throws( () => remoteProjectService.getProjectName("Sln1", "5").wait() );
+		});
+
+		it("returns correct name when solution name and project name are", () => {
+			let projName = remoteProjectService.getProjectName("Sln1", "BlankProj").wait();
+			assert.deepEqual(expectedResult, projName);
+		});
+
+		it("returns correct name when solution id and project name are correct", () => {
+			let projName = remoteProjectService.getProjectName("1", "BlankProj").wait();
+			assert.deepEqual(expectedResult, projName);
+		});
+
+		it("returns correct name when solution name and project id are correct", () => {
+			let projName = remoteProjectService.getProjectName("Sln1", "2").wait();
+			assert.deepEqual(expectedResult, projName);
+		});
+	});
+});


### PR DESCRIPTION
Our code is always exporting the first project in a solution. Also the endpoint which we are using does not exist anymore.
Use the new endpoint and modify the behavior in the following way:
* `$ appbuilder cloud` - prompts you to select solution for which to list the projects
* `$ appbuilder cloud Sln1` - lists projects of Sln1 solution
* `$ appbuilder cloud 1` - lists projects of the first solution listed by `$ appbuilder cloud`
* `$ appbuilder cloud export` - prompts to select solution from which to export project. If the selected solution has only one project - directly export it. In case the solution does not have any projects - show error. In case the project has more than one project - prompt the user to select one of the projects and after that export it.
* `$ appbuilder cloud export Sln1` - Checks if the selected solution (Sln1) has only one project - directly export it. In case the solution does not have any projects - show error. In case the project has more than one project - prompt the user to select one of the projects and after that export it.
* `$ appbuilder cloud export 1` - Checks if the selected solution (first project listed by `$ appbuilder cloud`) has only one project - directly export it. In case the solution does not have any projects - show error. In case the project has more than one project - prompt the user to select one of the projects and after that export it.
* `$ appbuilder cloud export Sln1 Proj1` - Exports Proj1 of Sln1. If any of them does not exists, throw error.
* `$ appbuilder cloud export 1 Proj1` - Exports Proj1 from the first solution listed by `$ appbuilder cloud`. If any of them does not exists, throw error.
* `$ appbuilder cloud Sln1 1` - Exports first project of Sln1 listed by `$ appbuilder cloud`. If any of them does not exists, throw error.
* `$ appbuilder cloud 1 1` - Exports first project of the first solution listed by `$ appbuilder cloud`. If any of them does not exists, throw error.

Add unit tests for RemoteProjectService and cloud commands.
Implements http://teampulse.telerik.com/view#item/295399

> Also: Make swagger generating enums as `const enum` and regenerate our server api.