### PR TITLE
Add dashedOptions for each command

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "winreg": "0.0.12",
     "xml-mapping": "1.5.2",
     "xmlhttprequest": "https://github.com/telerik/node-XMLHttpRequest/tarball/master",
-    "yargs": "1.2.2",
+    "yargs": "3.12.0",
     "zipstream": "https://github.com/Icenium/node-zipstream/tarball/master"
   },
   "analyze": true,

--- a/test/common-options.ts
+++ b/test/common-options.ts
@@ -1,22 +1,24 @@
 ///<reference path=".d.ts"/>
 "use strict";
 
-import optionsPath = require("../lib/common/options");
+let optionsPath = require("../lib/common/options");
 import errorsLib = require("../lib/common/errors");
 import yok = require("./../lib/common/yok");
-import yargs = require("yargs");
+let yargs = require("yargs");
 let assert = require("chai").assert;
 let optionType = optionsPath.OptionType;
 
 let isExecutionStopped = false;
 
 let knownOpts = {
-	"path": { type: optionType.String },
+	"path1": { type: optionType.String },
 	"help": { type: optionType.Boolean } ,
 	"verbose": { type: optionType.Boolean, alias: "v" },
 	"profileDir": { type: optionType.String },
 	"someDashedValue": { type: optionType.String },
-	"aBCDEFG": { type: optionType.String }
+	"aBCDEFG": { type: optionType.String },
+	"arr": { type: optionType.Array },
+	"specialDashedV": { type: optionType.Boolean }
 };
 
 function createTestInjector(): IInjector {
@@ -30,198 +32,243 @@ function createTestInjector(): IInjector {
 	return testInjector;
 }
 
-function createOptions(optionValues: any, testInjector: IInjector): IOptions {
-	yargs.options = () => { return <any>{ argv: optionValues } };
+function createOptions(testInjector: IInjector): IOptions {
 	let options = testInjector.resolve(optionsPath.OptionsBase, { options: knownOpts, defaultProfileDir: "1" }); // Validation is triggered in options's constructor
 	return options;
 }
 
 describe("common options", () => {
 	let testInjector: IInjector;
-	before(() => {
+	beforeEach(() => {
 		testInjector = createTestInjector();
 		
 		let errors = new errorsLib.Errors();
-        errors.failWithoutHelp = (message: string, ...args: any[]): void => {
-            isExecutionStopped = true;
-        }
+		errors.failWithoutHelp = (message: string, ...args: any[]): void => {
+			isExecutionStopped = true;
+		};
+		errors.fail = (message: string, ...args: any[]): void => {
+			isExecutionStopped = true;
+		};
 		
 		testInjector.register("errors", errors);
-		
-		yargs.argv = {}; // We need to ensure that the options from previous test are not passed to the next one
+		isExecutionStopped = false;
 	});
 
 	describe("validateOptions", () => {
 		it("breaks execution when option is not valid", () => {
-			isExecutionStopped = false;
-			let options = createOptions({pathr: "incorrect argument"}, testInjector);
+			process.argv.push('--pathr');
+			process.argv.push("incorrect argument");
+			let options = createOptions(testInjector);
 			options.validateOptions();
-
+			process.argv.pop();
+			process.argv.pop();
 			assert.isTrue(isExecutionStopped);
 		});
 
 		it("breaks execution when valid option does not have value", () => {
-			isExecutionStopped = false;
-
+			process.argv.push('--path1');
 			// If you do not pass value to an option, it's automatically set as true.
-			let options = createOptions({ path: true }, testInjector);
+			let options = createOptions(testInjector);
 			options.validateOptions();
-
+			process.argv.pop();
 			assert.isTrue(isExecutionStopped);
 		});
 
 		it("does not break execution when valid option has correct value", () => {
-			isExecutionStopped = false;
-
-			let options = createOptions({ path: "SomeDir" }, testInjector);
+			process.argv.push('--path1');
+			process.argv.push("SomeDir");
+			let options = createOptions(testInjector);
 			options.validateOptions();
-
+			process.argv.pop();
+			process.argv.pop();
 			assert.isFalse(isExecutionStopped);
 		});
 
-		it("breaks execution when valid option has incorrect value", () => {
-			isExecutionStopped = false;
-
-			// help requires boolean value.
-			let options = createOptions({help: "Invalid string value" }, testInjector);
-			options.validateOptions();
-
-			assert.isTrue(isExecutionStopped);
-		});
-
 		it("breaks execution when valid option has empty string value", () => {
-			isExecutionStopped = false;
-
-			let options = createOptions({ path: "" }, testInjector);
+			process.argv.push('--path');
+			let options = createOptions(testInjector);
 			options.validateOptions();
-
+			process.argv.pop();
 			assert.isTrue(isExecutionStopped);
 		});
 
 		it("breaks execution when valid option has value with spaces only", () => {
-			isExecutionStopped = false;
-
-			let options = createOptions({ path: "  " }, testInjector);
+			process.argv.push('--path');
+			process.argv.push('  ');
+			let options = createOptions(testInjector);
 			options.validateOptions();
-			
+			process.argv.pop();
+			process.argv.pop();
 			assert.isTrue(isExecutionStopped);
 		});
 
 		it("breaks execution when shorthand option is not valid", () => {
-			isExecutionStopped = false;
-
-			let options = createOptions({ r: "incorrect shorthand" }, testInjector);
+			process.argv.push('-r');
+			process.argv.push('incorrect shorthand');
+			let options = createOptions(testInjector);
 			options.validateOptions();
-
+			process.argv.pop();
+			process.argv.pop();
 			assert.isTrue(isExecutionStopped);
 		}); 
 
 		it("does not break execution when valid shorthand option has correct value", () => {
-			isExecutionStopped = false;
-
-			let options = createOptions({ v: true }, testInjector);
+			process.argv.push('-v');
+			let options = createOptions(testInjector);
 			options.validateOptions();
-
+			process.argv.pop();
 			assert.isFalse(isExecutionStopped);
 			assert.isTrue(options.verbose);
 		});
 
-		it("breaks execution when valid shorthand option has incorrect value", () => {
-			isExecutionStopped = false;
- 
- 			// v requires boolean value
-			let options = createOptions({ v: "invalid string value" }, testInjector);
-			options.validateOptions();
-
-			assert.isTrue(isExecutionStopped);
-		});
-
 		// all numbers are changed to strings before calling validateOptions
 		it("does not break execution when valid option has number value", () => {
-			isExecutionStopped = false;
-
-			let options = createOptions({ path: "1" }, testInjector);
+			process.argv.push('--path');
+			process.argv.push('1');
+			let options = createOptions(testInjector);
 			options.validateOptions();
-
+			process.argv.pop();
+			process.argv.pop();
 			assert.isFalse(isExecutionStopped);
 		});
 
-		it("breaks execution when valid option has null value", () => {
-			isExecutionStopped = false;
-
-			let options = createOptions({ path: null }, testInjector);
+		it("throws error when valid option has array value", () => {
+			process.argv.push('--path');
+			process.argv.push("value 1");
+			process.argv.push('--path');
+			process.argv.push("value 2");
+			let options = createOptions(testInjector);
 			options.validateOptions();
-
+			process.argv.pop();
+			process.argv.pop();
+			process.argv.pop();
+			process.argv.pop();
 			assert.isTrue(isExecutionStopped);
 		});
 
-		it("breaks execution when valid option has undefined value", () => {
-			isExecutionStopped = false;
+		it("converts string value to array when option type is array", () => {
+			let options: any = createOptions(testInjector);
+			process.argv.push("--test1");
+			process.argv.push("value");
+			options.validateOptions({test1: {type: optionsPath.OptionType.Array}});
+			process.argv.pop();
+			process.argv.pop();
+			assert.isFalse(isExecutionStopped);
+			assert.deepEqual(["value"], <any>options["test1"]);
+		});
 
-			let options = createOptions({ path: undefined }, testInjector);
+		it("does not break execution when valid commandSpecificOptions are passed", () => {
+			process.argv.push("--test1");
+			process.argv.push("value");
+			let options = createOptions(testInjector);
+			options.validateOptions({test1: {type: optionsPath.OptionType.String}});
+			process.argv.pop();
+			process.argv.pop();
+			assert.isFalse(isExecutionStopped);
+		});
+
+		it("does not break execution when valid commandSpecificOptions are passed and user specifies globally valid option", () => {
+			let options = createOptions(testInjector);
+			process.argv.push("--version");
+			options.validateOptions({test1: {type: optionsPath.OptionType.String}});
+			process.argv.pop();
+			assert.isFalse(isExecutionStopped);
+		});
+
+		it("breaks execution when valid array option has value with length 0", () =>{
+			process.argv.push('--arr');
+			let options = createOptions(testInjector);
 			options.validateOptions();
-
+			process.argv.pop();
 			assert.isTrue(isExecutionStopped);
+		});
+
+		describe("when commandSpecificOptions are passed", () => {
+			it("breaks execution when commandSpecificOptions are passed and user tries to use invalid option", () => {
+				process.argv.push("--invalidOption");
+				let options = testInjector.resolve(optionsPath.OptionsBase, { options: knownOpts, defaultProfileDir: "1" });
+				options.validateOptions({test1: {type: optionsPath.OptionType.String}});
+				process.argv.pop();
+				assert.isTrue(isExecutionStopped);
+			});
+
+			it("breaks execution when commandSpecificOptions are passed and user tries to use option valid for CLI, but not for this command", () => {
+				process.argv.push("--json");
+				let options = testInjector.resolve(optionsPath.OptionsBase, { options: knownOpts, defaultProfileDir: "1" });
+				options.validateOptions({test1: {type: optionsPath.OptionType.String}});
+				process.argv.pop();
+				assert.isTrue(isExecutionStopped);
+			});
+
+			it("uses profile-dir from yargs when it exists and commandSpecificOptions are passed", () => {
+				let expectedProfileDir = "TestDir";
+				process.argv.push("--profile-dir");
+				process.argv.push(expectedProfileDir);
+				let options = testInjector.resolve(optionsPath.OptionsBase, { options: knownOpts, defaultProfileDir: "1" });
+				options.validateOptions({test1: {type: optionsPath.OptionType.String}});
+				assert.equal(options.profileDir, expectedProfileDir);
+				process.argv.pop();
+				process.argv.pop();
+				assert.isFalse(isExecutionStopped);
+			});
 		});
 
 		// when you pass --option with dash, yargs adds it to yargs.argv in two ways:
 		// for ex. '$ appbuilder login --profile-dir "some dir"' will add profile dir to yargs.argv as: profileDir and profile-dir
 		describe("validates dashed options correctly",() => {
 			it("does not break execution when dashed option with single dash is passed",() => {
-				isExecutionStopped = false;
-				let optionValues = {
-					"profile-dir": "some dir",
-					profileDir: "some dir"
-				};
-
-				let options = createOptions(optionValues, testInjector);
+				process.argv.push("profile-dir");
+				process.argv.push("some dir");
+				let options = createOptions(testInjector);
 				options.validateOptions();
+				process.argv.pop();
+				process.argv.pop();
 				assert.isFalse(isExecutionStopped, "Dashed options should be validated in specific way. Make sure validation allows yargs specific behavior:" +
 					"Dashed options (profile-dir) are added to yargs.argv in two ways: profile-dir and profileDir");
 			});
 
 			it("does not break execution when dashed option with two dashes is passed",() => {
-				isExecutionStopped = false;
-				let optionValues = {
-					"some-dashed-value": "some dir",
-					"someDashedValue": "some dir"
-				};
-
-				let options = createOptions(optionValues, testInjector);
+				process.argv.push("some-dashed-value");
+				process.argv.push("some dir");
+				let options = createOptions(testInjector);
 				options.validateOptions();
+				process.argv.pop();
+				process.argv.pop();
 				assert.isFalse(isExecutionStopped, "Dashed options should be validated in specific way. Make sure validation allows yargs specific behavior:" +
 					"Dashed options (some-dashed-value) are added to yargs.argv in two ways: some-dashed-value and someDashedValue");
 			});
 
 			it("does not break execution when dashed option with a lot of dashes is passed",() => {
-				isExecutionStopped = false;
-				let optionValues = {
-					"a-b-c-d-e-f-g": "some dir",
-					"aBCDEFG": "some dir"
-				};
-
-				let options = createOptions(optionValues, testInjector);
+				process.argv.push("a-b-c-d-e-f-g");
+				process.argv.push("some dir");
+				let options = createOptions(testInjector);
 				options.validateOptions();
 
+				process.argv.pop();
+				process.argv.pop();
 				assert.isFalse(isExecutionStopped, "Dashed options should be validated in specific way. Make sure validation allows yargs specific behavior:" +
 					"Dashed options (a-b-c-d-e-f-g) are added to yargs.argv in two ways: a-b-c-d-e-f-g and aBCDEFG.");
 			});
+
+			it("does not break execution when dashed option with two dashes is passed",() => {
+				process.argv.push("--special-dashed-v");
+				let options = createOptions(testInjector);
+				options.validateOptions();
+				process.argv.pop();
+				assert.isFalse(isExecutionStopped, "Dashed options should be validated in specific way. Make sure validation allows yargs specific behavior:" +
+					"Dashed options (special-dashed-v) are added to yargs.argv in two ways: special-dashed-v and specialDashedV");
+			});
+			
 		});
 	});
 });
 
-
-function createOptionsWithProfileDir(optionValues: any, profileDir: string): IOptions {
-	let knownOptions = {
-		"profile-dir": { type: optionType.String }
-	}
-
+function createOptionsWithProfileDir(profileDir: string): IOptions {
 	let testInjector = new yok.Yok();
 	testInjector.register("errors", {});
 	testInjector.register("staticConfig", {});
 
-	yargs.options = () => { return <any>{ argv: optionValues } };
-	let options = testInjector.resolve(optionsPath.OptionsBase, { options: knownOptions, defaultProfileDir: profileDir });
+	let options = testInjector.resolve(optionsPath.OptionsBase, { options: {}, defaultProfileDir: profileDir });
 	return options;
 }
 
@@ -235,16 +282,18 @@ describe("common options profile-dir tests", () => {
 				"profile-dir": expectedProfileDir,
 				profileDir: expectedProfileDir
 			};
-
-			let options = createOptionsWithProfileDir(optionValues, "");
-			options.validateOptions();			
-			
+			process.argv.push("--profile-dir");
+			process.argv.push(expectedProfileDir);
+			let options = createOptionsWithProfileDir("");
+			options.validateOptions();
+			process.argv.pop();
+			process.argv.pop();
 			assert.equal(options.profileDir, expectedProfileDir);
 		});
 
 		it("sets default profile-dir when it is not passed on command line", () => {
 			let profileDir = "TestDir";
-			let options = createOptionsWithProfileDir({}, "TestDir");
+			let options = createOptionsWithProfileDir("TestDir");
 			options.validateOptions();
 			assert.equal(options.profileDir, profileDir);
 		});
@@ -254,10 +303,12 @@ describe("common options profile-dir tests", () => {
 			let optionValues = {
 				profileDir: expectedProfileDir
 			};
-
-			let options = createOptionsWithProfileDir(optionValues, "");
+			process.argv.push("--profileDir");
+			process.argv.push(expectedProfileDir);
+			let options = createOptionsWithProfileDir("");
 			options.validateOptions();
-			
+			process.argv.pop();
+			process.argv.pop();
 			assert.equal(options.profileDir, expectedProfileDir);
 		});
 	}); 

--- a/test/plugins-service.ts
+++ b/test/plugins-service.ts
@@ -568,7 +568,7 @@ describe("plugins-service", () => {
 				configurations: configs,
 				Version: version
 			};
-		}
+		};
 
 		describe("modifies marketplace plugin version in both configurations when different versions are used",() => {
 			let installedMarketplacePluginsInDebug = [getToastPlugin("2.0.1", "debug")],
@@ -923,6 +923,7 @@ describe("plugins-service", () => {
 						testInjector = createTestInjectorForProjectWithBothConfigurations(installedMarketplacePluginsInDebug, [], true);
 						testInjector.register("prompter", new PrompterStub(1, 0)); // 0 is for version 2.0.1
 						service = testInjector.resolve(pluginsService.PluginsService);
+						options = testInjector.resolve("options");
 					});
 					
 					it("when user wants to update same configuration only", ()=> {
@@ -1017,7 +1018,7 @@ describe("plugins-service", () => {
 			let testInjector: IInjector = createTestInjectorForProjectWithBothConfigurations(installedMarketplacePluginsInDebug, [], true);
 			testInjector.register("prompter", new PrompterStub(2));
 			service = testInjector.resolve(pluginsService.PluginsService);
-
+			options = testInjector.resolve("options");
 			options.debug = false;
 			options.release = true;
 			assert.throws(() => service.addPlugin(`Toast@${versionToSet}`).wait());

--- a/test/project.ts
+++ b/test/project.ts
@@ -225,13 +225,6 @@ describe("project integration tests", () => {
 				assert.deepEqual(testProperties[key], correctProperties[key]);
 			}
 		});
-
-		it("with long name should throw ", () => {
-			project = testInjector.resolve(projectlib.Project);
-			let projectName = "Thirtyone character long string";
-
-			assert.throws(() => project.createNewProject(projectName, projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait());
-		});
 	});
 
 	describe("updateProjectPropertiesAndSave",() => {
@@ -240,7 +233,7 @@ describe("project integration tests", () => {
 			prompter = testInjector.resolve("prompter");
 			prompter.confirmResult = true;
 			let tempFolder = temp.mkdirSync("template");
-
+			options = testInjector.resolve("options");
 			options.path = tempFolder;
 			options.template = "Blank";
 			options.appid = "com.telerik.Test";
@@ -315,9 +308,11 @@ describe("project integration tests", () => {
 		let mobileHelper: Mobile.IMobileHelper;
 		beforeEach(() => {
 			tempFolder = temp.mkdirSync("template");
+			options = testInjector.resolve("options");
 			options.path = tempFolder;
 			options.appid = "com.telerik.Test";
 			mobileHelper = testInjector.resolve("mobileHelper");
+			project = testInjector.resolve("project");
 		});
 
 		describe("NativeScript project", () => {

--- a/test/publish-service.ts
+++ b/test/publish-service.ts
@@ -24,6 +24,7 @@ function createTestInjector(publishConnections: IPublishConnection[]): IInjector
 	testInjector.register("project", {});
 	testInjector.register("projectConstants", {});
 	testInjector.register("hostInfo", hostInfoLib.HostInfo);
+	let yargs = require("yargs");
 	testInjector.register("options", optionsLib.Options);
 
 	// Register mocked dependencies
@@ -120,13 +121,12 @@ describe("publish-service", () => {
 			
 			let expected: Server.FtpConnectionData = {
 				RemoteUrl: remotePublishUrl,
-				ShouldPurge: undefined,
+				ShouldPurge: false,
 				Username: 'username',
 				Password: 'password' 
 			}
 
 			service.publish('1', 'username', 'password').wait();
-
 			assert.deepEqual(serverFtpConnectionData, expected, 'Incorrect data to server provided');
 		});
 
@@ -152,7 +152,7 @@ describe("publish-service", () => {
 			
 			let expected: Server.FtpConnectionData = {
 				RemoteUrl: '127.0.0.1',
-				ShouldPurge: undefined,
+				ShouldPurge: false,
 				Username: 'username',
 				Password: 'password' 
 			}

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -198,9 +198,9 @@ export class ErrorsNoFailStub implements IErrors {
 	fail(formatStr: string, ...args: any[]): void;
 	fail(opts: { formatStr?: string; errorCode?: number; suppressCommandHelp?: boolean }, ...args: any[]): void;
 
-	fail(...args: any[]) { throw new Error(); }
+	fail(...args: any[]) {throw new Error(util.format.apply(null,args)); }
 	failWithoutHelp(message: string, ...args: any[]): void {
-		throw new Error();
+		throw new Error(message);
 	}
 
 	beginCommand(action: () => IFuture<boolean>, printHelpCommand: () => IFuture<boolean>): IFuture<boolean> {


### PR DESCRIPTION
Each command can use specific dashed options (`-- avd <name>` for example is valid for one command, but not for other). Add dashedOptions parameter to ICommand interface and make sure to use it for validation when it exists. In case there's no dashedOptions paramter, use the common options.

Use correct types for yargs - "string", "boolean", etc. instead of 0, 1, 2 which were the result of our enum. Replace the enum with class and remove code, which we do not need anymore as yargs is doing its work as expected.
After yargs is updated to latest version, some fixes have to be applied - now when `yargs.options(opts).argv` is passed, it returns all members of `opts`, but the ones that are not part of process.argv have value undefined.
Fix unit tests based on the changes and remove some, which were testing our hacks. (+1 squashed commits)

