### PR TITLE
Fix creation of SB when simulator start fails

### DIFF
--- a/lib/commands/project/create.ts
+++ b/lib/commands/project/create.ts
@@ -39,12 +39,13 @@ export class CreateCommand extends ProjectCommandBaseLib.ProjectCommandBase {
 				this.$screenBuilderService.installAppDependencies(screenBuilderOptions).wait();
 
 				this.$project.initializeProjectFromExistingFiles(this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova, projectPath, projectName).wait();
-				if (this.$options.simulator) {
-					this.$simulatorService.launchSimulator().wait();
-				}
 			} catch(err) {
 				this.$fs.deleteDirectory(projectPath).wait();
 				throw err;
+			}
+			
+			if (this.$options.simulator) {
+				this.$simulatorService.launchSimulator().wait();
 			}
 		}).future<void>()();
 	}


### PR DESCRIPTION
When you create SB project and for some reason starting the simulator fails, the project is deleted. Make sure the start the simulator outside of the try-catch, so even if it fails, the project will not be deleted when the simulator fails.
Fixes http://teampulse.telerik.com/view#item/296228