### PR TITLE
Use correct semver version in package.json

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -112,5 +112,9 @@ export class StaticConfig extends staticConfigBaseLib.StaticConfigBase implement
 	public get HTML_CLI_HELPERS_DIR(): string {
 		return path.join(__dirname, "../docs/helpers");
 	}
+	
+	public get pathToPackageJson(): string {
+		return path.join(__dirname, "..", "package.json");
+	}
 }
 $injector.register("staticConfig", StaticConfig);

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -407,7 +407,11 @@ export class StaticConfig implements IStaticConfig {
 	public get GITHUB_ACCESS_TOKEN_FILEPATH(): string {
 		let tokenFileName = ".abgithub";
 		return tokenFileName;
-	} 
+	}
+	
+	public get pathToPackageJson(): string {
+		return path.join(__dirname, "..", "package.json");
+	}
 }
 
 export class HooksService implements IHooksService {


### PR DESCRIPTION
npm 2.11.2 introduced and issue when the version in package json has "-". Such packages cannot be installed directly from npmjs.org.
Fix this by adding buildVersion property in our package.json and set there the build number from Jenkins. This way the version in package.json will remain correct. Add "setPackageName" grunt task, which renames the `appbuilder-<version>.tgz` to `appbuilder-<version>-<buildVersion>.tgz`