### PR TITLE
Do not require latest version for OnPremise

### DIFF
--- a/lib/service-util.ts
+++ b/lib/service-util.ts
@@ -96,6 +96,10 @@ export class ServiceProxy implements Server.IServiceProxy {
 
 	private ensureUpToDate(): IFuture<void> {
 		return (() => {
+			if(this.$config.ON_PREM) {
+				return;
+			}
+
 			try {
 				if (!this.latestVersion) {
 					this.latestVersion = JSON.parse(this.$httpClient.httpRequest("http://registry.npmjs.org/appbuilder").wait().body)["dist-tags"].latest;


### PR DESCRIPTION
CLI has built-in mechanism for checking if the current version is the latest one. If it is not, CLI does not execute you any http requests (almost all commands have such requests). For OnPremise we do not want this check, so make sure to skip this behavior.

Fixes http://teampulse.telerik.com/view#item/296618