### PR TITLE
Fix swagger not generating enums properly

### DIFF
--- a/lib/server-api.d.ts
+++ b/lib/server-api.d.ts
@@ -21,20 +21,20 @@ declare module Server{
 		HasAgreedToEula: boolean;
 		Tenant: Server.Tenant;
 	}
-	enum EditionType{
+	const enum EditionType{
 		Starter,
 		Developer,
 		DeveloperPlus,
 		Professional,
 		Business,
 	}
-	enum TenantStatus{
+	const enum TenantStatus{
 		Active,
 		Suspended,
 		Disabled,
 		Incomplete,
 	}
-	enum LicenseType{
+	const enum LicenseType{
 		Purchase,
 		Trial,
 	}
@@ -112,10 +112,15 @@ declare module Server{
 		BaseVariables: any;
 		PerConfigurationVariables: any;
 	}
-	enum MigrationType{
+	const enum MigrationType{
 		Create,
 		Update,
 		Delete,
+	}
+	const enum DevicePlatform{
+		iOS,
+		Android,
+		WP8,
 	}
 	interface ICordovaServiceContract{
 		getLiveSyncToken(solutionName: string, projectName: string): IFuture<string>;
@@ -150,7 +155,7 @@ declare module Server{
 		UniqueName: string;
 		Subject: string;
 	}
-	enum ImportType{
+	const enum ImportType{
 		Pkcs12,
 		X509Certificate,
 	}
@@ -203,8 +208,14 @@ declare module Server{
 		Width: number;
 		Height: number;
 	}
+	const enum ImageType{
+		Icon,
+		SplashScreen,
+	}
 	interface IImagesServiceContract{
 		resizeImage(solutionName: string, path: string, size: Server.Size): IFuture<void>;
+		generate(solutionName: string, projectName: string, type: Server.ImageType, image: any): IFuture<string[]>;
+		generateArchive(type: Server.ImageType, image: any, $resultStream: any): IFuture<void>;
 	}
 	interface Application{
 		AppleID: number;
@@ -245,7 +256,7 @@ declare module Server{
 		Certificates: string[];
 		ProvisionedDevices: string[];
 	}
-	enum ProvisionType{
+	const enum ProvisionType{
 		Development,
 		AdHoc,
 		Enterprise,
@@ -254,6 +265,7 @@ declare module Server{
 	interface IMobileprovisionsServiceContract{
 		getProvisions(): IFuture<Server.ProvisionData[]>;
 		importProvision(provision: any): IFuture<Server.ProvisionData>;
+		getProvision(identifier: string, $resultStream: any): IFuture<void>;
 		removeProvision(identifier: string): IFuture<void>;
 	}
 	interface INativescriptServiceContract{
@@ -294,7 +306,7 @@ declare module Server{
 		Targets: string[];
 		Properties: IDictionary<string>;
 	}
-	enum TargetResultStatus{
+	const enum TargetResultStatus{
 		Failure,
 		Skipped,
 		Success,
@@ -423,11 +435,6 @@ declare module Server{
 		CodesigningSettings: Server.ICodesigningIdentitySettings;
 		ProvisionSettings: Server.IMobileProjectProvisionSettings;
 		SolutionSettings: Server.ISolutionSettings;
-	}
-	enum DevicePlatform{
-		iOS,
-		Android,
-		WP8,
 	}
 	interface ISettingsServiceContract{
 		getSettings(solutionName: string): IFuture<Server.SettingsData>;
@@ -576,7 +583,15 @@ declare module Server{
 		LastPath: string;
 		ChangeType: string;
 	}
-	enum DiffBlockType{
+	const enum ChangeType{
+		None,
+		Added,
+		Modified,
+		Deleted,
+		Renamed,
+		Conflict,
+	}
+	const enum DiffBlockType{
 		Unchanged,
 		Inserted,
 		Modified,
@@ -586,7 +601,7 @@ declare module Server{
 		Local,
 		Remote,
 	}
-	enum ResetMode{
+	const enum ResetMode{
 		Hard,
 		Soft,
 	}

--- a/lib/server-api.ts
+++ b/lib/server-api.ts
@@ -179,6 +179,12 @@ export class ImagesService implements Server.IImagesServiceContract{
 	public resizeImage(solutionName: string, path: string, size: Server.Size): IFuture<void>{
 		return this.$serviceProxy.call<void>('ResizeImage', 'POST', ['api','images','resize',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(path.replace(/\\/g, '/'))].join('/'), null, [{name: 'size', value: JSON.stringify(size), contentType: 'application/json'}], null);
 	}
+	public generate(solutionName: string, projectName: string, type: Server.ImageType, image: any): IFuture<string[]>{
+		return this.$serviceProxy.call<string[]>('Generate', 'POST', ['api','images','generate',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(projectName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'type': type }), 'application/json', [{name: 'image', value: image, contentType: 'application/octet-stream'}], null);
+	}
+	public generateArchive(type: Server.ImageType, image: any, $resultStream: any): IFuture<void>{
+		return this.$serviceProxy.call<void>('GenerateArchive', 'POST', ['api','images','generate'].join('/') + '?' + querystring.stringify({ 'type': type }), 'application/octet-stream', [{name: 'image', value: image, contentType: 'application/octet-stream'}], $resultStream);
+	}
 }
 export class ItmstransporterService implements Server.IItmstransporterServiceContract{
 	constructor(private $serviceProxy: Server.IServiceProxy){
@@ -211,6 +217,9 @@ export class MobileprovisionsService implements Server.IMobileprovisionsServiceC
 	}
 	public importProvision(provision: any): IFuture<Server.ProvisionData>{
 		return this.$serviceProxy.call<Server.ProvisionData>('ImportProvision', 'POST', ['api','mobileprovisions'].join('/'), 'application/json', [{name: 'provision', value: provision, contentType: 'application/octet-stream'}], null);
+	}
+	public getProvision(identifier: string, $resultStream: any): IFuture<void>{
+		return this.$serviceProxy.call<void>('GetProvision', 'GET', ['api','mobileprovisions',encodeURI(identifier.replace(/\\/g, '/'))].join('/'), 'application/octet-stream', null, $resultStream);
 	}
 	public removeProvision(identifier: string): IFuture<void>{
 		return this.$serviceProxy.call<void>('RemoveProvision', 'DELETE', ['api','mobileprovisions',encodeURI(identifier.replace(/\\/g, '/'))].join('/'), null, null, null);

--- a/lib/swagger/swagger.d.ts
+++ b/lib/swagger/swagger.d.ts
@@ -30,6 +30,7 @@ declare module Swagger {
 	}
 
 	interface ICodeEntity {
+		opener?: string;
 		codeEntityType: any;
 	}
 


### PR DESCRIPTION
Includes fixes for two bugs
* if an enum is encountered an even amount of numbers on a given endpoint definition it is not added to the end .d.ts result
* if an enum is encountered in multiple endpoint definition it is added as a duplicate