### PR TITLE
Fix analytics issues

### DIFF
--- a/.settings/launch.json
+++ b/.settings/launch.json
@@ -1,0 +1,41 @@
+{
+	"version": "0.1.0",
+	// List of configurations. Add new configurations or edit existing ones.  
+	// ONLY "node" and "mono" are supported, change "type" to switch.
+	"configurations": [
+		{
+			// Name of configuration; appears in the launch configuration drop down menu.
+			"name": "Default",
+			// Type of configuration. Possible values: "node", "mono".
+			"type": "node",
+			// Workspace relative or absolute path to the program.
+			"program": "./bin/appbuilder.js",
+			// Automatically stop program after launch.
+			"stopOnEntry": true,
+			// Command line arguments passed to the program.
+			"args": [],
+			// Workspace relative or absolute path to the working directory of the program being debugged. Default is the current workspace.
+			"cwd": ".",
+			// Workspace relative or absolute path to the runtime executable to be used. Default is the runtime executable on the PATH.
+			"runtimeExecutable": null,
+			// Optional arguments passed to the runtime executable.
+			"runtimeArgs": [],
+			// Environment variables passed to the program.
+			"env": { },
+			// Use JavaScript source maps (if they exist).
+			"sourceMaps": true,
+			"isShellCommand": true,
+			// If JavaScript source maps are enabled, the generated code is expected in this directory.
+			"outDir": null
+		}, 
+		{
+			"name": "Attach",
+			"type": "node",
+			// TCP/IP address. Default is "localhost".
+			"address": "localhost",
+			// Port to attach to.
+			"port": 5858,
+			"sourceMaps": true
+		}
+	]
+}

--- a/.settings/settings.json
+++ b/.settings/settings.json
@@ -1,0 +1,9 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+	"files.exclude": {
+		"**/.git": true,
+		"**/.DS_Store": true,
+		"**/*.js": { "when": "$(basename).ts"},
+		"**/*.js.map": true
+	}
+}


### PR DESCRIPTION
- Fix behavior that is trying to login the user when tracking command - in fact we should first check if the user is logged in and if not, do not try to login.
- Make sure commands are tracked, but for some of them we should not ask the user for confirmation of usage reporting (for example help command). So add new command property - `disableAnalyticsConsentCheck` and set it to true for help, usage-reporting and error-reporting commands. Make sure to prevent commandsService for checking the consent when this property is true.