### PR TITLE
Export solutions

### DIFF
--- a/lib/commands/cloud-projects.ts
+++ b/lib/commands/cloud-projects.ts
@@ -5,7 +5,6 @@ import util = require("util");
 import path = require("path");
 import helpers = require("../helpers");
 import unzip = require("unzip");
-import temp = require("temp");
 import commonHelpers = require("../common/helpers");
 
 class SolutionIdCommandParameter implements ICommandParameter {
@@ -60,83 +59,46 @@ $injector.registerCommand("cloud|*list", CloudListProjectsCommand);
 
 export class CloudExportProjectsCommand implements ICommand {
 	constructor(private $errors: IErrors,
-		private $fs: IFileSystem,
-		private $logger: ILogger,
-		private $project: Project.IProject,
-		private $projectConstants: Project.IProjectConstants,
 		private $remoteProjectService: IRemoteProjectService,
-		private $server: Server.IServer,
-		private $prompter: IPrompter,
-		private $userDataStore: IUserDataStore) { }
+		private $prompter: IPrompter) { }
 
 	allowedParameters: ICommandParameter[] = [];
 
 	execute(args: string[]): IFuture<void> {
 		return (() => {
-			let projectName: string;
+			let projectIdentifier = args[1];
 			let slnName: string;
 			if(args[0]) {
 				slnName = this.$remoteProjectService.getSolutionName(args[0]).wait();
 			} else {
 				let solutions = this.$remoteProjectService.getSolutions().wait().map(sln => sln.name);
-				slnName = this.$prompter.promptForChoice("Select solution for which to list projects:",solutions).wait();
+				slnName = this.$prompter.promptForChoice("Select solution to export", solutions).wait();
+				let projects = this.$remoteProjectService.getProjectsForSolution(slnName).wait().map(proj => proj.Name);
+				let exportSolutionItem = "Export the whole solution";
+				projects.push(exportSolutionItem);
+				let selection = this.$prompter.promptForChoice("Select project to export", projects).wait();
+				if(selection !== exportSolutionItem) {
+					projectIdentifier = selection;
+				}
 			}
-			
-			if(args[1]) {
-				projectName = this.$remoteProjectService.getProjectName(slnName, args[1]).wait();
+
+			if(projectIdentifier) {
+				let projectName = this.$remoteProjectService.getProjectName(slnName, projectIdentifier).wait();
+				this.$remoteProjectService.exportProject(slnName, projectName).wait();
 			} else {
-				let projectNames = this.$remoteProjectService.getProjectsForSolution(slnName).wait().map(sln => sln.Name);
-				if(projectNames.length === 1) {
-					projectName = projectNames[0];
-				} else if (projectNames.length > 1) {
-					projectName = this.$prompter.promptForChoice("Select project which you want to export:", projectNames).wait();
-				} else {
-					this.$logger.warn(`Solution ${slnName} does not have any projects.`);
-					return;
-				}
+				this.$remoteProjectService.exportSolution(slnName).wait();
 			}
-
-			this.doExportRemoteProject(slnName, projectName).wait();
-		}).future<void>()();
-	}
-
-	private doExportRemoteProject(remoteSolutionName: string, remoteProjectName: string): IFuture<void> {
-		return (() => {
-			let projectDir = path.join(this.$project.getNewProjectDir(), remoteProjectName);
-			if(this.$fs.exists(projectDir).wait()) {
-				this.$errors.fail("The folder %s already exists!", projectDir);
-			}
-			if (this.$project.projectData) {
-				this.$errors.failWithoutHelp("Cannot create project in this location because the specified directory is part of an existing project. Switch to or specify another location and try again.");
-			}
-
-			temp.track();
-			let projectZipFilePath = temp.path({prefix: "appbuilder-cli-", suffix: '.zip'});
-			let unzipStream = this.$fs.createWriteStream(projectZipFilePath);
-			let user = this.$userDataStore.getUser().wait();
-			let tenantId = user.tenant.id;
-			this.$remoteProjectService.makeTapServiceCall(() => this.$server.projects.exportProject(tenantId, remoteSolutionName, remoteProjectName, false, unzipStream)).wait();
-			this.$fs.unzip(projectZipFilePath, projectDir).wait();
-
-			try {
-				// if there is no .abproject when exporting, we must be dealing with a cordova project, otherwise everything is set server-side
-				let projectFile = path.join(projectDir, this.$projectConstants.PROJECT_FILE);
-				if(!this.$fs.exists(projectFile).wait()) {
-					let properties = this.$remoteProjectService.getProjectProperties(remoteSolutionName, remoteProjectName).wait();
-					this.$project.createProjectFile(projectDir, properties).wait();
-				}
-			}
-			catch(e) {
-				this.$logger.warn("Couldn't create project file: %s", e.message);
-			}
-
-			this.$logger.info("%s has been successfully exported to %s", remoteProjectName, projectDir);
 		}).future<void>()();
 	}
 
 	canExecute(args: string[]): IFuture<boolean> {
 		return ((): boolean => {
-			if(args.length) {
+			let solutionNames = this.$remoteProjectService.getSolutions().wait().map(sln => sln.name);
+			if(!solutionNames || !solutionNames.length) {
+				this.$errors.failWithoutHelp("You do not have any projects in the cloud.");
+			}
+
+			if(args && args.length) {
 				if(args.length > 2) {
 					this.$errors.fail("This command accepts maximum two parameters - solution name and project name.");
 				}
@@ -144,7 +106,15 @@ export class CloudExportProjectsCommand implements ICommand {
 				let slnName = this.$remoteProjectService.getSolutionName(args[0]).wait();
 				if(args[1]){
 					this.$remoteProjectService.getProjectName(slnName, args[1]).wait();
+				} else {
+					// only one argument is passed
+					let projectNames = this.$remoteProjectService.getProjectsForSolution(slnName).wait().map(sln => sln.Name);
+					if(!projectNames.length) {
+						this.$errors.failWithoutHelp(`Solution ${slnName} does not have any projects.`);
+					}
 				}
+			} else if(!commonHelpers.isInteractive()) {
+				this.$errors.fail("When console is not interactive, you have to provide at least one argument.")
 			}
 
 			return true;

--- a/lib/commands/cloud-projects.ts
+++ b/lib/commands/cloud-projects.ts
@@ -60,7 +60,8 @@ $injector.registerCommand("cloud|*list", CloudListProjectsCommand);
 export class CloudExportProjectsCommand implements ICommand {
 	constructor(private $errors: IErrors,
 		private $remoteProjectService: IRemoteProjectService,
-		private $prompter: IPrompter) { }
+		private $prompter: IPrompter,
+		private $project: Project.IProject) { }
 
 	allowedParameters: ICommandParameter[] = [];
 
@@ -96,6 +97,10 @@ export class CloudExportProjectsCommand implements ICommand {
 			let solutionNames = this.$remoteProjectService.getSolutions().wait().map(sln => sln.name);
 			if(!solutionNames || !solutionNames.length) {
 				this.$errors.failWithoutHelp("You do not have any projects in the cloud.");
+			}
+			
+			if (this.$project.projectData) {
+				this.$errors.failWithoutHelp("Cannot create project in this location because the specified directory is part of an existing project. Switch to or specify another location and try again.");
 			}
 
 			if(args && args.length) {

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -614,6 +614,8 @@ interface IRemoteProjectService {
 	getProjectsForSolution(solutionName: string): IFuture<Server.IWorkspaceItemData[]>;
 	getSolutionName(solutionId: string): IFuture<string>;
 	getProjectName(solutionId: string, projectId: string): IFuture<string>;
+	exportProject(remoteSolutionName: string, remoteProjectName: string): IFuture<void>;
+	exportSolution(remoteSolutionName: string): IFuture<void>;
 }
 
 interface IProjectSimulatorService {

--- a/test/cloud-projects.ts
+++ b/test/cloud-projects.ts
@@ -266,6 +266,12 @@ describe("cloud project commands", () => {
 				it("fails when solution does not have any projects", () => {
 					assert.throws(() => exportProjectCommand.canExecute(["Sln2"]).wait())
 				});
+				
+				it("fails when there's projectData", () => {
+					let project = testInjector.resolve("project");
+					project.projectData = <any>{};
+					assert.throws(() => exportProjectCommand.canExecute(["Sln1", "BlankProj"]).wait());
+				});
 			});
 
 			it("fails when console is not interactive and command arguments are not passed", () => {
@@ -351,11 +357,6 @@ describe("cloud project commands", () => {
 
 				it("fails when projectDir exists", () => {
 					fs.exists = (projectDir: string) => { return Future.fromResult(true);}
-					assert.throws(() => exportProjectCommand.execute(["Sln1", "BlankProj"]).wait());
-				});
-
-				it("fails when there's projectData", () => {
-					project.projectData = <any>{};
 					assert.throws(() => exportProjectCommand.execute(["Sln1", "BlankProj"]).wait());
 				});
 

--- a/test/cloud-projects.ts
+++ b/test/cloud-projects.ts
@@ -2,6 +2,7 @@
 "use strict";
 
 import stubs = require("./stubs");
+import helpers = require("../lib/common/helpers");
 import yok = require("../lib/common/yok");
 import optionsLib = require("../lib/options");
 import remoteProjectsServiceLib = require("../lib/services/remote-projects-service");
@@ -9,6 +10,7 @@ import cloudProjectsCommandsLib = require("../lib/commands/cloud-projects");
 import projectConstantsLib = require("../lib/project/project-constants");
 import os = require("os");
 
+let originalIsInteractiveMethod = helpers.isInteractive;
 let assert = require("chai").assert;
 import Future = require("fibers/future");
 import util = require("util");
@@ -72,9 +74,11 @@ export class PrompterStub {
 	}
 }
 
-function createTestInjector(promptSlnName?: string, promptPrjName?: string): IInjector {
+function createTestInjector(promptSlnName?: string, promptPrjName?: string, isInteractive?: boolean): IInjector {
 	let testInjector = new yok.Yok();
-
+	let helpers = require("../lib/common/helpers");
+	isInteractive = isInteractive === undefined ? true : false;
+	helpers.isInteractive = () => { return isInteractive; };
 	testInjector.register("errors", stubs.ErrorsStub);
 	testInjector.register("userDataStore", {
 		getUser: () =>  Future.fromResult({tenant: {id: "id"}}),
@@ -182,6 +186,9 @@ function createTestInjector(promptSlnName?: string, promptPrjName?: string): IIn
 			}, 
 			exportProject: (solutionSpaceName: string, solutionName: string, projectName: string, skipMetadata: boolean, $resultStream: any) => {
 				return Future.fromResult();
+			},
+			exportSolution: (solutionSpaceName: string, solutionName: string, skipMetadata: boolean, $resultStream: any) => {
+				return Future.fromResult();
 			}
 		}
 	});
@@ -195,7 +202,8 @@ function createTestInjector(promptSlnName?: string, promptPrjName?: string): IIn
 		},
 		createWriteStream: (path: string) => {},
 		unzip: (zipFile: string, destinationDir: string) => Future.fromResult(),
-	})
+		readDirectory: (projectDir: string) => Future.fromResult([])
+	});
 	testInjector.register("remoteProjectService", remoteProjectsServiceLib.RemoteProjectService);
 	testInjector.register("projectConstants", projectConstantsLib.ProjectConstants);
 	testInjector.register("project", {
@@ -208,46 +216,62 @@ function createTestInjector(promptSlnName?: string, promptPrjName?: string): IIn
 }
 
 describe("cloud project commands", () => {
+	after(() => {
+		helpers.isInteractive = originalIsInteractiveMethod;
+	});
+
 	describe("export project command", () => {
 		let testInjector: IInjector;
 		let exportProjectCommand: ICommand;
 
 		describe("canExecute", () => {
-			beforeEach(() => {
-				testInjector = createTestInjector();
+			describe("when console is interactive", () => {
+				beforeEach(() => {
+					testInjector = createTestInjector();
+					exportProjectCommand = testInjector.resolve(cloudProjectsCommandsLib.CloudExportProjectsCommand);
+				});
+
+				it("returns true when no arguments are specified", () => {
+					assert.isTrue(exportProjectCommand.canExecute([]).wait());
+				});
+
+				it("returns true when valid solution name is specified", () => {
+					assert.isTrue(exportProjectCommand.canExecute(["Sln1"]).wait());
+				});
+
+				it("returns true when valid solution name and project name are specified", () => {
+					assert.isTrue(exportProjectCommand.canExecute(["Sln1", "BlankProj"]).wait());
+				});
+
+				it("returns true when valid solution index is specified", () => {
+					assert.isTrue(exportProjectCommand.canExecute(["1"]).wait());
+				});
+
+				it("returns true when valid solution id and project name are specified", () => {
+					assert.isTrue(exportProjectCommand.canExecute(["1", "BlankProj"]).wait());
+				});
+
+				it("returns true when valid solution name and project id are specified", () => {
+					assert.isTrue(exportProjectCommand.canExecute(["Sln1", "2"]).wait());
+				});
+
+				it("returns true when valid solution id and project id are specified", () => {
+					assert.isTrue(exportProjectCommand.canExecute(["1", "2"]).wait());
+				});
+
+				it("fails when more than two arguments are passed", () => {
+					assert.throws(() => exportProjectCommand.canExecute(["1", "2", "3"]).wait())
+				});
+
+				it("fails when solution does not have any projects", () => {
+					assert.throws(() => exportProjectCommand.canExecute(["Sln2"]).wait())
+				});
+			});
+
+			it("fails when console is not interactive and command arguments are not passed", () => {
+				testInjector = createTestInjector("", "", false);
 				exportProjectCommand = testInjector.resolve(cloudProjectsCommandsLib.CloudExportProjectsCommand);
-			});
-
-			it("returns true when no arguments are specified", () => {
-				assert.isTrue(exportProjectCommand.canExecute([]).wait());
-			});
-
-			it("returns true when valid solution name is specified", () => {
-				assert.isTrue(exportProjectCommand.canExecute(["Sln1"]).wait());
-			});
-
-			it("returns true when valid solution name and project name are specified", () => {
-				assert.isTrue(exportProjectCommand.canExecute(["Sln1", "BlankProj"]).wait());
-			});
-
-			it("returns true when valid solution index is specified", () => {
-				assert.isTrue(exportProjectCommand.canExecute(["1"]).wait());
-			});
-
-			it("returns true when valid solution id and project name are specified", () => {
-				assert.isTrue(exportProjectCommand.canExecute(["1", "BlankProj"]).wait());
-			});
-
-			it("returns true when valid solution name and project id are specified", () => {
-				assert.isTrue(exportProjectCommand.canExecute(["Sln1", "2"]).wait());
-			});
-
-			it("returns true when valid solution id and project id are specified", () => {
-				assert.isTrue(exportProjectCommand.canExecute(["1", "2"]).wait());
-			});
-			
-			it("fails when more than two arguments are passed", () => {
-				assert.throws(() => exportProjectCommand.canExecute(["1", "2", "3"]).wait())
+				assert.throws(() => exportProjectCommand.canExecute([]).wait());
 			});
 		});
 
@@ -302,11 +326,6 @@ describe("cloud project commands", () => {
 					let prompter:PrompterStub = testInjector.resolve("prompter");
 					assert.isFalse(prompter.isPrompterCalled);
 					assert.isTrue(logger.infoOutput.indexOf("has been successfully exported") !== -1);
-				});
-				
-				it("throws error when solution does not have any projects", () => {
-					exportProjectCommand.execute(["Sln2"]).wait()
-					assert.isTrue(logger.warnOutput.indexOf("does not have any projects.") > 0);
 				});
 			});
 

--- a/test/remote-projects-service.ts
+++ b/test/remote-projects-service.ts
@@ -5,6 +5,8 @@ import stubs = require("./stubs");
 import yok = require("../lib/common/yok");
 import optionsLib = require("../lib/options");
 import remoteProjectsServiceLib = require("../lib/services/remote-projects-service");
+import projectConstantsLib = require("../lib/project/project-constants");
+import os = require("os");
 
 let assert = require("chai").assert;
 import Future = require("fibers/future");
@@ -82,6 +84,24 @@ function createTestInjector(): IInjector {
 			}
 		}
 	});
+	testInjector.register("project", {
+		getNewProjectDir:() => "proj dir",
+		createProjectFile: (projectDir: string, properties: any) => Future.fromResult()
+	});
+	testInjector.register("projectConstants", projectConstantsLib.ProjectConstants);
+	testInjector.register("fs", {
+		exists: (path: string) => {
+			if(path.indexOf("abproject") !== -1) {
+				return Future.fromResult(true);
+			} else {
+				return Future.fromResult(false);
+			}
+		},
+		createWriteStream: (path: string) => {},
+		unzip: (zipFile: string, destinationDir: string) => Future.fromResult(),
+		readDirectory: (projectDir: string) => Future.fromResult([])
+	});
+	testInjector.register("logger", stubs.LoggerStub);
 	return testInjector;
 }
 
@@ -204,7 +224,7 @@ describe("remote project service", () => {
 			assert.throws( () => remoteProjectService.getProjectName("Sln1", "5").wait() );
 		});
 
-		it("returns correct name when solution name and project name are", () => {
+		it("returns correct name when solution name and project name are correct", () => {
 			let projName = remoteProjectService.getProjectName("Sln1", "BlankProj").wait();
 			assert.deepEqual(expectedResult, projName);
 		});


### PR DESCRIPTION
According to our discussions, we would like to be able to export full solutions, not only one project. So the behavior of `appbuilder cloud export` command should be:
* `$ appbuilder cloud export` - prompts to select solution from which to export project. After solution is selected, prompt the user to select project. In this prompt there's option - export solution, when it is used, the full solution is exported.
* `$ appbuilder cloud export Sln1` - Exports the whole solution. In case the solution does not have any projects - show error.
* `$ appbuilder cloud export 1` - Exports the selected solution (first project listed by `$ appbuilder cloud`). In case the solution does not have any projects - show error. 
* `$ appbuilder cloud export Sln1 Proj1` - Exports Proj1 of Sln1. If any of them does not exists, throw error.
* `$ appbuilder cloud export 1 Proj1` - Exports Proj1 from the first solution listed by `$ appbuilder cloud`. If any of them does not exists, throw error.
* `$ appbuilder cloud export Sln1 1` - Exports first project of Sln1 listed by `$ appbuilder cloud`. If any of them does not exists, throw error.
* `$ appbuilder cloud export 1 1` - Exports first project of the first solution listed by `$ appbuilder cloud`. If any of them does not exists, throw error.

Move the logic of exporting to `remoteProjectService`. Keep the logic what to export in the command. Add check if the command `appbuilder cloud export` is executed with parameters in non-interactive console. In this case it will fail, as we do not know what to export.

http://teampulse.telerik.com/view#item/295399