### PR TITLE
Fix Invalid property name 'undefined' message

### DIFF
--- a/lib/project.ts
+++ b/lib/project.ts
@@ -513,6 +513,10 @@ export class Project implements Project.IProject {
 
 	public validateProjectProperty(property: string, args: string[], mode: string): IFuture<boolean> {
 		return (() => {
+			if (!property) {
+				this.$errors.fail("Please specify a property name.");
+			}
+
 			let validProperties = this.$jsonSchemaValidator.getValidProperties(this.projectData.Framework, this.projectData.FrameworkVersion);
 			if(_.contains(validProperties, property)) {
 				let normalizedPropertyName =  this.$projectPropertiesService.normalizePropertyName(property, this.projectData);


### PR DESCRIPTION
When running `$ appbuilder prop add` or any other prop-related command without a property name the message Invalid property name 'undefined' is displayed.
Fixes [#297059](http://teampulse.telerik.com/view#item/297059)