### PR TITLE
Print all error messages upon screenbuilder failure

### DIFF
--- a/lib/commands/project/create.ts
+++ b/lib/commands/project/create.ts
@@ -7,14 +7,15 @@ import util = require("util");
 import ProjectCommandBaseLib = require("./project-command-base");
 
 export class CreateCommand extends ProjectCommandBaseLib.ProjectCommandBase {
-	constructor($errors: IErrors,
-		private $fs: IFileSystem,
+	constructor(private $fs: IFileSystem,
+		private $logger: ILogger,
 		private $nameCommandParameter: ICommandParameter,
-		$project: Project.IProject,
+		private $options: IOptions,
 		private $projectConstants: Project.IProjectConstants,
-		private $simulatorService: ISimulatorService,
 		private $screenBuilderService: IScreenBuilderService,
-		private $options: IOptions) {
+		private $simulatorService: ISimulatorService,
+		$errors: IErrors,
+		$project: Project.IProject) {
 		super($errors, $project);
 	}
 
@@ -40,6 +41,7 @@ export class CreateCommand extends ProjectCommandBaseLib.ProjectCommandBase {
 
 				this.$project.initializeProjectFromExistingFiles(this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova, projectPath, projectName).wait();
 			} catch(err) {
+				this.$logger.trace(err);
 				this.$fs.deleteDirectory(projectPath).wait();
 				throw err;
 			}

--- a/lib/services/screen-builder-service.ts
+++ b/lib/services/screen-builder-service.ts
@@ -126,7 +126,7 @@ export class ScreenBuilderService implements IScreenBuilderService {
 			let future = new Future<void>();
 			let callback = (err:any, data:any) => {
 				if (err) {
-					let error = _.map(err.errors, (e:any) => e.message).join("\n");
+					let error = this.getErrorsRecursive(err.errors).join('\n');
 					this.$logger.trace("ScreenBuilder error while prompting: %s", err);
 					future.throw(error);
 				} else {
@@ -136,6 +136,16 @@ export class ScreenBuilderService implements IScreenBuilderService {
 
 			return {scaffolder: scaffolder, future: future, callback: callback};
 		}).future<{ scaffolder: any; future: IFuture<any>; callback: Function }>()();
+	}
+	
+	private getErrorsRecursive(errors: any): string[] {
+		let resultArray = _.map(errors, (e:any) => e.message),
+			childErrors = _(errors)
+							.map((e:any) => this.getErrorsRecursive(e.errors))
+							.flatten<string>()
+							.value();
+
+		return _.union(resultArray, childErrors);
 	}
 
 	private registerCommand(command: string, generatorName: string): void {


### PR DESCRIPTION
Upon a failure in any screenbuilder command an error object is thrown which contains multiple levels of nested errors. We should print all of the errors' messages instead of just root-level ones.
Fixes [#296877](http://teampulse.telerik.com/view#item/296877)