### PR TITLE
Move screebuilder cache under sb directory

### DIFF
--- a/lib/options.ts
+++ b/lib/options.ts
@@ -46,7 +46,7 @@ export class Options extends commonOptionsLibPath.OptionsBase {
 			$errors, $staticConfig);
 		
 		let that = <any>this;
-		that.screenBuilderCacheDir = ($hostInfo.isWindows && this.defaultProfileDir === that.profileDir) ? path.join(process.env.LocalAppData, "Telerik", "sb"): that.profileDir;
+		that.screenBuilderCacheDir = path.join((($hostInfo.isWindows && this.defaultProfileDir === that.profileDir) ? path.join(process.env.LocalAppData, "Telerik"): that.profileDir), "sb");
 	}
 }
 $injector.register("options", Options);


### PR DESCRIPTION
On Mac and Linux, move SB cache under sb directory. This will fix the issue that during first downloading of ScreenBuilder, CLI is deleting its own cache and after that a browser is opened, waiting for login information.

Fixes http://teampulse.telerik.com/view#item/297519