### PR TITLE
Fix editing of config files for {N} projects

### DIFF
--- a/lib/project/nativescript-project.ts
+++ b/lib/project/nativescript-project.ts
@@ -59,7 +59,7 @@ export class NativeScriptProject extends frameworkProjectBaseLib.FrameworkProjec
 	public get configFiles():  Project.IConfigurationFile[] {
 		let allConfigFiles = this.$projectFilesManager.availableConfigFiles;
 		return [
-			allConfigFiles["ios-info"],
+			allConfigFiles["nativescript-ios-info"],
 			allConfigFiles["nativescript-android-manifest"]
 		]
 	}

--- a/lib/project/project-files-manager.ts
+++ b/lib/project/project-files-manager.ts
@@ -33,7 +33,7 @@ export class ProjectFilesManager implements Project.IProjectFilesManager {
 			),
 			"nativescript-android-manifest": new ConfigurationFile(
 				"android-manifest",
-				"App_Resources/Android/AndroidManifest.xml",
+				"app/App_Resources/Android/AndroidManifest.xml",
 				"Mobile.NativeScript.Android.ManifestXml.zip",
 				"Opens AndroidManifest.xml for editing and creates it, if needed."
 			),
@@ -46,6 +46,12 @@ export class ProjectFilesManager implements Project.IProjectFilesManager {
 			"ios-info": new ConfigurationFile(
 				"ios-info",
 				"App_Resources/iOS/Info.plist",
+				"Mobile.iOS.InfoPlist.zip",
+				"Opens Info.plist for editing and creates it, if needed."
+			),
+			"nativescript-ios-info": new ConfigurationFile(
+				"ios-info",
+				"app/App_Resources/iOS/Info.plist",
 				"Mobile.iOS.InfoPlist.zip",
 				"Opens Info.plist for editing and creates it, if needed."
 			),


### PR DESCRIPTION
Fix editing of AndroidManifest and Info.plist for {N} projects. Currently we were creating them on the root level, but they should be inside app/App_Resources dir.

Fixes http://teampulse.telerik.com/view#item/297518