### PR TITLE
Fix error message of build commands

### DIFF
--- a/lib/commands/build.ts
+++ b/lib/commands/build.ts
@@ -1,11 +1,35 @@
 ///<reference path="../.d.ts"/>
 "use strict";
 
-export class BuildAndroidCommand implements ICommand {
-	constructor(private $buildService: Project.IBuildService,
-		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) { }
+import Future = require("fibers/future");
+import assert = require("assert");
 
+class BuildCommandBase implements ICommand {
+	constructor(private $project: Project.IProject,
+		private $errors: IErrors) { }
+	
 	allowedParameters: ICommandParameter[] = [];
+	
+	execute(args: string[]): IFuture<void> {
+		assert.fail("","", "You should never get here. Please contact Telerik support and send the output of your command, executed with `--log trace`.");
+		return Future.fromResult();
+	}
+	
+	canExecute(args: string[]): IFuture<boolean> {
+		return (() => {
+			this.$project.ensureProject();
+			if(args.length) {
+				this.$errors.fail("This command doesn't accept parameters.");
+			}
+			return true;
+		}).future<boolean>()();
+	}
+}
+export class BuildAndroidCommand extends BuildCommandBase {
+	constructor(private $buildService: Project.IBuildService,
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
+		$project: Project.IProject,
+		$errors: IErrors) { super($project, $errors) }
 
 	execute(args: string[]): IFuture<void> {
 		return this.$buildService.executeBuild(this.$devicePlatformsConstants.Android);
@@ -13,11 +37,11 @@ export class BuildAndroidCommand implements ICommand {
 }
 $injector.registerCommand("build|android", BuildAndroidCommand);
 
-export class BuildIosCommand implements ICommand {
+export class BuildIosCommand extends BuildCommandBase {
 	constructor(private $buildService: Project.IBuildService,
-		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) { }
-
-	allowedParameters: ICommandParameter[] = [];
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
+		$project: Project.IProject,
+		$errors: IErrors) { super($project, $errors) }
 
 	execute(args: string[]): IFuture<void> {
 		return this.$buildService.executeBuild(this.$devicePlatformsConstants.iOS);
@@ -25,11 +49,11 @@ export class BuildIosCommand implements ICommand {
 }
 $injector.registerCommand("build|ios", BuildIosCommand);
 
-export class BuildWP8Command implements ICommand {
+export class BuildWP8Command extends BuildCommandBase {
 	constructor(private $buildService: Project.IBuildService,
-		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) { }
-
-	allowedParameters: ICommandParameter[] = [];
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
+		$project: Project.IProject,
+		$errors: IErrors) { super($project, $errors) }
 
 	execute(args: string[]): IFuture<void> {
 		return this.$buildService.executeBuild(this.$devicePlatformsConstants.WP8);


### PR DESCRIPTION
When build command is executed outside of project dir, its execute logic is triggered and the hook that's attached to it is throwing an error. This error is caught by our uncaughtException listener, which prints message with call stack and exits the process. We have catch for this code, but it loosk like the problem is with the two fibers working in parallel.

**Also update common  lib, where the following change is applied:**
In case command does not have default command and arguments are not passed, we are trying to execute default command, which is not expected. Make sure not to return true in this method, when there's no default command.

Fixes: http://teampulse.telerik.com/view#item/297504