### PR TITLE
Disable WP8 related commands for OnPremise

### DIFF
--- a/lib/commands/appmanager.ts
+++ b/lib/commands/appmanager.ts
@@ -27,13 +27,15 @@ $injector.registerCommand("appmanager|upload|ios", AppManagerUploadIosCommand);
 
 class AppManagerUploadWP8Command implements ICommand {
 	constructor(private $appManagerService: IAppManagerService,
-		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) { }
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
+		private $config: Config.IConfig) { }
 
 	execute(args: string[]): IFuture<void> {
 		return this.$appManagerService.upload(this.$devicePlatformsConstants.WP8.toLowerCase());
 	}
 
 	allowedParameters: ICommandParameter[] = [];
+	public isDisabled = this.$config.ON_PREM;
 }
 $injector.registerCommand("appmanager|upload|wp8", AppManagerUploadWP8Command);
 

--- a/lib/commands/build.ts
+++ b/lib/commands/build.ts
@@ -27,12 +27,15 @@ $injector.registerCommand("build|ios", BuildIosCommand);
 
 export class BuildWP8Command implements ICommand {
 	constructor(private $buildService: Project.IBuildService,
-		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) { }
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
+		private $config: Config.IConfig) { }
 
 	allowedParameters: ICommandParameter[] = [];
 
 	execute(args: string[]): IFuture<void> {
 		return this.$buildService.executeBuild(this.$devicePlatformsConstants.WP8);
 	}
+
+	public isDisabled = this.$config.ON_PREM;
 }
 $injector.registerCommand("build|wp8", BuildWP8Command);

--- a/lib/commands/deploy.ts
+++ b/lib/commands/deploy.ts
@@ -98,13 +98,16 @@ $injector.registerCommand("deploy|ios", DeployIosCommand);
 
 export class DeployWP8Command implements ICommand {
 	constructor(private $deployHelper: IDeployHelper,
-		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) { }
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
+		private $config: Config.IConfig) { }
 
 	public allowedParameters: ICommandParameter[] = [];
 
 	public execute(args: string[]): IFuture<void> {
 		return this.$deployHelper.deploy(this.$devicePlatformsConstants.WP8);
 	}
+
+	public isDisabled = this.$config.ON_PREM;
 }
 $injector.registerCommand("deploy|wp8", DeployWP8Command);
 

--- a/lib/commands/emulate.ts
+++ b/lib/commands/emulate.ts
@@ -79,7 +79,8 @@ export class EmulateWp8Command implements ICommand {
 	constructor(private $project: Project.IProject,
 		private $buildService: Project.IBuildService,
 		private $wp8EmulatorServices: Mobile.IEmulatorPlatformServices,
-		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) {
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
+		private $config: Config.IConfig) {
 		this.$project.ensureProject();
 	}
 
@@ -103,5 +104,7 @@ export class EmulateWp8Command implements ICommand {
 			this.$wp8EmulatorServices.startEmulator(packageFilePath).wait();
 		}).future<void>()();
 	}
+	
+	public isDisabled = this.$config.ON_PREM;
 }
 $injector.registerCommand("emulate|wp8", EmulateWp8Command);

--- a/lib/commands/live-sync.ts
+++ b/lib/commands/live-sync.ts
@@ -48,11 +48,14 @@ $injector.registerCommand(["livesync|ios", "live-sync|ios"], LiveSyncIosCommand)
 
 class LiveSyncWP8Command implements ICommand {
 	constructor(private $liveSyncService: ILiveSyncService,
-		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) { }
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
+		private $config: Config.IConfig) { }
 	execute(args: string[]): IFuture<void> {
 		return this.$liveSyncService.livesync(this.$devicePlatformsConstants.WP8);
 	}
 
 	allowedParameters: ICommandParameter[] = [];
+
+	public isDisabled = this.$config.ON_PREM;
 }
 $injector.registerCommand(["livesync|wp8", "live-sync|wp8"], LiveSyncWP8Command);

--- a/lib/project/cordova-project.ts
+++ b/lib/project/cordova-project.ts
@@ -61,14 +61,19 @@ export class CordovaProject extends frameworkProjectBaseLib.FrameworkProjectBase
 
 	public get configFiles(): Project.IConfigurationFile[] {
 		let allConfigFiles = this.$projectFilesManager.availableConfigFiles;
-		return [
+		let availableConfigFiles = [
 			allConfigFiles["cordova-android-manifest"],
 			allConfigFiles["android-config"],
 			allConfigFiles["ios-info"],
-			allConfigFiles["ios-config"],
-			allConfigFiles["wp8-manifest"],
-			allConfigFiles["wp8-config"]
-		]
+			allConfigFiles["ios-config"]
+		];
+
+		if(!this.$config.ON_PREM) {
+			availableConfigFiles.push(allConfigFiles["wp8-manifest"]);
+			availableConfigFiles.push(allConfigFiles["wp8-config"]);
+		}
+
+		return availableConfigFiles;
 	}
 
 	public get startPackageActivity(): string {


### PR DESCRIPTION
WP8 related commands should be disabled for On Premise. Disable the following commands:
* `appmanager upload wp8`
* `build wp8`
* `deploy wp8`
* `emulate wp8`
* `livesync wp8`

Change `appbuilder appmanger livesync` command to exclude WP8 when listing available platforms. Also check if the user had specified WP8 platform, for example:
`appbuilder appmanger livesync android wp8` and fail if we are in On Premise scenario.

Do not allow editing of wp8-manifest and wp8-config files in OnPremise scenario.

Fixes http://teampulse.telerik.com/view#item/297596