### PR TITLE
Parse command line values as strings

### DIFF
--- a/lib/services/project-properties-service.ts
+++ b/lib/services/project-properties-service.ts
@@ -106,13 +106,6 @@ export class ProjectPropertiesService implements IProjectPropertiesService {
 				this.$errors.fail("Unknown property update mode '%s'", mode);
 			}
 
-			// HACK - yargs parses double values (8.0) as integers (8)
-			if(normalizedProperty === "WPSdk") {
-				if(propertyValue.indexOf(".") === -1) {
-					propertyValue += ".0";
-				}
-			}
-
 			this.notifyPropertyChanged(projectData.Framework, normalizedProperty, propertyValue).wait();
 
 			if(configurationSpecificData) {


### PR DESCRIPTION
Yargs will parse all non-hyphenated values as strings in case we tell we want this. So, let's declare we want this and remove our hack, that's doing it. This will also fix the case when numbers like 8.0 are passed on the console. Yargs is giving them to us as "8", but we need the full value. With this fix, we'll receive "8.0".

Remove the hack for WPSdk property as it is not required anymore.

The fix is required for http://teampulse.telerik.com/view#item/296803