### PR TITLE
Prevent deploy on iOS device with lower iOSDeploymentTarget

### DIFF
--- a/lib/commands/deploy.ts
+++ b/lib/commands/deploy.ts
@@ -4,6 +4,7 @@
 import util = require("util");
 import Future = require("fibers/future");
 import commandParams = require("../common/command-params");
+import helpers = require("../common/helpers");
 
 export class DeployHelper implements IDeployHelper {
 	constructor(protected $devicesServices: Mobile.IDevicesServices,
@@ -14,7 +15,8 @@ export class DeployHelper implements IDeployHelper {
 		protected $liveSyncService: ILiveSyncService,
 		protected $errors: IErrors,
 		private $mobileHelper: Mobile.IMobileHelper,
-		private $options: IOptions) { }
+		private $options: IOptions,
+		private $devicePlatformsConstants:Mobile.IDevicePlatformsConstants) { }
 
 
 	public deploy(platform?: string): IFuture<void> {
@@ -44,6 +46,15 @@ export class DeployHelper implements IDeployHelper {
 			this.$options.justlaunch = true; 
 
 			let action = (device: Mobile.IDevice): IFuture<void> => {
+				if(device.getPlatform().toLowerCase() === this.$devicePlatformsConstants.iOS.toLowerCase()) {
+					let deviceVersion = _.take(device.getVersion().split("."), 2).join(".");
+					let deploymentTarget = this.$project.projectData.iOSDeploymentTarget;
+					if(helpers.versionCompare(deviceVersion, deploymentTarget) < 0) {
+						this.$logger.error(`You cannot deploy on device ${device.getIdentifier()} with OS version ${deviceVersion} when iOSDeploymentTarget is set to ${deploymentTarget}.`);
+						return Future.fromResult();
+					}
+				}
+
 				if(!packageFile) {
 					let packageDefs = this.$buildService.deploy(this.$devicesServices.platform, device).wait();
 					packageFile = packageDefs[0].localFile;

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -186,6 +186,7 @@ interface IProjectData extends IDictionary<any> {
 	iOSStatusBarStyle: string;
 	iOSDeviceFamily: string[];
 	iOSBackgroundMode: string[];
+	iOSDeploymentTarget: string;
 	WP8ProductID: string;
 	WP8PublisherID: string;
 	WP8Publisher: string;

--- a/test/project.ts
+++ b/test/project.ts
@@ -505,7 +505,8 @@ function getProjectData(): IProjectData {
 		],
 		"CorePlugins": [ ],
 		"CordovaPluginVariables": {},
-		"WPSdk": "8.0"
+		"WPSdk": "8.0",
+		"iOSDeploymentTarget": "8.0"
 	};
 }
 


### PR DESCRIPTION
When iOSDeploymentTarget is set to 8.4 for example, but user is trying to deploy on iOS device with 8.1.2, we must fail as different issues occur (on Windows we say "Successfully deployed", but nothing is deployed, while on Mac the deployment freezes). Fix this behavior by showing error when device's OS is with lower version, but you can still deploy on other iOS devices.

Fixes http://teampulse.telerik.com/view#item/297476