### PR TITLE
Fix adb spawn when path contains spaces

### DIFF
--- a/lib/commands/emulate.ts
+++ b/lib/commands/emulate.ts
@@ -21,9 +21,7 @@ export class EmulateAndroidCommand implements ICommand {
 	public execute(args: string[]): IFuture<void> {
 		return (() => {
 			this.$project.ensureAllPlatformAssets().wait();
-			this.$androidEmulatorServices.checkDependencies().wait();
 			this.$androidEmulatorServices.checkAvailability().wait();
-
 			let tempDir = this.$project.getTempDir("emulatorfiles").wait();
 			let packageFilePath = path.join(tempDir, "package.apk");
 			let packageDefs = this.$buildService.build(<Project.IBuildSettings>{
@@ -40,6 +38,7 @@ export class EmulateAndroidCommand implements ICommand {
 	public canExecute(args: string[]): IFuture<boolean> {
 		return ((): boolean => {
 			this.$project.ensureProject();
+			this.$androidEmulatorServices.checkDependencies().wait();
 			return true;
 		}).future<boolean>()();
 	}


### PR DESCRIPTION
In case user does not have Android SDK installed, we are trying to execute adb from CLI resources. This fails in case `$ <CLI> device` command or `$ <CLI> deploy <platform>` is executed as the "exec" cannot resolve the path with spaces.

Also fix the check dependencies of AndroidEmulatorService in order to fail with correct error message when something is not configured properly (currently it is failing with ENOENT error).

Fixes http://teampulse.telerik.com/view#item/297604