### PR TITLE
When evaluating glob patterns with wild cards do not skip .files

### DIFF
--- a/lib/services/path-filtering.ts
+++ b/lib/services/path-filtering.ts
@@ -39,12 +39,12 @@ export class PathFilteringService implements IPathFilteringService {
 			let shouldInclude = rule[0] === '!';
 			if (shouldInclude) {
 				rule = rule.substr(1);
-				let ruleMatched = minimatch(file, rule, {nocase: true});
+				let ruleMatched = minimatch(file, rule, {nocase: true, dot: true});
 				if (ruleMatched) {
 					fileMatched = true;
 				}
 			} else {
-				let options = {nocase: true, nonegate: false};
+				let options = {nocase: true, nonegate: false, dot: true};
 				if (rule[0] === '\\' && rule[1] === '!') {
 					rule = rule.substr(1);
 					options.nonegate = true;

--- a/test/path-filtering.ts
+++ b/test/path-filtering.ts
@@ -87,4 +87,11 @@ describe("PathFilteringService", () => {
 		let expected = ["a","b"];
 		assert.deepEqual(actual, expected);
 	});
+
+	it("ignore .files", () => {
+		let projectFiles = prefixWithProjectDir(["test/A", "test/.B", "test/C"]);
+		let actual = testInjector.resolve("pathFilteringService").filterIgnoredFiles(projectFiles, ["test/**/*"], projectDir);
+		let expected: string[] = [];
+		assert.deepEqual(actual, expected);
+	});
 });


### PR DESCRIPTION
For example, test patern test/\*\*/\* must exclude test/.file

Fixes http://teampulse.telerik.com/view#item/297858