### PR TITLE
Do not fail when build property is not defined

### DIFF
--- a/lib/services/build.ts
+++ b/lib/services/build.ts
@@ -253,7 +253,7 @@ export class BuildService implements Project.IBuildService {
 		return ((): Project.IBuildResult => {
 			Object.keys(buildProperties).forEach((prop) => {
 				if(buildProperties[prop] === undefined) {
-					this.$errors.fail(util.format("Build property '%s' is undefined.", prop));
+					this.$logger.warn(`Build property '${prop}' is undefined. The property is optional, but you can set it by running '${this.$staticConfig.CLIENT_NAME.toLowerCase()} prop set ${prop} <value>'.`);
 				}
 
 				if(_.isArray(buildProperties[prop])) {


### PR DESCRIPTION
When some not mandatory property (like WP8SupportedResolutions) is not defined in .abproject, json schema validation is correct, but we have additional check for our build properties which is preventing the build. Show warning instead of error in such case as the json validation will fail long before that if mandatory property has value undefined.

Fixes http://teampulse.telerik.com/view#item/298156