### PR TITLE
Fix finding of Google Play certificate

### DIFF
--- a/lib/validators/cryptographic-identity-validators.ts
+++ b/lib/validators/cryptographic-identity-validators.ts
@@ -11,7 +11,7 @@ import path = require("path");
 
 export class SelfSignedIdentityValidator extends BaseValidators.BaseValidator<ISelfSignedIdentityModel> {
 	public static DATE_FORMAT = "YYYY-MM-DD";
-	public static GOOGLE_PLAY_IDENTITY_MIN_EXPIRATION_DATE = new Date("2033-10-23");
+	public static GOOGLE_PLAY_IDENTITY_MIN_EXPIRATION_DATE = new Date(2033, 9, 23, 0, 0, 0, 0);
 
 	public static EMPTY_FIELD_ERROR_MESSAGE_PATTERN = "%s is required";
 	public static INVALID_FIELD_ERROR_MESSAGE_PATTERN = "%s is invalid";


### PR DESCRIPTION
When building for Android AppStore, Google requires min endDate of the certificate to be 23 October 2033. When you have certificate expiring exactly at this date, CLI does not use it and tells you that it cannot find applicable store certificate.
The problem is that our constant for MIN expiration date of the certificate is created with Date only. This creates new Date object with specified date, but the hours in the object depend on the current timezone, so for BG it is set to 3:00:00. So when we validate the certificates expiring at 00:00:00 on 23 October 2033, we do not use them as they are not matching the MIN expiration date.

Fixes http://teampulse.telerik.com/view#item/298197