### PR TITLE
Generate QR codes only for application packages

### DIFF
--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -42,6 +42,8 @@ declare module Server {
 		solutionPath: string;
 		relativePath: string;
 		localFile?: string;
+		disposition: string;
+		format: string;
 	}
 
 	interface IBuildResult {

--- a/lib/services/build.ts
+++ b/lib/services/build.ts
@@ -81,7 +81,9 @@ export class BuildService implements Project.IBuildService {
 					platform: buildResult.Platform,
 					solution: solutionName,
 					solutionPath: solutionPath,
-					relativePath: buildResult.FullPath
+					relativePath: buildResult.FullPath,
+					disposition: buildResult.Disposition,
+					format: buildResult.Format
 				};
 			});
 
@@ -339,8 +341,9 @@ export class BuildService implements Project.IBuildService {
 			if(settings.showQrCodes) {
 				let urlKind = buildResult.provisionType === constants.ProvisionType.AdHoc ? "manifest" : "package";
 				let liveSyncToken = buildResult.buildProperties.LiveSyncToken;
+				let appPackages = _.filter(packageDefs, (def: Server.IPackageDef) =>  !def.disposition || def.disposition === "BuildResult");
 
-				let packageDownloadViewModels = _.map(packageDefs, (def: Server.IPackageDef): IPackageDownloadViewModel => {
+				let packageDownloadViewModels = _.map(appPackages, (def: Server.IPackageDef): IPackageDownloadViewModel => {
 					let liveSyncUrl = this.getLiveSyncUrl(urlKind, def.relativePath, liveSyncToken).wait();
 
 					let packageUrl = (urlKind !== "package")


### PR DESCRIPTION
The server will start returning multiple build result files. The app package is marked with disposition 'BuildResult', while additional configuration files with 'AdditionalFile'.
We need to download the additional files when --download option is specified, but should not generate a QR code for them.

ping @Fatme @rosen-vladimirov @teobugslayer 

refs https://github.com/Icenium/Ice/pull/4204, http://teampulse.telerik.com/view#item/300733