### PR TITLE
Integrate screenbuilder v0.0.10

### DIFF
--- a/config/dependency-config.json
+++ b/config/dependency-config.json
@@ -1,10 +1,10 @@
 {
 	"appScaffolding": {
-		"version": "0.0.9"
+		"version": "0.0.10"
 	},
 	"generators": [{
 		"name": "generator-kendo-ui-mobile",
-		"version": "0.0.9",
+		"version": "0.0.10",
 		"alias": "H"
 	}]
 }

--- a/docs/man_pages/index.md
+++ b/docs/man_pages/index.md
@@ -51,6 +51,7 @@ Command | Description
 -------|----------
 [create screenbuilder](project/creation/create.html) | Creates a new project for hybrid development with Screen Builder.
 [screenbuilder](screenbuilder/screenbuilder.html) | Shows all commands for project development with Screen Builder.
+[upgrade-screenbuilder](screenbuilder/upgrade-screenbuilder.html) | Upgrades a project to the latest Screen Builder version.
 [add-view](screenbuilder/add-view.html) | Adds a new application view to your project.
 [add-dataprovider](add-dataprovider.html) | Connects your project to a data provider.
 [add-authentication](screenbuilder/add-authentication.html) | Inserts sign-in and sign-up forms in an existing application view.

--- a/docs/man_pages/screenbuilder/add-about.md
+++ b/docs/man_pages/screenbuilder/add-about.md
@@ -14,7 +14,7 @@ Inserts an about form in an existing application view. <% if(isHtml) { %>An inte
 
 ### Attributes
 
-* `<File Path>` is the absolute or relative file path to a `JSON` file which contains configuration information about your project.<% if(isHtml) { %> The file must comply with the JSON specification described in detail [here](http://docs.telerik.com/platform/appbuilder/creating-your-project/screen-builder-automation#add-about).<% } %> 
+* `<File Path>` is the absolute or relative file path to a `JSON` file which contains configuration information about your project.<% if(isHtml) { %> The file must comply with the JSON specification described in detail [here](http://docs.telerik.com/platform/appbuilder/creating-your-project/screen-builder-automation#add-about).<% } %>
 
 <% if(isHtml) { %>
 ### Prerequisites
@@ -22,7 +22,7 @@ Inserts an about form in an existing application view. <% if(isHtml) { %>An inte
 * The existing application view must be added with `$ appbuilder add-view` or must be the default `home` view.
 * Verify that you have installed git on your system.
 
-### Command Limitations 
+### Command Limitations
 
 * You can run this command only on projects created with Screen Builder.
 * You cannot use this command to modify projects created with earlier versions of the Telerik AppBuilder CLI. This behavior will be fixed in an upcoming release.
@@ -33,6 +33,7 @@ Command | Description
 ----------|----------
 [create screenbuilder](../project/creation/create-screenbuilder.html) | Creates a new project for hybrid development with Screen Builder.
 [screenbuilder](screenbuilder.html) | Shows all commands for project development with Screen Builder.
+[upgrade-screenbuilder](upgrade-screenbuilder.html) | Upgrades a project to the latest Screen Builder version.
 [add-authentication](add-authentication.html) | Inserts sign-in and sign-up forms in an existing application view.
 [add-dataprovider](add-dataprovider.html) | Connects your project to a data provider.
 [add-field](add-field.html) | Inserts an input field in an existing form.

--- a/docs/man_pages/screenbuilder/add-authentication.md
+++ b/docs/man_pages/screenbuilder/add-authentication.md
@@ -14,7 +14,7 @@ Inserts sign-in and sign-up forms in an existing application view. You can conne
 
 ### Attributes
 
-* `<File Path>` is the absolute or relative file path to a `JSON` file which contains configuration information about your project.<% if(isHtml) { %> The file must comply with the JSON specification described in detail [here](http://docs.telerik.com/platform/appbuilder/creating-your-project/screen-builder-automation#add-authentication).<% } %> 
+* `<File Path>` is the absolute or relative file path to a `JSON` file which contains configuration information about your project.<% if(isHtml) { %> The file must comply with the JSON specification described in detail [here](http://docs.telerik.com/platform/appbuilder/creating-your-project/screen-builder-automation#add-authentication).<% } %>
 
 <% if(isHtml) { %>
 ### Prerequisites
@@ -23,7 +23,7 @@ Inserts sign-in and sign-up forms in an existing application view. You can conne
 * You must have at least one data provider configured with `$ appbuilder add-dataprovider`
 * Verify that you have installed git on your system.
 
-### Command Limitations 
+### Command Limitations
 
 * You can run this command only on projects created with Screen Builder.
 * You cannot use this command to modify projects created with earlier versions of the Telerik AppBuilder CLI. This behavior will be fixed in an upcoming release.
@@ -34,6 +34,7 @@ Command | Description
 ----------|----------
 [create screenbuilder](../project/creation/create-screenbuilder.html) | Creates a new project for hybrid development with Screen Builder.
 [screenbuilder](screenbuilder.html) | Shows all commands for project development with Screen Builder.
+[upgrade-screenbuilder](upgrade-screenbuilder.html) | Upgrades a project to the latest Screen Builder version.
 [add-about](add-about.html) | Inserts an about form in an existing application view.
 [add-dataprovider](add-dataprovider.html) | Connects your project to a data provider.
 [add-field](add-field.html) | Inserts an input field in an existing form.

--- a/docs/man_pages/screenbuilder/add-dataprovider.md
+++ b/docs/man_pages/screenbuilder/add-dataprovider.md
@@ -14,7 +14,7 @@ Connects your project to a Telerik Backend Services, JSON, OData or a Progress D
 
 ### Attributes
 
-* `<File Path>` is the absolute or relative file path to a `JSON` file which contains configuration information about your project.<% if(isHtml) { %> The file must comply with the JSON specification described in detail [here](http://docs.telerik.com/platform/appbuilder/creating-your-project/screen-builder-automation#add-dataprovider).<% } %> 
+* `<File Path>` is the absolute or relative file path to a `JSON` file which contains configuration information about your project.<% if(isHtml) { %> The file must comply with the JSON specification described in detail [here](http://docs.telerik.com/platform/appbuilder/creating-your-project/screen-builder-automation#add-dataprovider).<% } %>
 
 <% if(isHtml) { %>
 ### Prerequisites
@@ -32,6 +32,7 @@ Command | Description
 ----------|----------
 [create screenbuilder](../project/creation/create-screenbuilder.html) | Creates a new project for hybrid development with Screen Builder.
 [screenbuilder](screenbuilder.html) | Shows all commands for project development with Screen Builder.
+[upgrade-screenbuilder](upgrade-screenbuilder.html) | Upgrades a project to the latest Screen Builder version.
 [add-about](add-about.html) | Inserts an about form in an existing application view.
 [add-authentication](add-authentication.html) | Inserts sign-in and sign-up forms in an existing application view.
 [add-field](add-field.html) | Inserts an input field in an existing form.

--- a/docs/man_pages/screenbuilder/add-field.md
+++ b/docs/man_pages/screenbuilder/add-field.md
@@ -14,15 +14,15 @@ Inserts an input field of a selected type with a label and placeholder text in a
 
 ### Attributes
 
-* `<File Path>` is the absolute or relative file path to a `JSON` file which contains configuration information about your project.<% if(isHtml) { %> The file must comply with the JSON specification described in detail [here](http://docs.telerik.com/platform/appbuilder/creating-your-project/screen-builder-automation#add-field).<% } %> 
+* `<File Path>` is the absolute or relative file path to a `JSON` file which contains configuration information about your project.<% if(isHtml) { %> The file must comply with the JSON specification described in detail [here](http://docs.telerik.com/platform/appbuilder/creating-your-project/screen-builder-automation#add-field).<% } %>
 
 <% if(isHtml) { %>
 ### Prerequisites
 
 * The existing form must be added with `$ appbuilder add-form`
-* Verify that you have installed git on your system. 
+* Verify that you have installed git on your system.
 
-### Command Limitations 
+### Command Limitations
 
 * You can run this command only on projects created with Screen Builder.
 * You cannot use this command to modify projects created with earlier versions of the Telerik AppBuilder CLI. This behavior will be fixed in an upcoming release.
@@ -33,6 +33,7 @@ Command | Description
 ----------|----------
 [create screenbuilder](../project/creation/create-screenbuilder.html) | Creates a new project for hybrid development with Screen Builder.
 [screenbuilder](screenbuilder.html) | Shows all commands for project development with Screen Builder.
+[upgrade-screenbuilder](upgrade-screenbuilder.html) | Upgrades a project to the latest Screen Builder version.
 [add-about](add-about.html) | Inserts an about form in an existing application view.
 [add-authentication](add-authentication.html) | Inserts sign-in and sign-up forms in an existing application view.
 [add-dataprovider](add-dataprovider.html) | Connects your project to a data provider.

--- a/docs/man_pages/screenbuilder/add-form.md
+++ b/docs/man_pages/screenbuilder/add-form.md
@@ -14,7 +14,7 @@ Inserts a generic input form in an existing application view. You can later inse
 
 ### Attributes
 
-* `<File Path>` is the absolute or relative file path to a `JSON` file which contains configuration information about your project.<% if(isHtml) { %> The file must comply with the JSON specification described in detail [here](http://docs.telerik.com/platform/appbuilder/creating-your-project/screen-builder-automation#add-form).<% } %> 
+* `<File Path>` is the absolute or relative file path to a `JSON` file which contains configuration information about your project.<% if(isHtml) { %> The file must comply with the JSON specification described in detail [here](http://docs.telerik.com/platform/appbuilder/creating-your-project/screen-builder-automation#add-form).<% } %>
 
 <% if(isHtml) { %>
 ### Prerequisites
@@ -22,7 +22,7 @@ Inserts a generic input form in an existing application view. You can later inse
 * The existing application view must be added with `$ appbuilder add-view` or must be the default `home` view.
 * Verify that you have installed git on your system.
 
-### Command Limitations 
+### Command Limitations
 
 * You can run this command only on projects created with Screen Builder.
 * You cannot use this command to modify projects created with earlier versions of the Telerik AppBuilder CLI. This behavior will be fixed in an upcoming release.
@@ -33,6 +33,7 @@ Command | Description
 ----------|----------
 [create screenbuilder](../project/creation/create-screenbuilder.html) | Creates a new project for hybrid development with Screen Builder.
 [screenbuilder](screenbuilder.html) | Shows all commands for project development with Screen Builder.
+[upgrade-screenbuilder](upgrade-screenbuilder.html) | Upgrades a project to the latest Screen Builder version.
 [add-about](add-about.html) | Inserts an about form in an existing application view.
 [add-authentication](add-authentication.html) | Inserts sign-in and sign-up forms in an existing application view.
 [add-dataprovider](add-dataprovider.html) | Connects your project to a data provider.

--- a/docs/man_pages/screenbuilder/add-list.md
+++ b/docs/man_pages/screenbuilder/add-list.md
@@ -6,7 +6,7 @@ Usage | Synopsis
 General | `$ appbuilder add-list` [--answers <File Path>]
 
 Inserts a list in an existing application view. You can connect the list to a data provider added with `$ appbuilder add-dataprovider` <% if(isHtml) { %>An interactive prompt guides you through the setup process.<% } %>
-<% if(isConsole) { %>WARNING: This command is applicable only to Apache Cordova projects created with Screen Builder.<% } %> 
+<% if(isConsole) { %>WARNING: This command is applicable only to Apache Cordova projects created with Screen Builder.<% } %>
 
 ### Options
 
@@ -14,7 +14,7 @@ Inserts a list in an existing application view. You can connect the list to a da
 
 ### Attributes
 
-* `<File Path>` is the absolute or relative file path to a `JSON` file which contains configuration information about your project.<% if(isHtml) { %> The file must comply with the JSON specification described in detail [here](http://docs.telerik.com/platform/appbuilder/creating-your-project/screen-builder-automation#add-list).<% } %> 
+* `<File Path>` is the absolute or relative file path to a `JSON` file which contains configuration information about your project.<% if(isHtml) { %> The file must comply with the JSON specification described in detail [here](http://docs.telerik.com/platform/appbuilder/creating-your-project/screen-builder-automation#add-list).<% } %>
 
 <% if(isHtml) { %>
 ### Prerequisites
@@ -23,7 +23,7 @@ Inserts a list in an existing application view. You can connect the list to a da
 * You must have at least one data provider configured with `$ appbuilder add-dataprovider`
 * Verify that you have installed git on your system.
 
-### Command Limitations 
+### Command Limitations
 
 * You can run this command only on projects created with Screen Builder.
 * You cannot use this command to modify projects created with earlier versions of the Telerik AppBuilder CLI. This behavior will be fixed in an upcoming release.
@@ -34,6 +34,7 @@ Command | Description
 ----------|----------
 [create screenbuilder](../project/creation/create-screenbuilder.html) | Creates a new project for hybrid development with Screen Builder.
 [screenbuilder](screenbuilder.html) | Shows all commands for project development with Screen Builder.
+[upgrade-screenbuilder](upgrade-screenbuilder.html) | Upgrades a project to the latest Screen Builder version.
 [add-about](add-about.html) | Inserts an about form in an existing application view.
 [add-authentication](add-authentication.html) | Inserts sign-in and sign-up forms in an existing application view.
 [add-dataprovider](add-dataprovider.html) | Connects your project to a data provider.

--- a/docs/man_pages/screenbuilder/add-view.md
+++ b/docs/man_pages/screenbuilder/add-view.md
@@ -6,7 +6,7 @@ Usage | Synopsis
 General | `$ appbuilder add-view` [--answers <File Path>]
 
 Adds a new application view to your project. You can later add lists and forms to the view with the respective Screen Builder commands.<% if(isHtml) { %>An interactive prompt guides you through the setup process.<% } %>
-<% if(isConsole) { %>WARNING: This command is applicable only to Apache Cordova projects created with Screen Builder.<% } %> 
+<% if(isConsole) { %>WARNING: This command is applicable only to Apache Cordova projects created with Screen Builder.<% } %>
 
 ### Options
 
@@ -14,10 +14,10 @@ Adds a new application view to your project. You can later add lists and forms t
 
 ### Attributes
 
-* `<File Path>` is the absolute or relative file path to a `JSON` file which contains configuration information about your project.<% if(isHtml) { %> The file must comply with the JSON specification described in detail [here](http://docs.telerik.com/platform/appbuilder/creating-your-project/screen-builder-automation#add-view).<% } %> 
+* `<File Path>` is the absolute or relative file path to a `JSON` file which contains configuration information about your project.<% if(isHtml) { %> The file must comply with the JSON specification described in detail [here](http://docs.telerik.com/platform/appbuilder/creating-your-project/screen-builder-automation#add-view).<% } %>
 
 <% if(isHtml) { %>
-### Command Limitations 
+### Command Limitations
 
 * You can run this command only on projects created with Screen Builder.
 * Verify that you have installed git on your system.
@@ -29,6 +29,7 @@ Command | Description
 ----------|----------
 [create screenbuilder](../project/creation/create-screenbuilder.html) | Creates a new project for hybrid development with Screen Builder.
 [screenbuilder](screenbuilder.html) | Shows all commands for project development with Screen Builder.
+[upgrade-screenbuilder](upgrade-screenbuilder.html) | Upgrades a project to the latest Screen Builder version.
 [add-about](add-about.html) | Inserts an about form in an existing application view.
 [add-authentication](add-authentication.html) | Inserts sign-in and sign-up forms in an existing application view.
 [add-dataprovider](add-dataprovider.html) | Connects your project to a data provider.

--- a/docs/man_pages/screenbuilder/screenbuilder.md
+++ b/docs/man_pages/screenbuilder/screenbuilder.md
@@ -5,7 +5,7 @@ Usage | Synopsis
 ------|-------
 General | `$ appbuilder screenbuilder`
 
-Shows all commands for project development with Screen Builder. 
+Shows all commands for project development with Screen Builder.
 
 <% if(isConsole) { %>WARNING: This set of commands is applicable only to Apache Cordova projects created with Screen Builder.<% } %>
 
@@ -19,7 +19,7 @@ Command | Description
 [add-list](add-list.html) | Inserts a list in an existing application view.
 [add-view](add-view.html) | Adds a new application view to your project.
 
-<% if(isHtml) { %> 
+<% if(isHtml) { %>
 ### Prerequisites
 
 * Verify that you have installed git on your system.
@@ -32,4 +32,5 @@ Command | Description
 Command | Description
 ----------|----------
 [create screenbuilder](../project/creation/create-screenbuilder.html) | Creates a new project for hybrid development with Screen Builder.
+[upgrade-screenbuilder](upgrade-screenbuilder.html) | Upgrades a project to the latest Screen Builder version.
 <% } %>

--- a/docs/man_pages/screenbuilder/upgrade-screenbuilder.md
+++ b/docs/man_pages/screenbuilder/upgrade-screenbuilder.md
@@ -1,0 +1,29 @@
+upgrade-screenbuilder
+==========
+
+Usage | Synopsis
+------|-------
+General | `$ appbuilder upgrade-screenbuilder`
+
+Upgrades a project to the latest Screen Builder version. This operation regenerates the project and you might lose custom code changes.<% if(isHtml) { %> For more information how to preserve your custom code changes, see [How To Add And Keep Custom Code Changes In Your App](http://docs.telerik.com/platform/screenbuilder/troubleshooting/how-to-keep-custom-code-changes).<% } %>
+
+<% if(isConsole) { %>WARNING: This command is applicable only to Apache Cordova projects created with Screen Builder.<% } %>
+
+<% if(isHtml) { %>
+### Command Limitations
+
+* You can run this command only on Apache Cordova projects created with Screen Builder 0.0.7 and later. For projects created with earlier versions of Screen Builder, you need to upgrade your project manually. You need to create a new Screen Builder project and transfer custom code and resources to the newly created project.
+
+### Related Commands
+
+Command | Description
+----------|----------
+[create screenbuilder](../project/creation/create-screenbuilder.html) | Creates a new project for hybrid development with Screen Builder.
+[screenbuilder](screenbuilder.html) | Shows all commands for project development with Screen Builder.
+[add-about](add-about.html) | Inserts an about form in an existing application view.
+[add-authentication](add-authentication.html) | Inserts sign-in and sign-up forms in an existing application view.
+[add-dataprovider](add-dataprovider.html) | Connects your project to a data provider.
+[add-field](add-field.html) | Inserts an input field in an existing form.
+[add-form](add-form.html) | Inserts a generic input form in an existing application view.
+[add-list](add-list.html) | Inserts a list in an existing application view.
+<% } %>

--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -147,6 +147,8 @@ $injector.requireCommand("appmanager|groups", "./commands/appmanager");
 
 $injector.requireCommand("update-kendoui", "./commands/update-kendoui");
 
+$injector.requireCommand("upgrade-screenbuilder", "./commands/upgrade-screenbuilder");
+
 $injector.requireCommand("dev-prepackage", "./commands/dev/prepackage");
 $injector.require("platformServices", "./commands/simulate");
 $injector.require("remoteService", "./services/remote-service");

--- a/lib/commands/project/create.ts
+++ b/lib/commands/project/create.ts
@@ -27,7 +27,7 @@ export class CreateCommand extends ProjectCommandBaseLib.ProjectCommandBase {
 
 			this.$project.createTemplateFolder(projectPath).wait();
 
-			let screenBuilderOptions = this.$screenBuilderService.composeScreenBuilderOptions({
+			let screenBuilderOptions = this.$screenBuilderService.composeScreenBuilderOptions(this.$options.answers, {
 				projectPath: projectPath,
 				answers: {
 					name: projectName
@@ -35,8 +35,8 @@ export class CreateCommand extends ProjectCommandBaseLib.ProjectCommandBase {
 			}).wait();
 
 			try {
-				this.$screenBuilderService.prepareAndGeneratePrompt(this.$screenBuilderService.generatorName, screenBuilderOptions).wait();
-				this.$screenBuilderService.installAppDependencies(screenBuilderOptions).wait();
+				this.$screenBuilderService.prepareAndGeneratePrompt(this.$screenBuilderService.generatorName, this.$options.path, screenBuilderOptions).wait();
+				this.$screenBuilderService.installAppDependencies(screenBuilderOptions, this.$options.path).wait();
 
 				this.$project.initializeProjectFromExistingFiles(this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova, projectPath, projectName).wait();
 			} catch(err) {

--- a/lib/commands/upgrade-screenbuilder.ts
+++ b/lib/commands/upgrade-screenbuilder.ts
@@ -1,0 +1,35 @@
+///<reference path="../.d.ts"/>
+"use strict";
+
+class UpgradeScreenBuilder implements ICommand {
+
+	constructor(private $logger: ILogger,
+		private $project: Project.IProject,
+		private $screenBuilderService: IScreenBuilderService) {	}
+
+	allowedParameters: ICommandParameter[] = [];
+
+	canExecute(args: string[]): IFuture<boolean> {
+		return ((): boolean => {
+			this.$project.ensureProject();
+			let projectDir = this.$project.getProjectDir().wait();
+			this.$screenBuilderService.ensureScreenBuilderProject(projectDir).wait();
+
+			return true;
+		}).future<boolean>()();
+	}
+
+	execute(args: string[]): IFuture<void> {
+		return (() => {
+			if (!this.$screenBuilderService.shouldUpgrade().wait()) {
+				this.$logger.info("Your project is already up-to-date with the latest Screen Builder.");
+				return;
+			}
+
+			this.$screenBuilderService.upgrade().wait();
+			this.$logger.info("Project successfully upgraded.");
+		}).future<void>()();
+	}
+}
+
+$injector.registerCommand("upgrade-screenbuilder", UpgradeScreenBuilder);

--- a/lib/commands/upgrade-screenbuilder.ts
+++ b/lib/commands/upgrade-screenbuilder.ts
@@ -4,6 +4,7 @@
 class UpgradeScreenBuilder implements ICommand {
 
 	constructor(private $logger: ILogger,
+		private $options: IOptions,
 		private $project: Project.IProject,
 		private $screenBuilderService: IScreenBuilderService) {	}
 
@@ -21,12 +22,12 @@ class UpgradeScreenBuilder implements ICommand {
 
 	execute(args: string[]): IFuture<void> {
 		return (() => {
-			if (!this.$screenBuilderService.shouldUpgrade().wait()) {
+			if (!this.$screenBuilderService.shouldUpgrade(this.$options.path).wait()) {
 				this.$logger.info("Your project is already up-to-date with the latest Screen Builder.");
 				return;
 			}
 
-			this.$screenBuilderService.upgrade().wait();
+			this.$screenBuilderService.upgrade(this.$options.path).wait();
 			this.$logger.info("Project successfully upgraded.");
 		}).future<void>()();
 	}

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -389,11 +389,14 @@ interface IAppScaffoldingExtensionsService {
 interface IScreenBuilderService {
 	generatorName: string;
 	commandsPrefix: string;
-	prepareAndGeneratePrompt(generatorName: string, screenBuilderOptions?: IScreenBuilderOptions): IFuture<void>;
+	prepareAndGeneratePrompt(generatorName: string, screenBuilderOptions?: IScreenBuilderOptions): IFuture<boolean>;
 	allSupportedCommands(generatorName?: string): IFuture<string[]>;
 	generateAllCommands(generatorName: string): IFuture<void>;
 	installAppDependencies(screenBuilderOptions: IScreenBuilderOptions): IFuture<void>;
 	composeScreenBuilderOptions(bacisSceenBuilderOptions?: IScreenBuilderOptions): IFuture<IScreenBuilderOptions>;
+	ensureScreenBuilderProject(projectDir: string): IFuture<void>;
+	shouldUpgrade(): IFuture<boolean>;
+	upgrade(): IFuture<void>;
 }
 
 interface IScreenBuilderOptions {
@@ -862,4 +865,14 @@ interface IAppStoreService {
 	 * @param password
 	 */
 	getApplicationsReadyForUpload(userName: string, password: string): IFuture<Server.Application[]>;
+}
+
+
+/**
+ *	Used for communicating with screenbuilder generators
+ */
+interface IScaffolder {
+	scaffolder: any;
+	future: IFuture<any>;
+	callback: Function;
 }

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -389,14 +389,14 @@ interface IAppScaffoldingExtensionsService {
 interface IScreenBuilderService {
 	generatorName: string;
 	commandsPrefix: string;
-	prepareAndGeneratePrompt(generatorName: string, screenBuilderOptions?: IScreenBuilderOptions): IFuture<boolean>;
+	prepareAndGeneratePrompt(generatorName: string, projectPath: string, screenBuilderOptions?: IScreenBuilderOptions): IFuture<boolean>;
 	allSupportedCommands(generatorName?: string): IFuture<string[]>;
 	generateAllCommands(generatorName: string): IFuture<void>;
-	installAppDependencies(screenBuilderOptions: IScreenBuilderOptions): IFuture<void>;
-	composeScreenBuilderOptions(bacisSceenBuilderOptions?: IScreenBuilderOptions): IFuture<IScreenBuilderOptions>;
+	installAppDependencies(screenBuilderOptions: IScreenBuilderOptions, projectPath: string): IFuture<void>;
+	composeScreenBuilderOptions(answers: string, bacisSceenBuilderOptions?: IScreenBuilderOptions): IFuture<IScreenBuilderOptions>;
 	ensureScreenBuilderProject(projectDir: string): IFuture<void>;
-	shouldUpgrade(): IFuture<boolean>;
-	upgrade(): IFuture<void>;
+	shouldUpgrade(projectPath: string): IFuture<boolean>;
+	upgrade(projectPath: string): IFuture<void>;
 }
 
 interface IScreenBuilderOptions {

--- a/lib/services/screen-builder-service.ts
+++ b/lib/services/screen-builder-service.ts
@@ -5,18 +5,28 @@ import * as path from "path";
 import * as util from "util";
 
 export class ScreenBuilderService implements IScreenBuilderService {
+	private static SCREEN_BUILDER_SPECIFIC_FILES = [".yo-rc.json", ".app.json", "app.js"];
+	private static UPGRADE_ERROR_MESSAGE = "Your app has been build with an obsolete version of Screen Builder. Please, migrate it to latest version and retry.";
+	// This constant is introduced due to the original message (the one above)
+	// not being descriptive enough.
+	// It should be removed once Screen Builder team fixes the message from their side in the next version.
+	private static UPGRADE_ERROR_MESSAGE_SHOWN_ON_THE_CONSOLE = "Your app has been created with an obsolete version of Screen Builder. You need to upgrade your project to be able to run Screen Builder-related commands.";
 	public static DEFAULT_SCREENBUILDER_TYPE = "application";
+	private shouldUpgradeCached: boolean = null;
+
 	private static PREDEFINED_SCREENBUILDER_TYPES: IStringDictionary = {
 		dataprovider: "dataProvider"
 	};
 
 	constructor(private $appScaffoldingExtensionsService: IAppScaffoldingExtensionsService,
 		private $childProcess: IChildProcess,
+		private $errors: IErrors,
 		private $dependencyConfigService: IDependencyConfigService,
 		private $generatorExtensionsService: IGeneratorExtensionsService,
 		private $injector: IInjector,
 		private $logger: ILogger,
 		private $options: IOptions,
+		private $prompter: IPrompter,
 		private $fs: IFileSystem) { }
 
 	public get generatorName(): string {
@@ -27,11 +37,39 @@ export class ScreenBuilderService implements IScreenBuilderService {
 		return "add";
 	}
 
-	public prepareAndGeneratePrompt(generatorName: string, screenBuilderOptions?: IScreenBuilderOptions): IFuture<void> {
+	public prepareAndGeneratePrompt(generatorName: string, screenBuilderOptions?: IScreenBuilderOptions): IFuture<boolean> {
 		return (() => {
-			this.$logger.out("Please, wait while Screen Builder and its dependencies are being configured.");
-			this.promptGenerate(generatorName, screenBuilderOptions).wait();
-		}).future<void>()();
+			let scaffolderData = this.promptGenerate(generatorName, screenBuilderOptions).wait(),
+				scaffolderFutureResult = scaffolderData.future.wait(),
+				disableCommandHelpSuggestion = false;
+
+			if (scaffolderFutureResult === ScreenBuilderService.UPGRADE_ERROR_MESSAGE) {
+				this.$logger.error(ScreenBuilderService.UPGRADE_ERROR_MESSAGE_SHOWN_ON_THE_CONSOLE);
+				let shouldMigrate = this.$prompter.confirm('Do you want to upgrade your project now? Custom code changes might be lost.', () => false).wait();
+
+				if (shouldMigrate) {
+					let future = new Future<any>();
+					let callback = (err:Error, data:any) => {
+						if (err) {
+							let error = this.getErrorsRecursive(err).join('\n');
+							this.$logger.trace(`Screen Builder error: ${err.message}`);
+							future.throw(new Error(error));
+						} else {
+							future.return(data);
+						}
+					};
+
+					scaffolderData.scaffolder.upgrade(callback);
+
+					future.wait();
+					this.promptGenerate(generatorName, screenBuilderOptions).wait().future.wait();
+				}
+
+				disableCommandHelpSuggestion = !shouldMigrate;
+			}
+
+			return disableCommandHelpSuggestion;
+		}).future<boolean>()();
 	}
 
 	public allSupportedCommands(generatorName: string): IFuture<string[]> {
@@ -42,6 +80,10 @@ export class ScreenBuilderService implements IScreenBuilderService {
 
 			let generatorConfig = this.$dependencyConfigService.getGeneratorConfig(generatorName).wait();
 			let pathToGenerator = path.join(this.$appScaffoldingExtensionsService.appScaffoldingPath, generatorConfig.alias, generatorConfig.version, "node_modules", generatorName);
+			if (!this.$fs.exists(pathToGenerator).wait()) {
+				this.prepareScreenBuilder().wait();
+			}
+
 			let schema = require(path.join(pathToGenerator, ".schema.json"));
 			let allSupportedCommands = _.keys(schema);
 			return _.map(allSupportedCommands, (command:string) => util.format("%s-%s", this.commandsPrefix, command.toLowerCase()));
@@ -77,8 +119,62 @@ export class ScreenBuilderService implements IScreenBuilderService {
 		}).future<IScreenBuilderOptions>()();
 	}
 
+	public promptGenerate(generatorName: string, screenBuilderOptions?: IScreenBuilderOptions): IFuture<IScaffolder> {
+		return (() => {
+			let scaffolderData = this.createScaffolder(generatorName, screenBuilderOptions).wait();
+			let scaffolder = scaffolderData.scaffolder;
+			let type = screenBuilderOptions.type || ScreenBuilderService.DEFAULT_SCREENBUILDER_TYPE;
+			type = ScreenBuilderService.PREDEFINED_SCREENBUILDER_TYPES[type] || type;
+
+			if (type === ScreenBuilderService.DEFAULT_SCREENBUILDER_TYPE || screenBuilderOptions.answers) {
+					scaffolder.promptGenerate(type, screenBuilderOptions.answers, scaffolderData.callback);
+			} else {
+					scaffolder.promptGenerate(type, scaffolderData.callback);
+			}
+
+			return scaffolderData;
+		}).future<IScaffolder>()();
+	}
+
+	public ensureScreenBuilderProject(projectDir: string): IFuture<void> {
+		return (() => {
+			if(!_.every(ScreenBuilderService.SCREEN_BUILDER_SPECIFIC_FILES, file => this.$fs.exists(path.join(projectDir, file)).wait())) {
+				this.$errors.failWithoutHelp("This command is applicable only to Screen Builder projects.");
+			}
+		}).future<void>()();
+	}
+
+	public shouldUpgrade(): IFuture<boolean> {
+		return (() => {
+			if (!this.shouldUpgradeCached) {
+				let scaffolderData = this.createScaffolder(this.generatorName).wait();
+
+				scaffolderData.scaffolder.initContext({ collectMetadata: true }, scaffolderData.callback);
+
+				this.shouldUpgradeCached = scaffolderData.future.wait() === ScreenBuilderService.UPGRADE_ERROR_MESSAGE;
+			}
+
+			return this.shouldUpgradeCached;
+		}).future<boolean>()();
+	}
+
+	public upgrade(): IFuture<void> {
+		return (() => {
+			if (!this.shouldUpgrade().wait()) {
+				return;
+			}
+
+			let scaffolderData = this.createScaffolder(this.generatorName).wait();
+
+			scaffolderData.scaffolder.upgrade(scaffolderData.callback);
+
+			scaffolderData.future.wait();
+		}).future<void>()();
+	}
+
 	private prepareScreenBuilder(): IFuture<void> {
 		return (() => {
+			this.$logger.out("Please, wait while Screen Builder and its dependencies are being configured.");
 			this.$appScaffoldingExtensionsService.prepareAppScaffolding().wait();
 
 			let generators = this.$dependencyConfigService.getAllGenerators().wait();
@@ -86,25 +182,8 @@ export class ScreenBuilderService implements IScreenBuilderService {
 		}).future<void>()();
 	}
 
-	private promptGenerate(generatorName: string, screenBuilderOptions?: IScreenBuilderOptions): IFuture<void> {
-		let scaffolderData = this.createScaffolder(generatorName, screenBuilderOptions).wait();
-		let scaffolder = scaffolderData.scaffolder;
-		let type = screenBuilderOptions.type || ScreenBuilderService.DEFAULT_SCREENBUILDER_TYPE;
-		type = ScreenBuilderService.PREDEFINED_SCREENBUILDER_TYPES[type] || type;
-
-		if (type === ScreenBuilderService.DEFAULT_SCREENBUILDER_TYPE || screenBuilderOptions.answers) {
-				scaffolder.promptGenerate(type, screenBuilderOptions.answers, scaffolderData.callback);
-		} else {
-				scaffolder.promptGenerate(type, scaffolderData.callback);
-		}
-
-		return scaffolderData.future;
-	}
-
-	private createScaffolder(generatorName: string, screenBuilderOptions?: IScreenBuilderOptions): IFuture<{ scaffolder: any; future: IFuture<any>; callback: Function }> {
+	private getScaffolder(generatorName: string, screenBuilderOptions?: IScreenBuilderOptions): IFuture<any> {
 		return (() => {
-			this.prepareScreenBuilder().wait();
-			screenBuilderOptions = screenBuilderOptions || {};
 			let generatorConfig = this.$dependencyConfigService.getGeneratorConfig(generatorName).wait();
 
 			let appScaffoldingPath = this.$appScaffoldingExtensionsService.appScaffoldingPath;
@@ -114,7 +193,7 @@ export class ScreenBuilderService implements IScreenBuilderService {
 			let connector = {
 				generatorsCache: appScaffoldingPath,
 				generatorsAlias: [generatorConfig.alias],
-				path: screenBuilderOptions.projectPath || path.resolve(this.$options.path || "."),
+				path: screenBuilderOptions && screenBuilderOptions.projectPath || path.resolve(this.$options.path || "."),
 				dependencies: [util.format("%s@%s", generatorName, generatorConfig.version)],
 				connect: (done:Function) => {
 					done();
@@ -122,20 +201,33 @@ export class ScreenBuilderService implements IScreenBuilderService {
 				logger: this.$logger.trace.bind(this.$logger)
 			};
 
-			let scaffolder = new Scaffolder(connector);
-			let future = new Future<void>();
-			let callback = (err:any, data:any) => {
+			return new Scaffolder(connector);
+		}).future<IScaffolder>()();
+	}
+
+	private createScaffolder(generatorName: string, screenBuilderOptions?: IScreenBuilderOptions): IFuture<IScaffolder> {
+		return (() => {
+			this.prepareScreenBuilder().wait();
+			screenBuilderOptions = screenBuilderOptions || {};
+
+			let scaffolder = this.getScaffolder(generatorName, screenBuilderOptions).wait();
+			let future = new Future<any>();
+			let callback = (err:Error, data:any) => {
 				if (err) {
 					let error = this.getErrorsRecursive(err).join('\n');
-					this.$logger.trace("ScreenBuilder error while prompting: %s", err);
-					future.throw(new Error(error));
+					this.$logger.trace(`Screen Builder error while prompting: ${err.message}`);
+					if (err.message === ScreenBuilderService.UPGRADE_ERROR_MESSAGE) {
+						future.return(ScreenBuilderService.UPGRADE_ERROR_MESSAGE);
+					} else {
+						future.throw(new Error(error));
+					}
 				} else {
 					future.return(data);
 				}
 			};
 
 			return {scaffolder: scaffolder, future: future, callback: callback};
-		}).future<{ scaffolder: any; future: IFuture<any>; callback: Function }>()();
+		}).future<IScaffolder>()();
 	}
 
 	private getErrorsRecursive(errorObject: any): string[] {
@@ -160,33 +252,25 @@ export class ScreenBuilderService implements IScreenBuilderService {
 $injector.register("screenBuilderService", ScreenBuilderService);
 
 class ScreenBuilderDynamicCommand implements ICommand {
-	private static SCREEN_BUILDER_SPECIFIC_FILES = [".yo-rc.json", ".app.json", "app.js"];
+	public disableCommandHelpSuggestion: boolean;
 
 	constructor(public generatorName: string,
 		public command: string,
-		private $errors: IErrors,
 		private $fs: IFileSystem,
 		private $project: Project.IProject,
 		private $screenBuilderService: IScreenBuilderService) { }
 
 	public execute(args: string[]): IFuture<void> {
-		this.ensureScreenBuilderProject().wait();
-
-		let screenBuilderOptions = this.$screenBuilderService.composeScreenBuilderOptions({
-			type: this.command.substr(this.command.indexOf("-") + 1)
-		}).wait();
-
-		return this.$screenBuilderService.prepareAndGeneratePrompt(this.generatorName, screenBuilderOptions);
-	}
-
-	private ensureScreenBuilderProject(): IFuture<void> {
 		return (() => {
 			this.$project.ensureProject();
-
 			let projectDir = this.$project.getProjectDir().wait();
-			if(!_.every(ScreenBuilderDynamicCommand.SCREEN_BUILDER_SPECIFIC_FILES, file => this.$fs.exists(path.join(projectDir, file)).wait())) {
-				this.$errors.fail("This command is applicable only to Screen Builder projects.");
-			}
+			this.$screenBuilderService.ensureScreenBuilderProject(projectDir).wait();
+
+			let screenBuilderOptions = this.$screenBuilderService.composeScreenBuilderOptions({
+				type: this.command.substr(this.command.indexOf("-") + 1)
+			}).wait();
+
+			this.disableCommandHelpSuggestion = this.$screenBuilderService.prepareAndGeneratePrompt(this.generatorName, screenBuilderOptions).wait();
 		}).future<void>()();
 	}
 


### PR DESCRIPTION
Includes
+ Backwards compatibility with projects, created with earlier Screen Builder versions
+ An option to explicitly upgrade an existing project - **new command**
+ Help for the new command
+ A prompt upon executing any Screen Builder-related command in an old project of whether or not to upgrade the project's Screen Builder version. Should the user choose to upgrade, the original command is automatically executed afterwards
+ Apparently Screen Builder now releases the console after a successful command's execution
+ Minor refactorings and fixes in the ```screen-builder-service.ts```

Depends on https://github.com/telerik/mobile-cli-lib/pull/450
Implements [Integrate with new Screen Builder latest release](http://teampulse.telerik.com/view#item/298407)
And fixes [Error on add-field if form is missing](http://teampulse.telerik.com/view#item/297304)