### PR TITLE
Conform image generation with server

### DIFF
--- a/lib/services/image-service.ts
+++ b/lib/services/image-service.ts
@@ -103,16 +103,16 @@ class ImageService implements IImageService {
 			this.$logger.printInfoMessageOnSameLine('Extracting images');
 			this.$progressIndicator.showProgressIndicator(this.$fs.unzip(resultImageArchivePath, tempDir), 2000).wait();
 			this.$fs.unzip(resultImageArchivePath, tempDir).wait();
+			this.$fs.deleteFile(resultImageArchivePath).wait();
 
-			let imageBasePath = path.join(tempDir, 'App_Resources'),
-				images = this.$fs.enumerateFilesInDirectorySync(imageBasePath);
+			let images = this.$fs.enumerateFilesInDirectorySync(tempDir);
 
 			_.each(images, imagePath => {
 				if (!this.$project.capabilities.wp8Supported && ~imagePath.indexOf(this.$devicePlatformsConstants.WP8)) {
 					return;
 				}
 
-				let projectImagePath = path.join(this.$project.appResourcesPath().wait(), imagePath.substring(imageBasePath.length));
+				let projectImagePath = path.join(this.$project.appResourcesPath().wait(), imagePath.substring(tempDir.length));
 				this.copyImageToProject(imagePath, projectImagePath).wait();
 			});
 		}).future<void>()();


### PR DESCRIPTION
Server's response was altered a bit in https://github.com/Icenium/Ice/pull/4206. Conform CLI with new server response
Implements/fixes [#299047](http://teampulse.telerik.com/view#item/299047)