### PR TITLE
Fix Livesync service

### DIFF
--- a/lib/services/livesync-service.ts
+++ b/lib/services/livesync-service.ts
@@ -81,7 +81,7 @@ export class LiveSyncService extends usbLivesyncServiceBaseLib.UsbLiveSyncServic
 			};
 
 			this.sync(platform, this.$project.projectData.AppIdentifier, projectDir,
-				this.excludedProjectDirsAndFiles, projectDir + "/**/*", platformSpecificLiveSyncServices, () => Future.fromResult(), notInstalledAppOnDeviceAction,
+				this.excludedProjectDirsAndFiles, projectDir + "/**/*", platformSpecificLiveSyncServices, notInstalledAppOnDeviceAction,
 				() => Future.fromResult()).wait();
 
 		}).future<void>()();


### PR DESCRIPTION
Remove a parameter that is no longer used in common's master branch from
livesync service.