### PR TITLE
Revert App_Resources fix

### DIFF
--- a/lib/services/image-service.ts
+++ b/lib/services/image-service.ts
@@ -103,16 +103,16 @@ class ImageService implements IImageService {
 			this.$logger.printInfoMessageOnSameLine('Extracting images');
 			this.$progressIndicator.showProgressIndicator(this.$fs.unzip(resultImageArchivePath, tempDir), 2000).wait();
 			this.$fs.unzip(resultImageArchivePath, tempDir).wait();
-			this.$fs.deleteFile(resultImageArchivePath).wait();
 
-			let images = this.$fs.enumerateFilesInDirectorySync(tempDir);
+			let imageBasePath = path.join(tempDir, 'App_Resources'),
+				images = this.$fs.enumerateFilesInDirectorySync(imageBasePath);
 
 			_.each(images, imagePath => {
 				if (!this.$project.capabilities.wp8Supported && ~imagePath.indexOf(this.$devicePlatformsConstants.WP8)) {
 					return;
 				}
 
-				let projectImagePath = path.join(this.$project.appResourcesPath().wait(), imagePath.substring(tempDir.length));
+				let projectImagePath = path.join(this.$project.appResourcesPath().wait(), imagePath.substring(imageBasePath.length));
 				this.copyImageToProject(imagePath, projectImagePath).wait();
 			});
 		}).future<void>()();


### PR DESCRIPTION
Due to backwards compatibility issues, App_Resources folder will not be removed from the result archive and changes made because of this need to be reverted.
Reference: https://github.com/Icenium/Ice/pull/4330
Ping @rosen-vladimirov 
This change fully reverts https://github.com/Icenium/icenium-cli/commit/3ec1bbb51e38dfa71934e38560d59e4c15b20f4f