### PR TITLE
Fix kendoui command-related bugs

### DIFF
--- a/lib/commands/kendoui-base.ts
+++ b/lib/commands/kendoui-base.ts
@@ -33,7 +33,7 @@ export class KendoUIBaseCommand implements ICommand {
 		return Future.fromResult();
 	}
 
-	public getKendoPackages(): IFuture<Server.IKendoDownloadablePackageData[]>{
+	public getKendoPackages(configuration?: { withReleaseNotesOnly: boolean }): IFuture<Server.IKendoDownloadablePackageData[]>{
 		return (() => {
 			this.$loginManager.ensureLoggedIn().wait();
 			this.$project.ensureCordovaProject();
@@ -41,7 +41,14 @@ export class KendoUIBaseCommand implements ICommand {
 				this.$errors.fail(`This operation is not applicable to ${this.$project.projectData.Framework} projects.`);
 			}
 
-			let kendoFilterOptions = { core: this.$options.core, professional: this.$options.professional, verified: this.$options.verified };
+			let kendoFilterOptions: IKendoUIFilterOptions = {
+				core: this.$options.core,
+				professional: this.$options.professional,
+				verified: this.$options.verified,
+				latest: this.$options.latest,
+				withReleaseNotesOnly: configuration && configuration.withReleaseNotesOnly
+			};
+
 			let packages = this.$kendoUIService.getKendoPackages(kendoFilterOptions).wait();
 
 			if (packages.length === 0) {

--- a/lib/commands/kendoui-notes.ts
+++ b/lib/commands/kendoui-notes.ts
@@ -20,7 +20,7 @@ class KendoUINotesCommand extends KendoUIBaseCommand implements ICommand {
 
 	execute(args: string[]): IFuture<void> {
 		return (() => {
-			let packages = _.filter(this.getKendoPackages().wait(), p => p.HasReleaseNotes);
+			let packages = this.getKendoPackages({withReleaseNotesOnly: true}).wait();
 			if (packages.length === 1) {
 				this.$opener.open(_.first(packages).ReleaseNotesUrl);
 				return;

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -749,6 +749,8 @@ interface IKendoUIFilterOptions {
 	verified: boolean;
 	core: boolean;
 	professional: boolean;
+	latest: boolean;
+	withReleaseNotesOnly: boolean;
 }
 
 /**

--- a/lib/services/kendoui-service.ts
+++ b/lib/services/kendoui-service.ts
@@ -27,6 +27,15 @@ export class KendoUIService implements IKendoUIService {
 					packages = _.filter(packages, pack => pack.Name === KendoUIService.KENDO_PROFESSIONAL);
 				}
 
+				if (options.withReleaseNotesOnly) {
+					packages = _.filter(packages, pack => pack.HasReleaseNotes);
+				}
+
+				if (options.latest) {
+					let latestPackage = _.first(packages);
+					packages = _.filter(packages, pack => pack.Version === latestPackage.Version);
+				}
+
 				this._packages = packages;
 			}
 


### PR DESCRIPTION
Includes fixes for
+ Package listing does not respect the `--latest` tag
+ Error handling rather than prompt whenever zero packages meet certain conditions (e. g. `$ appbuilder notes --verified`)
+ Prompt for release note review upon installation with `--latest` tag. **Note:** this prompt can be avoided by setting the --force tag
+ Show package version after successful package installation

Fixes [kendo critical bug](http://teampulse.telerik.com/view#item/301864)
Ping @rosen-vladimirov 