### PR TITLE
Use intersection for plugin|find command

### DIFF
--- a/lib/commands/plugin/find-plugins.ts
+++ b/lib/commands/plugin/find-plugins.ts
@@ -27,6 +27,10 @@ export class FindPluginsCommand implements ICommand {
 	}
 
 	private printPlugins(plugins: IBasicPluginInformation[]) {
+		if(!plugins || plugins.length === 0) {
+			this.$errors.failWithoutHelp("Could not find any plugins matching the provided arguments.");
+		}
+
 		_.each(plugins, (plugin) => {
 			let pluginDescription = this.composePluginDescription(plugin);
 			this.$logger.info(pluginDescription);


### PR DESCRIPTION
Plugin find command must show intersection of all provided parameters.
Also use encodeUriComponent for all parameters that user will fill when calling npmsearch.
Add error message when we cannot find any plugin matching provided arguments.