### PR TITLE
Ignore npm scripts of {N} plugins

### DIFF
--- a/lib/services/nativescript-project-plugins-service.ts
+++ b/lib/services/nativescript-project-plugins-service.ts
@@ -415,7 +415,7 @@ export class NativeScriptProjectPluginsService implements IPluginsService {
 			let tempInstallDir = temp.mkdirSync("nativeScriptPluginInstallation");
 			let pathToInstalledPlugin: string;
 			try {
-				let npmInstallOutput = this.$childProcess.exec(`npm install ${identifier} --production`, {cwd: tempInstallDir}).wait();
+				let npmInstallOutput = this.$childProcess.exec(`npm install ${identifier} --production --ignore-scripts`, {cwd: tempInstallDir}).wait();
 				// output is something like: nativescript-google-sdk@0.1.18 node_modules\nativescript-google-sdk\n
 				let npmOutputMatch = npmInstallOutput.match(/.*?@.*?\s+?(.*?node_modules.*?)\r?\n?$/m);
 				if(npmOutputMatch) {


### PR DESCRIPTION
Ignore npm scripts when installing {N} plugins/npm modules to temp
directory as they may cause unexpected behavior or client's machines.
Fixes:
```
appbuilder plugin add https://github.com/rosen-vladimirov/NativeScriptPluginTest/tarball/master
```
which throws `ENOENT error`.