### PR TITLE
Use correct watchGlob

### DIFF
--- a/lib/services/livesync-service.ts
+++ b/lib/services/livesync-service.ts
@@ -81,7 +81,7 @@ export class LiveSyncService extends usbLivesyncServiceBaseLib.UsbLiveSyncServic
 			};
 
 			this.sync(platform, this.$project.projectData.AppIdentifier, projectDir,
-				this.excludedProjectDirsAndFiles, projectDir + "/**/*", platformSpecificLiveSyncServices, notInstalledAppOnDeviceAction,
+				this.excludedProjectDirsAndFiles, projectDir, platformSpecificLiveSyncServices, notInstalledAppOnDeviceAction,
 				() => Future.fromResult()).wait();
 
 		}).future<void>()();


### PR DESCRIPTION
In order to work correctly for added files we've changed the usage of gaze module - https://github.com/telerik/mobile-cli-lib/blob/master/services/usb-livesync-service-base.ts#L106. This requires to change the passed watch glob from cli.

If livesync --watch command is executed only the first sync works correctly. After that the changes aren't reported from the watch.