### PR TITLE
Fix init command for NativeScript projects

### DIFF
--- a/lib/commands/project/init.ts
+++ b/lib/commands/project/init.ts
@@ -13,6 +13,7 @@ export class InitProjectCommand implements ICommand {
 	public projectDir: string;
 	public tnsModulesDir: FileDescriptor;
 	public indexHtml: FileDescriptor;
+	public packageJson: FileDescriptor;
 	public projectFilesDescriptors: any;
 
 	constructor(private $project: Project.IProject,
@@ -26,6 +27,7 @@ export class InitProjectCommand implements ICommand {
 		this.tnsModulesDir = new FileDescriptor(path.join(this.projectDir, "app", "tns_modules"), "directory");
 		this.indexHtml = new FileDescriptor(path.join(this.projectDir, "index.html"), "file");
 		this.cordovaFiles = _.map(this.$mobileHelper.platformNames, platform => new FileDescriptor(util.format("cordova.%s.js", platform).toLowerCase(), "file"));
+		this.packageJson = new FileDescriptor(path.join(this.projectDir, this.$projectConstants.PACKAGE_JSON_NAME), "file");
 
 		this.generateMandatoryAndForbiddenFiles();
 	}
@@ -80,13 +82,13 @@ export class InitProjectCommand implements ICommand {
 		this.projectFilesDescriptors = Object.create(null);
 
 		this.generateMandatoryAndForbiddenFilesCore(this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova, this.cordovaFiles, [this.tnsModulesDir]);
-		this.generateMandatoryAndForbiddenFilesCore(this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript, [this.tnsModulesDir], this.cordovaFiles.concat([this.indexHtml]));
+		this.generateMandatoryAndForbiddenFilesCore(this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript, [this.packageJson], this.cordovaFiles.concat([this.indexHtml]));
 		this.generateMandatoryAndForbiddenFilesCore(this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.MobileWebsite, [this.indexHtml], this.cordovaFiles.concat([this.tnsModulesDir]));
 	}
 
-	private generateMandatoryAndForbiddenFilesCore(frameworkIdentifer: string, manddatorFiles: FileDescriptor[], forbiddenFiles: FileDescriptor[]): void {
+	private generateMandatoryAndForbiddenFilesCore(frameworkIdentifer: string, mandatoryFiles: FileDescriptor[], forbiddenFiles: FileDescriptor[]): void {
 		this.projectFilesDescriptors[frameworkIdentifer] = {
-			"mandatoryFiles": manddatorFiles,
+			"mandatoryFiles": mandatoryFiles,
 			"forbiddenFiles": forbiddenFiles
 		};
 	}

--- a/test/project.ts
+++ b/test/project.ts
@@ -314,16 +314,16 @@ describe("project integration tests", () => {
 				options.template = "Blank";
 				project.createNewProject(projectName, projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript).wait();
 				let projectDir = project.getProjectDir().wait();
-				let tnsDir = path.join(projectDir, "app", "tns_modules");
-				assert.isTrue(fs.existsSync(tnsDir), "NativeScript Blank template does not contain mandatory 'tns_modules' directory. This directory is required in init command. You should check if this is problem with the template or change init command to use another file.");
+				let packageJson = path.join(projectDir, "package.json");
+				assert.isTrue(fs.existsSync(packageJson), "NativeScript Blank template does not contain mandatory 'package.json' file. This file is required in init command. You should check if this is problem with the template or change init command to use another file.");
 			});
 
 			it("TypeScript.Blank template has mandatory files", () => {
 				options.template = "TypeScript.Blank";
 				project.createNewProject(projectName, projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript).wait();
 				let projectDir = project.getProjectDir().wait();
-				let tnsDir = path.join(projectDir, "app", "tns_modules");
-				assert.isTrue(fs.existsSync(tnsDir), "NativeScript TypeScript.Blank template does not contain mandatory 'tns_modules' directory. This directory is required in init command. You should check if this is problem with the template or change init command to use another file.");
+				let packageJson = path.join(projectDir, "package.json");
+				assert.isTrue(fs.existsSync(packageJson), "NativeScript TypeScript.Blank template does not contain mandatory 'package.json' file. This file is required in init command. You should check if this is problem with the template or change init command to use another file.");
 			});
 
 			it("existing TypeScript.Blank project has project files after init",() => {

--- a/test/resources/blank-NativeScript.abproject
+++ b/test/resources/blank-NativeScript.abproject
@@ -12,7 +12,7 @@
         "2"
     ]
     ,"iOSBackgroundMode": []
-    ,"FrameworkVersion": "1.2.3"
+    ,"FrameworkVersion": "1.4.1"
     ,"AndroidPermissions": [
         "android.permission.INTERNET"
      ]


### PR DESCRIPTION
Currently `appbuilder init` command checks that the project has `app/tns_modules` dir.
We do not have such directory anymore, so check the `package.json` instead of it.
Fix unit tests.