### PR TITLE
Track user's edition type by using tenant.editionType

### DIFF
--- a/lib/commands/user-status.ts
+++ b/lib/commands/user-status.ts
@@ -10,14 +10,6 @@ export class UserStatusCommand implements ICommand {
 
 	allowedParameters: ICommandParameter[] = [];
 
-	private licenseNames: IStringDictionary = {
-		"Starter": "AppBuilder Starter Edition",
-		"Developer": "AppBuilder Developer Edition",
-		"DeveloperPlus": "Telerik Platform Developer Edition",
-		"Professional": "AppBuilder Professional Edition",
-		"Business": "AppBuilder Business Edition"
-	};
-
 	public execute(args:string[]): IFuture<void> {
 		return (() => {
 			let user = this.$userDataStore.getUser().wait();
@@ -28,7 +20,7 @@ export class UserStatusCommand implements ICommand {
 			};
 
 			if (user.tenant) {
-				fields["License"] = util.format("%s (%s)", this.licenseNames[user.tenant.edition] || user.tenant.edition, user.tenant.license);
+				fields["License"] = util.format("%s (%s)", user.tenant.editionType, user.tenant.license);
 				let expires = new Date(Date.parse(user.tenant.expSoft));
 				fields["License expires"] = expires.toLocaleDateString();
 				fields["Licensed by"] = user.tenant.name;

--- a/lib/login.ts
+++ b/lib/login.ts
@@ -12,15 +12,6 @@ export class UserDataStore implements IUserDataStore {
 	private cookies: IStringDictionary;
 	private user: any;
 
-	private static APPBUILDER_EDITION_TYPE: IStringDictionary = {
-		"Starter": "AppBuilder Starter Edition",
-		"Developer": "AppBuilder Developer Edition",
-		"Business": "AppBuilder Business Edition",
-		"Professional": "AppBuilder Professional Edition",
-		"Enterprise": "AppBuilder Enterprise Edition",
-		"Developer Plus": "Telerik Platform Developer Edition"
-	};
-
 	constructor(private $fs: IFileSystem,
 		private $config: Config.IConfig,
 		private $logger: ILogger,
@@ -130,12 +121,10 @@ export class UserDataStore implements IUserDataStore {
 
 	private trackTenantInformation(userData: any): IFuture<void> {
 		return (() => {
-			if(userData) {
-				let tenant = userData.tenant;
-				let tenantEdition = UserDataStore.APPBUILDER_EDITION_TYPE[tenant.edition] || tenant.edition || "no-edition";
-				let tenantInfo = `${tenantEdition || "no-edition"} - ${tenant.license || "no-license"}`;
+			if(userData && userData.tenant) {
+				let tenantEdition = userData.tenant.editionType || "no-edition";
 				let $analyticsService = this.$injector.resolve("analyticsService");
-				$analyticsService.track("UserTenant", tenantInfo).wait();
+				$analyticsService.track("UserTenant", tenantEdition).wait();
 			}
 		}).future<void>()();
 	}

--- a/lib/server-api.d.ts
+++ b/lib/server-api.d.ts
@@ -9,6 +9,7 @@ declare module Server{
 		expSoft: Date;
 		expStrict: Date;
 		edition: string;
+		editionType: string;
 		status: string;
 		projectSlots: number;
 		license: string;


### PR DESCRIPTION
Track user's edition type by using new property - editionType.
Implements http://teampulse.telerik.com/view#item/303569

Should be merged after https://github.com/Icenium/Ice/pull/4436 