### PR TITLE
Unify mobileframework and prop <subcommand> FrameworkVersion commands

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -101,6 +101,8 @@ $injector.requireCommand("prop|set", "./commands/prop/prop-set");
 $injector.requireCommand("prop|rm", "./commands/prop/prop-remove");
 $injector.requireCommand("prop|remove", "./commands/prop/prop-remove");
 $injector.requireCommand("prop|print", "./commands/prop/prop-print");
+$injector.requireCommand("prop|print|frameworkversion", "./commands/framework-versions/print-versions");
+$injector.requireCommand("prop|set|frameworkversion", "./commands/framework-versions/set-version");
 
 $injector.requireCommand("cloud|*list", "./commands/cloud-projects");
 $injector.requireCommand("cloud|export", "./commands/cloud-projects");

--- a/lib/commands/framework-versions/print-versions.ts
+++ b/lib/commands/framework-versions/print-versions.ts
@@ -40,4 +40,4 @@ export class PrintFrameworkVersionsCommand implements ICommand {
 		}).future<boolean>()();
 	}
 }
-$injector.registerCommand("mobileframework|*print", PrintFrameworkVersionsCommand);
+$injector.registerCommand(["mobileframework|*print", "prop|print|frameworkversion"], PrintFrameworkVersionsCommand);

--- a/lib/commands/framework-versions/set-version.ts
+++ b/lib/commands/framework-versions/set-version.ts
@@ -11,7 +11,7 @@ export class SetFrameworkVersionCommand implements ICommand {
 
 	public allowedParameters: ICommandParameter[] = [this.$injector.resolve(MobileFrameworkCommandParameter)];
 }
-$injector.registerCommand("mobileframework|set", SetFrameworkVersionCommand);
+$injector.registerCommand(["mobileframework|set", "prop|set|frameworkversion"], SetFrameworkVersionCommand);
 
 export class MobileFrameworkCommandParameter implements ICommandParameter {
 	private static VERSION_REGEX = new RegExp("^(\\d+\\.){2}\\d+$");


### PR DESCRIPTION
`$ appbuilder mobileframework` should work in the same way as `$ appbuilder prop print FrameworkVersion`
Same is valid for `$ appbuilder mobileframework set <version>` and `$ appbuilder prop set FrameworkVersion <version>`.
In order to achieve this, register new commands - `prop|print|frameworkversion` and `prop|set|frameworkversion`.