### PR TITLE
Delete styles.xml when migrating to {N} 1.4.3+

### DIFF
--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -502,6 +502,11 @@ interface INativeScriptMigrationConfiguration {
 	projectDir: string;
 	appResourcesRequiredPath: string;
 	appResourcesObsoletePath: string;
+
+	valuesStylesXmlPath: string;
+	valuesV21StylesXmlPath: string;
+
+	shouldRollBackAppResources: boolean;
 }
 
 /**

--- a/test/file-system.ts
+++ b/test/file-system.ts
@@ -127,4 +127,30 @@ describe("FileSystem", () => {
 			});
 		});
 	});
+
+	describe("renameIfExists", () => {
+		it("returns true when file is renamed", () => {
+			let testInjector = createTestInjector();
+			let tempDir = temp.mkdirSync("renameIfExists");
+			let testFileName = path.join(tempDir, "testRenameIfExistsMethod");
+			let newFileName = path.join(tempDir, "newfilename");
+
+			let fs: IFileSystem = testInjector.resolve("fs");
+			fs.writeFile(testFileName, "data").wait();
+
+			let result = fs.renameIfExists(testFileName, newFileName).wait();
+			assert.isTrue(result, "On successfull rename, result must be true.");
+			assert.isTrue(fs.exists(newFileName).wait(), "Renamed file should exists.");
+			assert.isFalse(fs.exists(testFileName).wait(), "Original file should not exist.");
+		});
+
+		it("returns false when file does not exist", () => {
+			let testInjector = createTestInjector();
+			let fs: IFileSystem = testInjector.resolve("fs");
+			let newName = "tempDir2";
+			let result = fs.renameIfExists("tempDir", newName).wait();
+			assert.isFalse(result, "On successfull rename, result must be true.");
+			assert.isFalse(fs.exists(newName).wait(), "Original file should not exist.");
+		});
+	});
 });

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -148,6 +148,10 @@ export class FileSystemStub implements IFileSystem {
 		return undefined;
 	}
 
+	renameIfExists(oldPath: string, newPath: string): IFuture<boolean> {
+		return undefined;
+	}
+
 	symlink(sourePath: string, destinationPath: string): IFuture<void> {
 		return undefined;
 	}


### PR DESCRIPTION
Due to bug in {N} 0.4.2 in our templates we have `AppResources/Android/values/styles.xml`
and `AppResources/Android/values-v21/styles.xml` files. When migrating to 1.4.3 or later,
we must remove these files as they are change in {N} android runtime.
The real styles will be taken during build.

Add unit test for renameIfExists method of fs.

http://teampulse.telerik.com/view#item/303971