### PR TITLE
Fix appbuilder hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ docs/html
 **/.vs
 **/.vscode
 **/.ntvs_analysis.dat
+!lib/hooks/before-*.js
+!lib/hooks/after-*.js

--- a/lib/hooks/before-build.js
+++ b/lib/hooks/before-build.js
@@ -1,0 +1,1 @@
+require("./typescript-compilation.js");

--- a/lib/hooks/before-build.ts
+++ b/lib/hooks/before-build.ts
@@ -1,2 +1,0 @@
-require("./typescript-compilation.js");
-

--- a/lib/hooks/before-deploy.js
+++ b/lib/hooks/before-deploy.js
@@ -1,0 +1,1 @@
+require("./typescript-compilation.js");

--- a/lib/hooks/before-deploy.ts
+++ b/lib/hooks/before-deploy.ts
@@ -1,1 +1,0 @@
-require("./typescript-compilation.js");

--- a/lib/hooks/before-livesync.js
+++ b/lib/hooks/before-livesync.js
@@ -1,0 +1,1 @@
+require("./typescript-compilation.js");

--- a/lib/hooks/before-livesync.ts
+++ b/lib/hooks/before-livesync.ts
@@ -1,1 +1,0 @@
-require("./typescript-compilation.js");


### PR DESCRIPTION
Due to changes in hooks service, our current code is trying to execute both `.ts` and `.js` hook files.
As the `.ts` do not contain any TypeScript specific logic, just remove them and use the `.js` directly.