### PR TITLE
Introduce SysInfo class

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -211,3 +211,4 @@ $injector.requireCommand("resource|create", "./commands/resource");
 
 $injector.require("deviceAppDataProvider", "./providers/device-app-data-provider");
 $injector.require("nativeScriptResources", "./nativescript-resources");
+$injector.require("sysInfo", "./sys-info");

--- a/lib/services/doctor-service.ts
+++ b/lib/services/doctor-service.ts
@@ -12,7 +12,7 @@ class DoctorService implements IDoctorService {
 
 	public printWarnings(): boolean {
 		let result = false;
-		let sysInfo = this.$sysInfo.getSysInfo();
+		let sysInfo = this.$sysInfo.getSysInfo().wait();
 
 		if (!sysInfo.adbVer) {
 			this.$logger.warn("WARNING: adb from the Android SDK is not installed or is not configured properly. ");

--- a/lib/sys-info.ts
+++ b/lib/sys-info.ts
@@ -1,0 +1,25 @@
+///<reference path=".d.ts"/>
+"use strict";
+
+import {SysInfoBase} from "./common/sys-info-base";
+
+export class SysInfo extends SysInfoBase {
+	constructor(protected $childProcess: IChildProcess,
+				protected $hostInfo: IHostInfo,
+				protected $iTunesValidator: Mobile.IiTunesValidator,
+				protected $logger: ILogger) {
+		super($childProcess, $hostInfo, $iTunesValidator, $logger);
+	}
+
+	public getSysInfo(androidToolsInfo?: {pathToAdb: string, pathToAndroid: string}): IFuture<ISysInfoData> {
+		return ((): ISysInfoData => {
+			let defaultAndroidToolsInfo = {
+				pathToAdb: "adb",
+				pathToAndroid: "android" + (this.$hostInfo.isWindows ? ".bat" : "")
+			};
+
+			return super.getSysInfo(androidToolsInfo || defaultAndroidToolsInfo).wait();
+		}).future<ISysInfoData>()();
+	}
+}
+$injector.register("sysInfo", SysInfo);


### PR DESCRIPTION
Introduce SysInfo class that extends SysInfoBase from common lib.
This class holds AppBuilder specific implementation of gathering SysInfo.