### PR TITLE
Allow export of apps and solutions using new server API

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -51,6 +51,7 @@ $injector.requireCommand("debug", "./commands/debug");
 $injector.require("server", "./server-api");
 $injector.require("httpServer", "./http-server");
 $injector.require("serviceProxy", "./service-util");
+$injector.require("serviceProxyBase", "./service-util");
 
 $injector.require("serviceContractGenerator", "./swagger/service-contract-generator");
 $injector.require("serviceContractProvider", "./swagger/service-contract-provider");

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -9,7 +9,10 @@ declare module Server {
 	interface IServiceProxy {
 		call<T>(name: string, method: string, path: string, accept: string, body: IRequestBodyElement[], resultStream: NodeJS.WritableStream, headers?: any): IFuture<T>;
 		setShouldAuthenticate(shouldAuthenticate: boolean): void;
-		setSolutionSpaceName(solutionSpaceName: string): void;
+	}
+
+	interface IAppBuilderServiceProxy extends IServiceProxy {
+		makeTapServiceCall<T>(call: () => IFuture<T>, solutionSpaceHeaderOptions?: {discardSolutionSpaceHeader: boolean}): IFuture<T>
 	}
 
 	interface IServiceContractClientCode {
@@ -812,14 +815,13 @@ interface IProcessInfo {
 }
 
 interface IRemoteProjectService {
-	makeTapServiceCall<T>(call: () => IFuture<T>): IFuture<T>;
 	getProjectProperties(solutionName: string, projectName: string): IFuture<any>;
-	getSolutions(): IFuture<Server.TapSolutionData[]>;
-	getProjectsForSolution(solutionName: string): IFuture<Server.IWorkspaceItemData[]>;
-	getSolutionName(solutionId: string): IFuture<string>;
+	getProjectsForSolution(solutionId: string): IFuture<Server.IWorkspaceItemData[]>;
 	getProjectName(solutionId: string, projectId: string): IFuture<string>;
 	exportProject(remoteSolutionName: string, remoteProjectName: string): IFuture<void>;
 	exportSolution(remoteSolutionName: string): IFuture<void>;
+	getAvailableAppsAndSolutions(): IFuture<ITapAppData[]>;
+	getSolutionData(propertyValue: string): IFuture<Server.SolutionData>;
 }
 
 interface IProjectSimulatorService {
@@ -1105,4 +1107,58 @@ interface INativeScriptResources {
 	 * different NativeScript versions.
 	 */
 	nativeScriptMigrationFile: string;
+}
+
+/**
+ * Describes information for applications returned by TAP
+ */
+interface ITapAppData {
+	/**
+	 * AccountId of the owner of the project.
+	 */
+	accountId: string;
+
+	/**
+	 * Platform application Identifier.
+	 */
+	id: string;
+
+	/**
+	 * Type of the application (Hybrid, Native, etc.).
+	 */
+	type: string;
+
+	/**
+	 * Specific settings of the application.
+	 */
+	settings: any;
+
+	/**
+	 * Unique name of the application.
+	 * NOTE: It is unique in the context of applications only. Old Solutions and new apps may have the same name.
+	 */
+	name: string;
+
+	/**
+	 * Description of the application.
+	 */
+	description: string;
+
+	/**
+	 * The name that can be used by the users when they want to specify app for export.
+	 * This property is set client side, it does not exist in TAP.
+	 */
+	displayName: string;
+
+	/**
+	 * The name that will be shown to the users in the prompter.
+	 * This property is set client side, it does not exist in TAP.
+	 */
+	colorizedDisplayName: string;
+
+	/**
+	 * Indicates if the application is migrated (true) or not (false).
+	 * This property is set client side, it does not exist in TAP.
+	 */
+	isApp: boolean;
 }

--- a/lib/server-api.d.ts
+++ b/lib/server-api.d.ts
@@ -167,6 +167,21 @@ declare module Server{
 		getCordovaPluginVariables(solutionName: string, projectName: string): IFuture<Server.CordovaPluginVariablesData>;
 		setCordovaPluginVariable(solutionName: string, projectName: string, pluginId: string, variableName: string, configuration: string, value: string): IFuture<void>;
 	}
+	interface ApplicationProjectInfo{
+		AppId: string;
+		ProjectName: string;
+		SolutionName: string;
+		SolutionSpaceName: string;
+	}
+	interface IAppsCordovaServiceContract{
+		getLiveSyncToken(appId: string, projectName: string): IFuture<string>;
+		getCurrentPlatforms(appId: string, projectName: string): IFuture<Server.DevicePlatform[]>;
+		addPlatform(appId: string, projectName: string, platform: Server.DevicePlatform): IFuture<Server.MigrationResult>;
+		migrate(appId: string, projectName: string, targetVersion: string): IFuture<Server.MigrationResult>;
+		getProjectCordovaPlugins(appId: string, projectName: string): IFuture<Server.CordovaPluginData[]>;
+		getCordovaPluginVariables(appId: string, projectName: string): IFuture<Server.CordovaPluginVariablesData>;
+		setCordovaPluginVariable(appId: string, projectName: string, pluginId: string, variableName: string, configuration: string, value: string): IFuture<void>;
+	}
 	interface CryptographicIdentityData{
 		Alias: string;
 		Attributes: IDictionary<string>;
@@ -217,6 +232,11 @@ declare module Server{
 		publish(package_: any): IFuture<void>;
 		deleteExtension(extensionName: string, extensionVersion: string): IFuture<void>;
 	}
+	interface IUploadServiceContract{
+		completeUpload(path: string, originalFileHash: string): IFuture<void>;
+		initUpload(path: string): IFuture<void>;
+		uploadChunk(path: string, content: any): IFuture<void>;
+	}
 	interface SolutionInfo{
 		SolutionName: string;
 		SolutionSpaceName: string;
@@ -228,10 +248,18 @@ declare module Server{
 		createDirectory(solutionName: string, path: string): IFuture<void>;
 		remove(solutionName: string, path: string): IFuture<void>;
 	}
-	interface IUploadServiceContract{
-		completeUpload(path: string, originalFileHash: string): IFuture<void>;
-		initUpload(path: string): IFuture<void>;
-		uploadChunk(path: string, content: any): IFuture<void>;
+	interface ApplicationInfo{
+		AppId: string;
+		SolutionName: string;
+		SolutionSpaceName: string;
+	}
+	interface IAppsFilesServiceContract{
+		getFile(appId: string, path: string, $resultStream: any): IFuture<void>;
+		save(appId: string, path: string, content: any): IFuture<void>;
+		createDirectory(appId: string, path: string): IFuture<void>;
+		remove(appId: string, path: string): IFuture<void>;
+		rename(appId: string, path: string, destinationAppId: string, newPath: string): IFuture<void>;
+		copy(appId: string, path: string, destinationAppId: string, destination: string): IFuture<void>;
 	}
 	interface Size{
 		Width: number;
@@ -242,10 +270,17 @@ declare module Server{
 		SplashScreen,
 		NinePatch,
 	}
+	interface IAppsImagesServiceContract{
+		resizeImage(appId: string, path: string, size: Server.Size): IFuture<void>;
+		generate(appId: string, projectName: string, type: Server.ImageType, image: any): IFuture<string[]>;
+	}
 	interface IImagesServiceContract{
 		resizeImage(solutionName: string, path: string, size: Server.Size): IFuture<void>;
 		generate(solutionName: string, projectName: string, type: Server.ImageType, image: any): IFuture<string[]>;
 		generateArchive(type: Server.ImageType, image: any, $resultStream: any): IFuture<void>;
+	}
+	interface IAppsItmstransporterServiceContract{
+		uploadApplication(appId: string, projectName: string, relativePackagePath: string, adamId: number, username: string, password: string): IFuture<void>;
 	}
 	interface Application{
 		AppleID: number;
@@ -277,6 +312,10 @@ declare module Server{
 		getPackages(): IFuture<Server.KendoDownloadablePackageData[]>;
 		changeKendoPackage(solutionName: string, projectName: string, packageId: string): IFuture<void>;
 		getCurrentPackage(solutionName: string, projectName: string): IFuture<Server.KendoPackageData>;
+	}
+	interface IAppsKendoServiceContract{
+		changeKendoPackage(appId: string, projectName: string, packageId: string): IFuture<void>;
+		getCurrentPackage(appId: string, projectName: string): IFuture<Server.KendoPackageData>;
 	}
 	interface ProvisionData{
 		Identifier: string;
@@ -325,93 +364,8 @@ declare module Server{
 		migrate(solutionName: string, projectName: string, targetVersion: string): IFuture<Server.MigrationResult>;
 		getMarketplacePluginVersionsData(): IFuture<Server.NativeScriptMarketplacePluginVersionsData[]>;
 	}
-	interface BuildIssueData{
-		Code: string;
-		File: string;
-		ProjectFile: string;
-		Target: string;
-		Message: string;
-		LineNumber: number;
-		ColumnNumber: number;
-		EndLineNumber: number;
-		EndColumnNumber: number;
-		IsRealError: boolean;
-	}
-	interface TaskItemData{
-		ItemSpec: string;
-		Properties: IDictionary<string>;
-		Comparer: any;
-		Count: number;
-		Keys: string[];
-		Values: string[];
-		Item: string;
-	}
-	interface TargetResultData{
-		Status: string;
-		Items: Server.TaskItemData[];
-	}
-	interface BuildResultData{
-		Errors: Server.BuildIssueData[];
-		Warnings: Server.BuildIssueData[];
-		Output: string;
-		ResultsByTarget: IDictionary<TargetResultData>;
-	}
-	interface BuildRequestData{
-		Targets: string[];
-		Properties: IDictionary<string>;
-	}
-	const enum TargetResultStatus{
-		Failure,
-		Skipped,
-		Success,
-	}
-	interface IBuildServiceContract{
-		buildProject(solutionName: string, projectName: string, buildRequest: Server.BuildRequestData): IFuture<Server.BuildResultData>;
-	}
-	interface NpmSearchPackageEntry{
-		Name: string;
-		Description: string;
-		Authors: string[];
-		HomePage: string;
-		Licenses: string[];
-		Modified: Date;
-		Version: string;
-		KeyWords: string[];
-		Rating: number;
-	}
-	interface NpmSearchResult{
-		Results: Server.NpmSearchPackageEntry[];
-		Total: number;
-	}
-	interface Repository{
-		Type: string;
-		Url: string;
-	}
-	interface NpmVersion{
-		Name: string;
-		Description: string;
-		HomePage: string;
-		Repository: Server.Repository;
-		Version: string;
-	}
-	interface NpmPackage{
-		Name: string;
-		Description: string;
-		HomePage: string;
-		Repository: Server.Repository;
-		Versions: IDictionary<NpmVersion>;
-		DistTags: IDictionary<string>;
-		LatestVersion: string;
-	}
-	const enum SortOrder{
-		Default,
-		RatingAscending,
-		RatingDescending,
-	}
-	interface INpmServiceContract{
-		queryNpmSearch(packageName: string, size: number, sortOrder: Server.SortOrder, start: number): IFuture<Server.NpmSearchResult>;
-		getNpmPackageInfo(packageName: string): IFuture<Server.NpmPackage>;
-		getNpmPackageDownloads(packageName: string): IFuture<number>;
+	interface IAppsNativescriptServiceContract{
+		migrate(appId: string, projectName: string, targetVersion: string): IFuture<Server.MigrationResult>;
 	}
 	interface ProjectTemplateData{
 		CanCreateProject: boolean;
@@ -484,25 +438,163 @@ declare module Server{
 		renameProject(solutionName: string, projectName: string, newProjectName: string): IFuture<void>;
 		createNewProjectItem(solutionName: string, projectName: string, itemIdentifier: string, expansionData: Server.ItemTemplateExpansionData): IFuture<Server.ProjectItemInfo[]>;
 	}
+	interface IAppsProjectsServiceContract{
+		exportProject(appId: string, projectName: string, skipMetadata: boolean, $resultStream: any): IFuture<void>;
+		importPackage(appId: string, projectName: string, parentIdentifier: string, archivePackage: any): IFuture<void>;
+		importProject(appId: string, projectName: string, package_: any): IFuture<void>;
+		importLocalProject(appId: string, projectName: string, bucketKey: string): IFuture<void>;
+		getProjectContents(appId: string, projectName: string): IFuture<string>;
+		saveProjectContents(appId: string, projectName: string, projectContents: string): IFuture<void>;
+		createProject(appId: string, projectName: string, expansionData: Server.ProjectTemplateExpansionData): IFuture<void>;
+		deleteProject(appId: string, projectName: string): IFuture<void>;
+		setProjectProperty(appId: string, projectName: string, configuration: string, changeset: IDictionary<string>): IFuture<void>;
+		renameProject(appId: string, projectName: string, newProjectName: string): IFuture<void>;
+		createNewProjectItem(appId: string, projectName: string, itemIdentifier: string, expansionData: Server.ItemTemplateExpansionData): IFuture<Server.ProjectItemInfo[]>;
+	}
+	interface ApplicationCreationData{
+		AccountId: string;
+		AppData: IDictionary<Object>;
+		ProjectName: string;
+		TemplateIdentifier: string;
+		Arguments: IDictionary<string>;
+	}
+	interface ApplicationServiceData{
+		Type: string;
+		Comparer: any;
+		Count: number;
+		Keys: string[];
+		Values: Server.Object[];
+		Item: Server.Object;
+	}
+	interface IAppsServiceContract{
+		exportApplication(appId: string, skipMetadata: boolean, $resultStream: any): IFuture<void>;
+		createApplication(applicationData: Server.ApplicationCreationData): IFuture<IDictionary<Object>>;
+		enableApplication(appId: string, expansionData: Server.ProjectTemplateExpansionData): IFuture<void>;
+		getApplication(appId: string, checkUpgradability: boolean): IFuture<Server.SolutionData>;
+		canLoadApplication(appId: string): IFuture<boolean>;
+		deleteApplication(appId: string): IFuture<void>;
+		upgradeApplication(appId: string): IFuture<void>;
+		getApplicationServices(appId: string): IFuture<Server.ApplicationServiceData[]>;
+		enableApplicationService(appId: string, serviceData: IDictionary<Object>): IFuture<IDictionary<Object>>;
+	}
 	interface PackageData{
 		Name: string;
 		Version: string;
+	}
+	interface IAppsBowerServiceContract{
+		installDependencies(appId: string, projectName: string): IFuture<void>;
+		installPackage(appId: string, projectName: string, packageName: string, version: string): IFuture<void>;
+		getInstalledPackages(appId: string, projectName: string): IFuture<Server.PackageData[]>;
 	}
 	interface BowerPackagesFilters{
 		Blacklist: string[];
 		DuplicatesList: IDictionary<string>;
 	}
-	interface IPackagesServiceContract{
+	interface IBowerServiceContract{
 		installDependencies(solutionName: string, projectName: string): IFuture<void>;
 		installPackage(solutionName: string, projectName: string, packageName: string, version: string): IFuture<void>;
 		getInstalledPackages(solutionName: string, projectName: string): IFuture<Server.PackageData[]>;
 		getFilters(): IFuture<Server.BowerPackagesFilters>;
+	}
+	interface BuildIssueData{
+		Code: string;
+		File: string;
+		ProjectFile: string;
+		Target: string;
+		Message: string;
+		LineNumber: number;
+		ColumnNumber: number;
+		EndLineNumber: number;
+		EndColumnNumber: number;
+		IsRealError: boolean;
+	}
+	interface TaskItemData{
+		ItemSpec: string;
+		Properties: IDictionary<string>;
+		Comparer: any;
+		Count: number;
+		Keys: string[];
+		Values: string[];
+		Item: string;
+	}
+	interface TargetResultData{
+		Status: string;
+		Items: Server.TaskItemData[];
+	}
+	interface BuildResultData{
+		Errors: Server.BuildIssueData[];
+		Warnings: Server.BuildIssueData[];
+		Output: string;
+		ResultsByTarget: IDictionary<TargetResultData>;
+	}
+	interface BuildRequestData{
+		Targets: string[];
+		Properties: IDictionary<string>;
+	}
+	const enum TargetResultStatus{
+		Failure,
+		Skipped,
+		Success,
+	}
+	interface IBuildServiceContract{
+		buildProject(solutionName: string, projectName: string, buildRequest: Server.BuildRequestData): IFuture<Server.BuildResultData>;
+	}
+	interface IAppsBuildServiceContract{
+		buildProject(appId: string, projectName: string, buildRequest: Server.BuildRequestData): IFuture<Server.BuildResultData>;
+	}
+	interface NpmSearchPackageEntry{
+		Name: string;
+		Description: string;
+		Authors: string[];
+		HomePage: string;
+		Licenses: string[];
+		Modified: Date;
+		Version: string;
+		KeyWords: string[];
+		Rating: number;
+	}
+	interface NpmSearchResult{
+		Results: Server.NpmSearchPackageEntry[];
+		Total: number;
+	}
+	interface Repository{
+		Type: string;
+		Url: string;
+	}
+	interface NpmVersion{
+		Name: string;
+		Description: string;
+		HomePage: string;
+		Repository: Server.Repository;
+		Version: string;
+	}
+	interface NpmPackage{
+		Name: string;
+		Description: string;
+		HomePage: string;
+		Repository: Server.Repository;
+		Versions: IDictionary<NpmVersion>;
+		DistTags: IDictionary<string>;
+		LatestVersion: string;
+	}
+	const enum SortOrder{
+		Default,
+		RatingAscending,
+		RatingDescending,
+	}
+	interface INpmServiceContract{
+		queryNpmSearch(packageName: string, size: number, sortOrder: Server.SortOrder, start: number): IFuture<Server.NpmSearchResult>;
+		getNpmPackageInfo(packageName: string): IFuture<Server.NpmPackage>;
+		getNpmPackageDownloads(packageName: string): IFuture<number>;
 	}
 	interface FtpConnectionData{
 		RemoteUrl: string;
 		ShouldPurge: boolean;
 		Username: string;
 		Password: string;
+	}
+	interface IAppsPublishServiceContract{
+		publishFtp(appId: string, projectName: string, ftpConnectionData: Server.FtpConnectionData): IFuture<void>;
 	}
 	interface IPublishServiceContract{
 		publishFtp(solutionName: string, projectName: string, ftpConnectionData: Server.FtpConnectionData): IFuture<void>;
@@ -512,6 +604,10 @@ declare module Server{
 		saveUserSettings(content: any): IFuture<void>;
 		getSolutionUserSettings(solutionName: string, $resultStream: any): IFuture<void>;
 		saveSolutionUserSettings(solutionName: string, content: any): IFuture<void>;
+	}
+	interface IAppsRawSettingsServiceContract{
+		getSolutionUserSettings(appId: string, $resultStream: any): IFuture<void>;
+		saveSolutionUserSettings(appId: string, content: any): IFuture<void>;
 	}
 	interface DevicePlatformIdentityAliasDictionary{
 		Comparer: any;
@@ -534,6 +630,13 @@ declare module Server{
 		CodesigningSettings: Server.ICodesigningIdentitySettings;
 		ProvisionSettings: Server.IMobileProjectProvisionSettings;
 		SolutionSettings: Server.ISolutionSettings;
+	}
+	interface IAppsSettingsServiceContract{
+		getSettings(appId: string): IFuture<Server.SettingsData>;
+		setCodesignIdentity(appId: string, projectIdentity: string, platform: Server.DevicePlatform, identityAlias: string): IFuture<void>;
+		setMobileProvision(appId: string, projectIdentity: string, provisionIdentifier: string): IFuture<void>;
+		setActiveBuildConfiguration(appId: string, buildConfiguration: string): IFuture<void>;
+		updateSettingsProjectIdentifier(appId: string, projectIdentity: string, newProjectIdentity: string): IFuture<void>;
 	}
 	interface ISettingsServiceContract{
 		getSettings(solutionName: string): IFuture<Server.SettingsData>;
@@ -577,6 +680,15 @@ declare module Server{
 		uploadPatch(solutionName: string, projectName: string, patchData: Server.PatchData): IFuture<void>;
 		getAccountStatus(): IFuture<Server.FeatureStatus>;
 	}
+	interface IAppsTamServiceContract{
+		uploadApplication(appId: string, projectName: string, relativePackagePath: string, settings: Server.PublishSettings): IFuture<Server.UploadedAppData>;
+		uploadPatch(appId: string, projectName: string, patchData: Server.PatchData): IFuture<void>;
+	}
+	interface IAppsTapServiceContract{
+		getRemote(appId: string): IFuture<string>;
+		setRemote(appId: string, remoteUrl: string): IFuture<void>;
+		initCurrentUserSharedRepository(appId: string): IFuture<boolean>;
+	}
 	interface TapSolutionData{
 		id: string;
 		name: string;
@@ -586,6 +698,7 @@ declare module Server{
 	}
 	interface Collaborator{
 		email: string;
+		role: string;
 		id: string;
 		name: string;
 	}
@@ -609,7 +722,7 @@ declare module Server{
 		getRemote(solutionName: string): IFuture<string>;
 		setRemote(solutionName: string, remoteUrl: string): IFuture<void>;
 		getUsersForProject(solutionName: string): IFuture<Server.Collaborator[]>;
-		initCurrentUserSharedRepository(solutionName: string): IFuture<void>;
+		initCurrentUserSharedRepository(solutionName: string): IFuture<boolean>;
 		getWorkspaces(accountId: string): IFuture<Server.TapWorkspaceData[]>;
 		getServiceApplications(serviceType: string, accountId: string): IFuture<Server.TapSolutionData[]>;
 		getServiceApplicationProjectKey(serviceType: string, id: string): IFuture<string>;
@@ -705,6 +818,34 @@ declare module Server{
 		Hard,
 		Soft,
 	}
+	interface IAppsVersioncontrolServiceContract{
+		init(appId: string): IFuture<void>;
+		rollback(appId: string, versionName: string): IFuture<void>;
+		reset(appId: string, resetMode: Server.ResetMode, versionName: string): IFuture<void>;
+		merge(appId: string, versionName: string): IFuture<Server.BranchItemData>;
+		revert(appId: string, versionName: string, filePaths: string[]): IFuture<void>;
+		resolve(appId: string, versionName: string, filePaths: string[]): IFuture<void>;
+		checkout(appId: string, versionName: string, filePaths: string[]): IFuture<void>;
+		add(appId: string, filePaths: string[]): IFuture<void>;
+		remove(appId: string, filePaths: string[]): IFuture<void>;
+		getBranches(appId: string): IFuture<Server.BranchItemData[]>;
+		getCurrentBranch(appId: string): IFuture<Server.BranchItemData>;
+		checkoutBranch(appId: string, branchName: string, createBranch: boolean, versionName: string): IFuture<Server.BranchItemData>;
+		createBranch(appId: string, branchName: string, versionName: string): IFuture<Server.BranchItemData>;
+		deleteBranch(appId: string, branchName: string, forceDelete: boolean): IFuture<void>;
+		getRemote(appId: string): IFuture<string>;
+		setRemote(appId: string, remoteData: Server.GitRemoteData): IFuture<void>;
+		getInfo(appId: string): IFuture<Server.VersionControlData>;
+		track(appId: string): IFuture<Server.ChangeItemData[]>;
+		getStatus(appId: string, filePaths: string[]): IFuture<Server.ChangeItemData[]>;
+		getDiff(appId: string, versionName: string, contextSize: number, otherVersionName: string, filePaths: string[]): IFuture<Server.DiffLineResultData[]>;
+		getConflicts(appId: string, contextSize: number, filePaths: string[]): IFuture<Server.DiffLineResultData[]>;
+		getCommits(appId: string, endDate: Date, startDate: Date): IFuture<Server.ChangeSetData[]>;
+		getCommit(appId: string, versionName: string): IFuture<Server.ChangeSetData>;
+		getChanges(appId: string, versionName: string): IFuture<Server.ChangeItemData[]>;
+		getContents(appId: string, versionName: string, filePath: string): IFuture<string>;
+		getHistory(appId: string, versionName: string, filePath: string): IFuture<Server.HistoryItemData[]>;
+	}
 	interface IVersioncontrolServiceContract{
 		init(solutionName: string): IFuture<void>;
 		rollback(solutionName: string, versionName: string): IFuture<void>;
@@ -736,27 +877,43 @@ declare module Server{
 	interface IServer{
 		authentication: Server.IAuthenticationServiceContract;
 		cordova: Server.ICordovaServiceContract;
+		appsCordova: Server.IAppsCordovaServiceContract;
 		identityStore: Server.IIdentityStoreServiceContract;
 		everlive: Server.IEverliveServiceContract;
 		extensions: Server.IExtensionsServiceContract;
 		internalExtensions: Server.IInternalExtensionsServiceContract;
-		filesystem: Server.IFilesystemServiceContract;
 		upload: Server.IUploadServiceContract;
+		filesystem: Server.IFilesystemServiceContract;
+		appsFiles: Server.IAppsFilesServiceContract;
+		appsImages: Server.IAppsImagesServiceContract;
 		images: Server.IImagesServiceContract;
+		appsItmstransporter: Server.IAppsItmstransporterServiceContract;
 		itmstransporter: Server.IItmstransporterServiceContract;
 		kendo: Server.IKendoServiceContract;
+		appsKendo: Server.IAppsKendoServiceContract;
 		mobileprovisions: Server.IMobileprovisionsServiceContract;
 		nativescript: Server.INativescriptServiceContract;
-		build: Server.IBuildServiceContract;
-		npm: Server.INpmServiceContract;
+		appsNativescript: Server.IAppsNativescriptServiceContract;
 		projects: Server.IProjectsServiceContract;
-		packages: Server.IPackagesServiceContract;
+		appsProjects: Server.IAppsProjectsServiceContract;
+		apps: Server.IAppsServiceContract;
+		appsBower: Server.IAppsBowerServiceContract;
+		bower: Server.IBowerServiceContract;
+		build: Server.IBuildServiceContract;
+		appsBuild: Server.IAppsBuildServiceContract;
+		npm: Server.INpmServiceContract;
+		appsPublish: Server.IAppsPublishServiceContract;
 		publish: Server.IPublishServiceContract;
 		rawSettings: Server.IRawSettingsServiceContract;
+		appsRawSettings: Server.IAppsRawSettingsServiceContract;
+		appsSettings: Server.IAppsSettingsServiceContract;
 		settings: Server.ISettingsServiceContract;
 		status: Server.IStatusServiceContract;
 		tam: Server.ITamServiceContract;
+		appsTam: Server.IAppsTamServiceContract;
+		appsTap: Server.IAppsTapServiceContract;
 		tap: Server.ITapServiceContract;
+		appsVersioncontrol: Server.IAppsVersioncontrolServiceContract;
 		versioncontrol: Server.IVersioncontrolServiceContract;
 	}
 }

--- a/lib/server-api.ts
+++ b/lib/server-api.ts
@@ -83,6 +83,31 @@ export class CordovaService implements Server.ICordovaServiceContract{
 		return this.$serviceProxy.call<void>('SetCordovaPluginVariable', 'POST', ['api','cordova','plugins',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(projectName.replace(/\\/g, '/')),'variables',encodeURI(pluginId.replace(/\\/g, '/')),encodeURI(variableName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'configuration': configuration }), null, [{name: 'value', value: JSON.stringify(value), contentType: 'application/json'}], null);
 	}
 }
+export class AppsCordovaService implements Server.IAppsCordovaServiceContract{
+	constructor(private $serviceProxy: Server.IServiceProxy){
+	}
+	public getLiveSyncToken(appId: string, projectName: string): IFuture<string>{
+		return this.$serviceProxy.call<string>('GetLiveSyncToken', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'cordova',encodeURI(projectName.replace(/\\/g, '/')),'liveSyncToken'].join('/'), 'application/json', null, null);
+	}
+	public getCurrentPlatforms(appId: string, projectName: string): IFuture<Server.DevicePlatform[]>{
+		return this.$serviceProxy.call<Server.DevicePlatform[]>('GetCurrentPlatforms', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'cordova',encodeURI(projectName.replace(/\\/g, '/')),'platforms'].join('/'), 'application/json', null, null);
+	}
+	public addPlatform(appId: string, projectName: string, platform: Server.DevicePlatform): IFuture<Server.MigrationResult>{
+		return this.$serviceProxy.call<Server.MigrationResult>('AddPlatform', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'cordova',encodeURI(projectName.replace(/\\/g, '/')),'platforms',encodeURI((<any>platform).replace(/\\/g, '/'))].join('/'), 'application/json', null, null);
+	}
+	public migrate(appId: string, projectName: string, targetVersion: string): IFuture<Server.MigrationResult>{
+		return this.$serviceProxy.call<Server.MigrationResult>('Migrate', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'cordova',encodeURI(projectName.replace(/\\/g, '/')),'migrate'].join('/') + '?' + querystring.stringify({ 'targetVersion': targetVersion }), 'application/json', null, null);
+	}
+	public getProjectCordovaPlugins(appId: string, projectName: string): IFuture<Server.CordovaPluginData[]>{
+		return this.$serviceProxy.call<Server.CordovaPluginData[]>('GetProjectCordovaPlugins', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'cordova',encodeURI(projectName.replace(/\\/g, '/')),'plugins'].join('/'), 'application/json', null, null);
+	}
+	public getCordovaPluginVariables(appId: string, projectName: string): IFuture<Server.CordovaPluginVariablesData>{
+		return this.$serviceProxy.call<Server.CordovaPluginVariablesData>('GetCordovaPluginVariables', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'cordova',encodeURI(projectName.replace(/\\/g, '/')),'plugins','variables'].join('/'), 'application/json', null, null);
+	}
+	public setCordovaPluginVariable(appId: string, projectName: string, pluginId: string, variableName: string, configuration: string, value: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('SetCordovaPluginVariable', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'cordova',encodeURI(projectName.replace(/\\/g, '/')),'plugins','variables',encodeURI(pluginId.replace(/\\/g, '/')),encodeURI(variableName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'configuration': configuration }), null, [{name: 'value', value: JSON.stringify(value), contentType: 'application/json'}], null);
+	}
+}
 export class IdentityStoreService implements Server.IIdentityStoreServiceContract{
 	constructor(private $serviceProxy: Server.IServiceProxy){
 	}
@@ -144,6 +169,19 @@ export class InternalExtensionsService implements Server.IInternalExtensionsServ
 		return this.$serviceProxy.call<void>('DeleteExtension', 'DELETE', ['api','internal','extensions',encodeURI(extensionName.replace(/\\/g, '/')),encodeURI(extensionVersion.replace(/\\/g, '/'))].join('/'), null, null, null);
 	}
 }
+export class UploadService implements Server.IUploadServiceContract{
+	constructor(private $serviceProxy: Server.IServiceProxy){
+	}
+	public completeUpload(path: string, originalFileHash: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('CompleteUpload', 'POST', ['api','upload','complete',encodeURI(path.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'originalFileHash': originalFileHash }), null, null, null);
+	}
+	public initUpload(path: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('InitUpload', 'POST', ['api','upload',encodeURI(path.replace(/\\/g, '/'))].join('/'), null, null, null);
+	}
+	public uploadChunk(path: string, content: any): IFuture<void>{
+		return this.$serviceProxy.call<void>('UploadChunk', 'PUT', ['api','upload',encodeURI(path.replace(/\\/g, '/'))].join('/'), null, [{name: 'content', value: content, contentType: 'application/octet-stream'}], null);
+	}
+}
 export class FilesystemService implements Server.IFilesystemServiceContract{
 	constructor(private $serviceProxy: Server.IServiceProxy){
 	}
@@ -163,17 +201,36 @@ export class FilesystemService implements Server.IFilesystemServiceContract{
 		return this.$serviceProxy.call<void>('Remove', 'DELETE', ['api','filesystem',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(path.replace(/\\/g, '/'))].join('/'), null, null, null);
 	}
 }
-export class UploadService implements Server.IUploadServiceContract{
+export class AppsFilesService implements Server.IAppsFilesServiceContract{
 	constructor(private $serviceProxy: Server.IServiceProxy){
 	}
-	public completeUpload(path: string, originalFileHash: string): IFuture<void>{
-		return this.$serviceProxy.call<void>('CompleteUpload', 'POST', ['api','upload','complete',encodeURI(path.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'originalFileHash': originalFileHash }), null, null, null);
+	public getFile(appId: string, path: string, $resultStream: any): IFuture<void>{
+		return this.$serviceProxy.call<void>('GetFile', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'files',encodeURI(path.replace(/\\/g, '/'))].join('/'), 'application/octet-stream', null, $resultStream);
 	}
-	public initUpload(path: string): IFuture<void>{
-		return this.$serviceProxy.call<void>('InitUpload', 'POST', ['api','upload',encodeURI(path.replace(/\\/g, '/'))].join('/'), null, null, null);
+	public save(appId: string, path: string, content: any): IFuture<void>{
+		return this.$serviceProxy.call<void>('Save', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'files',encodeURI(path.replace(/\\/g, '/'))].join('/'), null, [{name: 'content', value: content, contentType: 'application/octet-stream'}], null);
 	}
-	public uploadChunk(path: string, content: any): IFuture<void>{
-		return this.$serviceProxy.call<void>('UploadChunk', 'PUT', ['api','upload',encodeURI(path.replace(/\\/g, '/'))].join('/'), null, [{name: 'content', value: content, contentType: 'application/octet-stream'}], null);
+	public createDirectory(appId: string, path: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('CreateDirectory', 'MKDIR', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'files',encodeURI(path.replace(/\\/g, '/'))].join('/'), null, null, null);
+	}
+	public remove(appId: string, path: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('Remove', 'DELETE', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'files',encodeURI(path.replace(/\\/g, '/'))].join('/'), null, null, null);
+	}
+	public rename(appId: string, path: string, destinationAppId: string, newPath: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('Rename', 'MOVE', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'files',encodeURI(path.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'destinationAppId': destinationAppId }), null, [{name: 'newPath', value: JSON.stringify(newPath), contentType: 'application/json'}], null);
+	}
+	public copy(appId: string, path: string, destinationAppId: string, destination: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('Copy', 'COPY', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'files',encodeURI(path.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'destinationAppId': destinationAppId }), null, [{name: 'destination', value: JSON.stringify(destination), contentType: 'application/json'}], null);
+	}
+}
+export class AppsImagesService implements Server.IAppsImagesServiceContract{
+	constructor(private $serviceProxy: Server.IServiceProxy){
+	}
+	public resizeImage(appId: string, path: string, size: Server.Size): IFuture<void>{
+		return this.$serviceProxy.call<void>('ResizeImage', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'images','resize',encodeURI(path.replace(/\\/g, '/'))].join('/'), null, [{name: 'size', value: JSON.stringify(size), contentType: 'application/json'}], null);
+	}
+	public generate(appId: string, projectName: string, type: Server.ImageType, image: any): IFuture<string[]>{
+		return this.$serviceProxy.call<string[]>('Generate', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'images','generate',encodeURI(projectName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'type': type }), 'application/json', [{name: 'image', value: image, contentType: 'application/octet-stream'}], null);
 	}
 }
 export class ImagesService implements Server.IImagesServiceContract{
@@ -187,6 +244,13 @@ export class ImagesService implements Server.IImagesServiceContract{
 	}
 	public generateArchive(type: Server.ImageType, image: any, $resultStream: any): IFuture<void>{
 		return this.$serviceProxy.call<void>('GenerateArchive', 'POST', ['api','images','generate'].join('/') + '?' + querystring.stringify({ 'type': type }), 'application/octet-stream', [{name: 'image', value: image, contentType: 'application/octet-stream'}], $resultStream);
+	}
+}
+export class AppsItmstransporterService implements Server.IAppsItmstransporterServiceContract{
+	constructor(private $serviceProxy: Server.IServiceProxy){
+	}
+	public uploadApplication(appId: string, projectName: string, relativePackagePath: string, adamId: number, username: string, password: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('UploadApplication', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'itmstransporter','upload',encodeURI(projectName.replace(/\\/g, '/')),encodeURI(relativePackagePath.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'adamId': adamId, 'username': username }), null, [{name: 'password', value: JSON.stringify(password), contentType: 'application/json'}], null);
 	}
 }
 export class ItmstransporterService implements Server.IItmstransporterServiceContract{
@@ -210,6 +274,16 @@ export class KendoService implements Server.IKendoServiceContract{
 	}
 	public getCurrentPackage(solutionName: string, projectName: string): IFuture<Server.KendoPackageData>{
 		return this.$serviceProxy.call<Server.KendoPackageData>('GetCurrentPackage', 'GET', ['api','kendo',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(projectName.replace(/\\/g, '/')),'version'].join('/'), 'application/json', null, null);
+	}
+}
+export class AppsKendoService implements Server.IAppsKendoServiceContract{
+	constructor(private $serviceProxy: Server.IServiceProxy){
+	}
+	public changeKendoPackage(appId: string, projectName: string, packageId: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('ChangeKendoPackage', 'PATCH', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'kendo',encodeURI(projectName.replace(/\\/g, '/')),'migrate'].join('/') + '?' + querystring.stringify({ 'packageId': packageId }), null, null, null);
+	}
+	public getCurrentPackage(appId: string, projectName: string): IFuture<Server.KendoPackageData>{
+		return this.$serviceProxy.call<Server.KendoPackageData>('GetCurrentPackage', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'kendo',encodeURI(projectName.replace(/\\/g, '/')),'version'].join('/'), 'application/json', null, null);
 	}
 }
 export class MobileprovisionsService implements Server.IMobileprovisionsServiceContract{
@@ -238,24 +312,11 @@ export class NativescriptService implements Server.INativescriptServiceContract{
 		return this.$serviceProxy.call<Server.NativeScriptMarketplacePluginVersionsData[]>('GetMarketplacePluginVersionsData', 'GET', ['api','nativescript','marketplace-plugins'].join('/'), 'application/json', null, null);
 	}
 }
-export class BuildService implements Server.IBuildServiceContract{
+export class AppsNativescriptService implements Server.IAppsNativescriptServiceContract{
 	constructor(private $serviceProxy: Server.IServiceProxy){
 	}
-	public buildProject(solutionName: string, projectName: string, buildRequest: Server.BuildRequestData): IFuture<Server.BuildResultData>{
-		return this.$serviceProxy.call<Server.BuildResultData>('BuildProject', 'POST', ['api','build',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(projectName.replace(/\\/g, '/'))].join('/'), 'application/json', [{name: 'buildRequest', value: JSON.stringify(buildRequest), contentType: 'application/json'}], null);
-	}
-}
-export class NpmService implements Server.INpmServiceContract{
-	constructor(private $serviceProxy: Server.IServiceProxy){
-	}
-	public queryNpmSearch(packageName: string, size: number, sortOrder: Server.SortOrder, start: number): IFuture<Server.NpmSearchResult>{
-		return this.$serviceProxy.call<Server.NpmSearchResult>('QueryNpmSearch', 'GET', ['api','npm','search'].join('/') + '?' + querystring.stringify({ 'packageName': packageName, 'size': size, 'sortOrder': sortOrder, 'start': start }), 'application/json', null, null);
-	}
-	public getNpmPackageInfo(packageName: string): IFuture<Server.NpmPackage>{
-		return this.$serviceProxy.call<Server.NpmPackage>('GetNpmPackageInfo', 'GET', ['api','npm','info',encodeURI(packageName.replace(/\\/g, '/'))].join('/'), 'application/json', null, null);
-	}
-	public getNpmPackageDownloads(packageName: string): IFuture<number>{
-		return this.$serviceProxy.call<number>('GetNpmPackageDownloads', 'GET', ['api','npm','downloads',encodeURI(packageName.replace(/\\/g, '/'))].join('/'), 'application/json', null, null);
+	public migrate(appId: string, projectName: string, targetVersion: string): IFuture<Server.MigrationResult>{
+		return this.$serviceProxy.call<Server.MigrationResult>('Migrate', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'nativescript','migrate',encodeURI(projectName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'targetVersion': targetVersion }), 'application/json', null, null);
 	}
 }
 export class ProjectsService implements Server.IProjectsServiceContract{
@@ -325,20 +386,135 @@ export class ProjectsService implements Server.IProjectsServiceContract{
 		return this.$serviceProxy.call<Server.ProjectItemInfo[]>('CreateNewProjectItem', 'POST', ['api','projects',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(projectName.replace(/\\/g, '/')),encodeURI(itemIdentifier.replace(/\\/g, '/'))].join('/'), 'application/json', [{name: 'expansionData', value: JSON.stringify(expansionData), contentType: 'application/json'}], null);
 	}
 }
-export class PackagesService implements Server.IPackagesServiceContract{
+export class AppsProjectsService implements Server.IAppsProjectsServiceContract{
+	constructor(private $serviceProxy: Server.IServiceProxy){
+	}
+	public exportProject(appId: string, projectName: string, skipMetadata: boolean, $resultStream: any): IFuture<void>{
+		return this.$serviceProxy.call<void>('ExportProject', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'projects','export',encodeURI(projectName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'skipMetadata': skipMetadata }), 'application/octet-stream', null, $resultStream);
+	}
+	public importPackage(appId: string, projectName: string, parentIdentifier: string, archivePackage: any): IFuture<void>{
+		return this.$serviceProxy.call<void>('ImportPackage', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'projects','import',encodeURI(projectName.replace(/\\/g, '/')),encodeURI(parentIdentifier.replace(/\\/g, '/'))].join('/'), null, [{name: 'archivePackage', value: archivePackage, contentType: 'application/octet-stream'}], null);
+	}
+	public importProject(appId: string, projectName: string, package_: any): IFuture<void>{
+		return this.$serviceProxy.call<void>('ImportProject', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'projects','importProject',encodeURI(projectName.replace(/\\/g, '/'))].join('/'), null, [{name: 'package_', value: package_, contentType: 'application/octet-stream'}], null);
+	}
+	public importLocalProject(appId: string, projectName: string, bucketKey: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('ImportLocalProject', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'projects','importProject',encodeURI(projectName.replace(/\\/g, '/')),encodeURI(bucketKey.replace(/\\/g, '/'))].join('/'), null, null, null);
+	}
+	public getProjectContents(appId: string, projectName: string): IFuture<string>{
+		return this.$serviceProxy.call<string>('GetProjectContents', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'projects','contents',encodeURI(projectName.replace(/\\/g, '/'))].join('/'), 'application/json', null, null);
+	}
+	public saveProjectContents(appId: string, projectName: string, projectContents: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('SaveProjectContents', 'PUT', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'projects','contents',encodeURI(projectName.replace(/\\/g, '/'))].join('/'), null, [{name: 'projectContents', value: JSON.stringify(projectContents), contentType: 'application/json'}], null);
+	}
+	public createProject(appId: string, projectName: string, expansionData: Server.ProjectTemplateExpansionData): IFuture<void>{
+		return this.$serviceProxy.call<void>('CreateProject', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'projects',encodeURI(projectName.replace(/\\/g, '/'))].join('/'), null, [{name: 'expansionData', value: JSON.stringify(expansionData), contentType: 'application/json'}], null);
+	}
+	public deleteProject(appId: string, projectName: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('DeleteProject', 'DELETE', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'projects',encodeURI(projectName.replace(/\\/g, '/'))].join('/'), null, null, null);
+	}
+	public setProjectProperty(appId: string, projectName: string, configuration: string, changeset: IDictionary<string>): IFuture<void>{
+		return this.$serviceProxy.call<void>('SetProjectProperty', 'PATCH', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'projects',encodeURI(projectName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'configuration': configuration }), null, [{name: 'changeset', value: JSON.stringify(changeset), contentType: 'application/json'}], null);
+	}
+	public renameProject(appId: string, projectName: string, newProjectName: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('RenameProject', 'PUT', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'projects','rename',encodeURI(projectName.replace(/\\/g, '/')),encodeURI(newProjectName.replace(/\\/g, '/'))].join('/'), null, null, null);
+	}
+	public createNewProjectItem(appId: string, projectName: string, itemIdentifier: string, expansionData: Server.ItemTemplateExpansionData): IFuture<Server.ProjectItemInfo[]>{
+		return this.$serviceProxy.call<Server.ProjectItemInfo[]>('CreateNewProjectItem', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'projects',encodeURI(projectName.replace(/\\/g, '/')),encodeURI(itemIdentifier.replace(/\\/g, '/'))].join('/'), 'application/json', [{name: 'expansionData', value: JSON.stringify(expansionData), contentType: 'application/json'}], null);
+	}
+}
+export class AppsService implements Server.IAppsServiceContract{
+	constructor(private $serviceProxy: Server.IServiceProxy){
+	}
+	public exportApplication(appId: string, skipMetadata: boolean, $resultStream: any): IFuture<void>{
+		return this.$serviceProxy.call<void>('ExportApplication', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'export'].join('/') + '?' + querystring.stringify({ 'skipMetadata': skipMetadata }), 'application/octet-stream', null, $resultStream);
+	}
+	public createApplication(applicationData: Server.ApplicationCreationData): IFuture<IDictionary<Object>>{
+		return this.$serviceProxy.call<IDictionary<Object>>('CreateApplication', 'POST', ['api','apps'].join('/'), 'application/json', [{name: 'applicationData', value: JSON.stringify(applicationData), contentType: 'application/json'}], null);
+	}
+	public enableApplication(appId: string, expansionData: Server.ProjectTemplateExpansionData): IFuture<void>{
+		return this.$serviceProxy.call<void>('EnableApplication', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/'))].join('/'), null, [{name: 'expansionData', value: JSON.stringify(expansionData), contentType: 'application/json'}], null);
+	}
+	public getApplication(appId: string, checkUpgradability: boolean): IFuture<Server.SolutionData>{
+		return this.$serviceProxy.call<Server.SolutionData>('GetApplication', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'checkUpgradability': checkUpgradability }), 'application/json', null, null);
+	}
+	public canLoadApplication(appId: string): IFuture<boolean>{
+		return this.$serviceProxy.call<boolean>('CanLoadApplication', 'EXISTS', ['api','apps',encodeURI(appId.replace(/\\/g, '/'))].join('/'), 'application/json', null, null);
+	}
+	public deleteApplication(appId: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('DeleteApplication', 'DELETE', ['api','apps',encodeURI(appId.replace(/\\/g, '/'))].join('/'), null, null, null);
+	}
+	public upgradeApplication(appId: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('UpgradeApplication', 'PUT', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'upgrade'].join('/'), null, null, null);
+	}
+	public getApplicationServices(appId: string): IFuture<Server.ApplicationServiceData[]>{
+		return this.$serviceProxy.call<Server.ApplicationServiceData[]>('GetApplicationServices', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'services'].join('/'), 'application/json', null, null);
+	}
+	public enableApplicationService(appId: string, serviceData: IDictionary<Object>): IFuture<IDictionary<Object>>{
+		return this.$serviceProxy.call<IDictionary<Object>>('EnableApplicationService', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'services'].join('/'), 'application/json', [{name: 'serviceData', value: JSON.stringify(serviceData), contentType: 'application/json'}], null);
+	}
+}
+export class AppsBowerService implements Server.IAppsBowerServiceContract{
+	constructor(private $serviceProxy: Server.IServiceProxy){
+	}
+	public installDependencies(appId: string, projectName: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('InstallDependencies', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'bower','dependencies',encodeURI(projectName.replace(/\\/g, '/'))].join('/'), null, null, null);
+	}
+	public installPackage(appId: string, projectName: string, packageName: string, version: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('InstallPackage', 'PUT', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'bower',encodeURI(projectName.replace(/\\/g, '/')),encodeURI(packageName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'version': version }), null, null, null);
+	}
+	public getInstalledPackages(appId: string, projectName: string): IFuture<Server.PackageData[]>{
+		return this.$serviceProxy.call<Server.PackageData[]>('GetInstalledPackages', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'bower',encodeURI(projectName.replace(/\\/g, '/'))].join('/'), 'application/json', null, null);
+	}
+}
+export class BowerService implements Server.IBowerServiceContract{
 	constructor(private $serviceProxy: Server.IServiceProxy){
 	}
 	public installDependencies(solutionName: string, projectName: string): IFuture<void>{
-		return this.$serviceProxy.call<void>('InstallDependencies', 'POST', ['api','packages','dependencies',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(projectName.replace(/\\/g, '/'))].join('/'), null, null, null);
+		return this.$serviceProxy.call<void>('InstallDependencies', 'POST', ['api','bower','dependencies',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(projectName.replace(/\\/g, '/'))].join('/'), null, null, null);
 	}
 	public installPackage(solutionName: string, projectName: string, packageName: string, version: string): IFuture<void>{
-		return this.$serviceProxy.call<void>('InstallPackage', 'PUT', ['api','packages',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(projectName.replace(/\\/g, '/')),encodeURI(packageName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'version': version }), null, null, null);
+		return this.$serviceProxy.call<void>('InstallPackage', 'PUT', ['api','bower',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(projectName.replace(/\\/g, '/')),encodeURI(packageName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'version': version }), null, null, null);
 	}
 	public getInstalledPackages(solutionName: string, projectName: string): IFuture<Server.PackageData[]>{
-		return this.$serviceProxy.call<Server.PackageData[]>('GetInstalledPackages', 'GET', ['api','packages',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(projectName.replace(/\\/g, '/'))].join('/'), 'application/json', null, null);
+		return this.$serviceProxy.call<Server.PackageData[]>('GetInstalledPackages', 'GET', ['api','bower',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(projectName.replace(/\\/g, '/'))].join('/'), 'application/json', null, null);
 	}
 	public getFilters(): IFuture<Server.BowerPackagesFilters>{
-		return this.$serviceProxy.call<Server.BowerPackagesFilters>('GetFilters', 'GET', ['api','packages','filters'].join('/'), 'application/json', null, null);
+		return this.$serviceProxy.call<Server.BowerPackagesFilters>('GetFilters', 'GET', ['api','bower','filters'].join('/'), 'application/json', null, null);
+	}
+}
+export class BuildService implements Server.IBuildServiceContract{
+	constructor(private $serviceProxy: Server.IServiceProxy){
+	}
+	public buildProject(solutionName: string, projectName: string, buildRequest: Server.BuildRequestData): IFuture<Server.BuildResultData>{
+		return this.$serviceProxy.call<Server.BuildResultData>('BuildProject', 'POST', ['api','build',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(projectName.replace(/\\/g, '/'))].join('/'), 'application/json', [{name: 'buildRequest', value: JSON.stringify(buildRequest), contentType: 'application/json'}], null);
+	}
+}
+export class AppsBuildService implements Server.IAppsBuildServiceContract{
+	constructor(private $serviceProxy: Server.IServiceProxy){
+	}
+	public buildProject(appId: string, projectName: string, buildRequest: Server.BuildRequestData): IFuture<Server.BuildResultData>{
+		return this.$serviceProxy.call<Server.BuildResultData>('BuildProject', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'build',encodeURI(projectName.replace(/\\/g, '/'))].join('/'), 'application/json', [{name: 'buildRequest', value: JSON.stringify(buildRequest), contentType: 'application/json'}], null);
+	}
+}
+export class NpmService implements Server.INpmServiceContract{
+	constructor(private $serviceProxy: Server.IServiceProxy){
+	}
+	public queryNpmSearch(packageName: string, size: number, sortOrder: Server.SortOrder, start: number): IFuture<Server.NpmSearchResult>{
+		return this.$serviceProxy.call<Server.NpmSearchResult>('QueryNpmSearch', 'GET', ['api','npm','search'].join('/') + '?' + querystring.stringify({ 'packageName': packageName, 'size': size, 'sortOrder': sortOrder, 'start': start }), 'application/json', null, null);
+	}
+	public getNpmPackageInfo(packageName: string): IFuture<Server.NpmPackage>{
+		return this.$serviceProxy.call<Server.NpmPackage>('GetNpmPackageInfo', 'GET', ['api','npm','info',encodeURI(packageName.replace(/\\/g, '/'))].join('/'), 'application/json', null, null);
+	}
+	public getNpmPackageDownloads(packageName: string): IFuture<number>{
+		return this.$serviceProxy.call<number>('GetNpmPackageDownloads', 'GET', ['api','npm','downloads',encodeURI(packageName.replace(/\\/g, '/'))].join('/'), 'application/json', null, null);
+	}
+}
+export class AppsPublishService implements Server.IAppsPublishServiceContract{
+	constructor(private $serviceProxy: Server.IServiceProxy){
+	}
+	public publishFtp(appId: string, projectName: string, ftpConnectionData: Server.FtpConnectionData): IFuture<void>{
+		return this.$serviceProxy.call<void>('PublishFtp', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'publish','ftp',encodeURI(projectName.replace(/\\/g, '/'))].join('/'), null, [{name: 'ftpConnectionData', value: JSON.stringify(ftpConnectionData), contentType: 'application/json'}], null);
 	}
 }
 export class PublishService implements Server.IPublishServiceContract{
@@ -362,6 +538,35 @@ export class RawSettingsService implements Server.IRawSettingsServiceContract{
 	}
 	public saveSolutionUserSettings(solutionName: string, content: any): IFuture<void>{
 		return this.$serviceProxy.call<void>('SaveSolutionUserSettings', 'POST', ['api','rawSettings','solution',encodeURI(solutionName.replace(/\\/g, '/'))].join('/'), null, [{name: 'content', value: content, contentType: 'application/octet-stream'}], null);
+	}
+}
+export class AppsRawSettingsService implements Server.IAppsRawSettingsServiceContract{
+	constructor(private $serviceProxy: Server.IServiceProxy){
+	}
+	public getSolutionUserSettings(appId: string, $resultStream: any): IFuture<void>{
+		return this.$serviceProxy.call<void>('GetSolutionUserSettings', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'rawSettings','solution'].join('/'), 'application/octet-stream', null, $resultStream);
+	}
+	public saveSolutionUserSettings(appId: string, content: any): IFuture<void>{
+		return this.$serviceProxy.call<void>('SaveSolutionUserSettings', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'rawSettings','solution'].join('/'), null, [{name: 'content', value: content, contentType: 'application/octet-stream'}], null);
+	}
+}
+export class AppsSettingsService implements Server.IAppsSettingsServiceContract{
+	constructor(private $serviceProxy: Server.IServiceProxy){
+	}
+	public getSettings(appId: string): IFuture<Server.SettingsData>{
+		return this.$serviceProxy.call<Server.SettingsData>('GetSettings', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'settings','solution'].join('/'), 'application/json', null, null);
+	}
+	public setCodesignIdentity(appId: string, projectIdentity: string, platform: Server.DevicePlatform, identityAlias: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('SetCodesignIdentity', 'PUT', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'settings','codesignIdentity',encodeURI(projectIdentity.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'platform': platform }), null, [{name: 'identityAlias', value: JSON.stringify(identityAlias), contentType: 'application/json'}], null);
+	}
+	public setMobileProvision(appId: string, projectIdentity: string, provisionIdentifier: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('SetMobileProvision', 'PUT', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'settings','mobileProvision',encodeURI(projectIdentity.replace(/\\/g, '/'))].join('/'), null, [{name: 'provisionIdentifier', value: JSON.stringify(provisionIdentifier), contentType: 'application/json'}], null);
+	}
+	public setActiveBuildConfiguration(appId: string, buildConfiguration: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('SetActiveBuildConfiguration', 'PUT', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'settings','buildConfiguration',encodeURI(buildConfiguration.replace(/\\/g, '/'))].join('/'), null, null, null);
+	}
+	public updateSettingsProjectIdentifier(appId: string, projectIdentity: string, newProjectIdentity: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('UpdateSettingsProjectIdentifier', 'PATCH', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'settings','updateProjectIdentifier',encodeURI(projectIdentity.replace(/\\/g, '/'))].join('/'), null, [{name: 'newProjectIdentity', value: JSON.stringify(newProjectIdentity), contentType: 'application/json'}], null);
 	}
 }
 export class SettingsService implements Server.ISettingsServiceContract{
@@ -412,6 +617,29 @@ export class TamService implements Server.ITamServiceContract{
 		return this.$serviceProxy.call<Server.FeatureStatus>('GetAccountStatus', 'GET', ['api','tam','account','status'].join('/'), 'application/json', null, null);
 	}
 }
+export class AppsTamService implements Server.IAppsTamServiceContract{
+	constructor(private $serviceProxy: Server.IServiceProxy){
+	}
+	public uploadApplication(appId: string, projectName: string, relativePackagePath: string, settings: Server.PublishSettings): IFuture<Server.UploadedAppData>{
+		return this.$serviceProxy.call<Server.UploadedAppData>('UploadApplication', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'tam','applications',encodeURI(projectName.replace(/\\/g, '/')),encodeURI(relativePackagePath.replace(/\\/g, '/'))].join('/'), 'application/json', [{name: 'settings', value: JSON.stringify(settings), contentType: 'application/json'}], null);
+	}
+	public uploadPatch(appId: string, projectName: string, patchData: Server.PatchData): IFuture<void>{
+		return this.$serviceProxy.call<void>('UploadPatch', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'tam','patches',encodeURI(projectName.replace(/\\/g, '/'))].join('/'), null, [{name: 'patchData', value: JSON.stringify(patchData), contentType: 'application/json'}], null);
+	}
+}
+export class AppsTapService implements Server.IAppsTapServiceContract{
+	constructor(private $serviceProxy: Server.IServiceProxy){
+	}
+	public getRemote(appId: string): IFuture<string>{
+		return this.$serviceProxy.call<string>('GetRemote', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'tap','versioncontrol','remote'].join('/'), 'application/json', null, null);
+	}
+	public setRemote(appId: string, remoteUrl: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('SetRemote', 'PUT', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'tap','versioncontrol','remote'].join('/'), null, [{name: 'remoteUrl', value: JSON.stringify(remoteUrl), contentType: 'application/json'}], null);
+	}
+	public initCurrentUserSharedRepository(appId: string): IFuture<boolean>{
+		return this.$serviceProxy.call<boolean>('InitCurrentUserSharedRepository', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'tap','userProjects','initSharedRepository'].join('/'), 'application/json', null, null);
+	}
+}
 export class TapService implements Server.ITapServiceContract{
 	constructor(private $serviceProxy: Server.IServiceProxy){
 	}
@@ -430,8 +658,8 @@ export class TapService implements Server.ITapServiceContract{
 	public getUsersForProject(solutionName: string): IFuture<Server.Collaborator[]>{
 		return this.$serviceProxy.call<Server.Collaborator[]>('GetUsersForProject', 'GET', ['api','tap','userProjects',encodeURI(solutionName.replace(/\\/g, '/'))].join('/'), 'application/json', null, null);
 	}
-	public initCurrentUserSharedRepository(solutionName: string): IFuture<void>{
-		return this.$serviceProxy.call<void>('InitCurrentUserSharedRepository', 'POST', ['api','tap','userProjects',encodeURI(solutionName.replace(/\\/g, '/')),'initSharedRepository'].join('/'), null, null, null);
+	public initCurrentUserSharedRepository(solutionName: string): IFuture<boolean>{
+		return this.$serviceProxy.call<boolean>('InitCurrentUserSharedRepository', 'POST', ['api','tap','userProjects',encodeURI(solutionName.replace(/\\/g, '/')),'initSharedRepository'].join('/'), 'application/json', null, null);
 	}
 	public getWorkspaces(accountId: string): IFuture<Server.TapWorkspaceData[]>{
 		return this.$serviceProxy.call<Server.TapWorkspaceData[]>('GetWorkspaces', 'GET', ['api','tap','workspaces',encodeURI(accountId.replace(/\\/g, '/'))].join('/'), 'application/json', null, null);
@@ -453,6 +681,88 @@ export class TapService implements Server.ITapServiceContract{
 	}
 	public getReadNotifications(accountId: string, fromDate: Date): IFuture<Server.TapNotificationData[]>{
 		return this.$serviceProxy.call<Server.TapNotificationData[]>('GetReadNotifications', 'GET', ['api','tap','notifications',encodeURI(accountId.replace(/\\/g, '/')),'read'].join('/') + '?' + querystring.stringify({ 'fromDate': fromDate }), 'application/json', null, null);
+	}
+}
+export class AppsVersioncontrolService implements Server.IAppsVersioncontrolServiceContract{
+	constructor(private $serviceProxy: Server.IServiceProxy){
+	}
+	public init(appId: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('Init', 'INIT', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol'].join('/'), null, null, null);
+	}
+	public rollback(appId: string, versionName: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('Rollback', 'ROLLBACK', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol'].join('/') + '?' + querystring.stringify({ 'versionName': versionName }), null, null, null);
+	}
+	public reset(appId: string, resetMode: Server.ResetMode, versionName: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('Reset', 'RESET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol'].join('/') + '?' + querystring.stringify({ 'resetMode': resetMode, 'versionName': versionName }), null, null, null);
+	}
+	public merge(appId: string, versionName: string): IFuture<Server.BranchItemData>{
+		return this.$serviceProxy.call<Server.BranchItemData>('Merge', 'MERGE', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol'].join('/') + '?' + querystring.stringify({ 'versionName': versionName }), 'application/json', null, null);
+	}
+	public revert(appId: string, versionName: string, filePaths: string[]): IFuture<void>{
+		return this.$serviceProxy.call<void>('Revert', 'REVERT', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','files'].join('/') + '?' + querystring.stringify({ 'versionName': versionName }), null, [{name: 'filePaths', value: JSON.stringify(filePaths), contentType: 'application/json'}], null);
+	}
+	public resolve(appId: string, versionName: string, filePaths: string[]): IFuture<void>{
+		return this.$serviceProxy.call<void>('Resolve', 'RESOLVE', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','files'].join('/') + '?' + querystring.stringify({ 'versionName': versionName }), null, [{name: 'filePaths', value: JSON.stringify(filePaths), contentType: 'application/json'}], null);
+	}
+	public checkout(appId: string, versionName: string, filePaths: string[]): IFuture<void>{
+		return this.$serviceProxy.call<void>('Checkout', 'CHECKOUT', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','files'].join('/') + '?' + querystring.stringify({ 'versionName': versionName }), null, [{name: 'filePaths', value: JSON.stringify(filePaths), contentType: 'application/json'}], null);
+	}
+	public add(appId: string, filePaths: string[]): IFuture<void>{
+		return this.$serviceProxy.call<void>('Add', 'ADD', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','files'].join('/'), null, [{name: 'filePaths', value: JSON.stringify(filePaths), contentType: 'application/json'}], null);
+	}
+	public remove(appId: string, filePaths: string[]): IFuture<void>{
+		return this.$serviceProxy.call<void>('Remove', 'REMOVE', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','files'].join('/'), null, [{name: 'filePaths', value: JSON.stringify(filePaths), contentType: 'application/json'}], null);
+	}
+	public getBranches(appId: string): IFuture<Server.BranchItemData[]>{
+		return this.$serviceProxy.call<Server.BranchItemData[]>('GetBranches', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','branches'].join('/'), 'application/json', null, null);
+	}
+	public getCurrentBranch(appId: string): IFuture<Server.BranchItemData>{
+		return this.$serviceProxy.call<Server.BranchItemData>('GetCurrentBranch', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','branch'].join('/'), 'application/json', null, null);
+	}
+	public checkoutBranch(appId: string, branchName: string, createBranch: boolean, versionName: string): IFuture<Server.BranchItemData>{
+		return this.$serviceProxy.call<Server.BranchItemData>('CheckoutBranch', 'CHECKOUT', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','branches',encodeURI(branchName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'createBranch': createBranch, 'versionName': versionName }), 'application/json', null, null);
+	}
+	public createBranch(appId: string, branchName: string, versionName: string): IFuture<Server.BranchItemData>{
+		return this.$serviceProxy.call<Server.BranchItemData>('CreateBranch', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','branches',encodeURI(branchName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'versionName': versionName }), 'application/json', null, null);
+	}
+	public deleteBranch(appId: string, branchName: string, forceDelete: boolean): IFuture<void>{
+		return this.$serviceProxy.call<void>('DeleteBranch', 'DELETE', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','branches',encodeURI(branchName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'forceDelete': forceDelete }), null, null, null);
+	}
+	public getRemote(appId: string): IFuture<string>{
+		return this.$serviceProxy.call<string>('GetRemote', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','remote'].join('/'), 'application/json', null, null);
+	}
+	public setRemote(appId: string, remoteData: Server.GitRemoteData): IFuture<void>{
+		return this.$serviceProxy.call<void>('SetRemote', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','remote'].join('/'), null, [{name: 'remoteData', value: JSON.stringify(remoteData), contentType: 'application/json'}], null);
+	}
+	public getInfo(appId: string): IFuture<Server.VersionControlData>{
+		return this.$serviceProxy.call<Server.VersionControlData>('GetInfo', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','info'].join('/'), 'application/json', null, null);
+	}
+	public track(appId: string): IFuture<Server.ChangeItemData[]>{
+		return this.$serviceProxy.call<Server.ChangeItemData[]>('Track', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','status'].join('/'), 'application/json', null, null);
+	}
+	public getStatus(appId: string, filePaths: string[]): IFuture<Server.ChangeItemData[]>{
+		return this.$serviceProxy.call<Server.ChangeItemData[]>('GetStatus', 'XGET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','status','files'].join('/'), 'application/json', [{name: 'filePaths', value: JSON.stringify(filePaths), contentType: 'application/json'}], null);
+	}
+	public getDiff(appId: string, versionName: string, contextSize: number, otherVersionName: string, filePaths: string[]): IFuture<Server.DiffLineResultData[]>{
+		return this.$serviceProxy.call<Server.DiffLineResultData[]>('GetDiff', 'XGET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol',encodeURI(versionName.replace(/\\/g, '/')),'diff','files'].join('/') + '?' + querystring.stringify({ 'contextSize': contextSize, 'otherVersionName': otherVersionName }), 'application/json', [{name: 'filePaths', value: JSON.stringify(filePaths), contentType: 'application/json'}], null);
+	}
+	public getConflicts(appId: string, contextSize: number, filePaths: string[]): IFuture<Server.DiffLineResultData[]>{
+		return this.$serviceProxy.call<Server.DiffLineResultData[]>('GetConflicts', 'XGET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','conflicts','files'].join('/') + '?' + querystring.stringify({ 'contextSize': contextSize }), 'application/json', [{name: 'filePaths', value: JSON.stringify(filePaths), contentType: 'application/json'}], null);
+	}
+	public getCommits(appId: string, endDate: Date, startDate: Date): IFuture<Server.ChangeSetData[]>{
+		return this.$serviceProxy.call<Server.ChangeSetData[]>('GetCommits', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','commits'].join('/') + '?' + querystring.stringify({ 'endDate': endDate, 'startDate': startDate }), 'application/json', null, null);
+	}
+	public getCommit(appId: string, versionName: string): IFuture<Server.ChangeSetData>{
+		return this.$serviceProxy.call<Server.ChangeSetData>('GetCommit', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','commit'].join('/') + '?' + querystring.stringify({ 'versionName': versionName }), 'application/json', null, null);
+	}
+	public getChanges(appId: string, versionName: string): IFuture<Server.ChangeItemData[]>{
+		return this.$serviceProxy.call<Server.ChangeItemData[]>('GetChanges', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol',encodeURI(versionName.replace(/\\/g, '/')),'changes'].join('/'), 'application/json', null, null);
+	}
+	public getContents(appId: string, versionName: string, filePath: string): IFuture<string>{
+		return this.$serviceProxy.call<string>('GetContents', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol',encodeURI(versionName.replace(/\\/g, '/')),'contents',encodeURI(filePath.replace(/\\/g, '/'))].join('/'), 'application/json', null, null);
+	}
+	public getHistory(appId: string, versionName: string, filePath: string): IFuture<Server.HistoryItemData[]>{
+		return this.$serviceProxy.call<Server.HistoryItemData[]>('GetHistory', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol',encodeURI(versionName.replace(/\\/g, '/')),'history',encodeURI(filePath.replace(/\\/g, '/'))].join('/'), 'application/json', null, null);
 	}
 }
 export class VersioncontrolService implements Server.IVersioncontrolServiceContract{
@@ -541,27 +851,43 @@ export class ServiceContainer implements Server.IServer{
 	constructor(private $injector: IInjector){ }
 	public authentication: Server.IAuthenticationServiceContract = this.$injector.resolve(AuthenticationService);
 	public cordova: Server.ICordovaServiceContract = this.$injector.resolve(CordovaService);
+	public appsCordova: Server.IAppsCordovaServiceContract = this.$injector.resolve(AppsCordovaService);
 	public identityStore: Server.IIdentityStoreServiceContract = this.$injector.resolve(IdentityStoreService);
 	public everlive: Server.IEverliveServiceContract = this.$injector.resolve(EverliveService);
 	public extensions: Server.IExtensionsServiceContract = this.$injector.resolve(ExtensionsService);
 	public internalExtensions: Server.IInternalExtensionsServiceContract = this.$injector.resolve(InternalExtensionsService);
-	public filesystem: Server.IFilesystemServiceContract = this.$injector.resolve(FilesystemService);
 	public upload: Server.IUploadServiceContract = this.$injector.resolve(UploadService);
+	public filesystem: Server.IFilesystemServiceContract = this.$injector.resolve(FilesystemService);
+	public appsFiles: Server.IAppsFilesServiceContract = this.$injector.resolve(AppsFilesService);
+	public appsImages: Server.IAppsImagesServiceContract = this.$injector.resolve(AppsImagesService);
 	public images: Server.IImagesServiceContract = this.$injector.resolve(ImagesService);
+	public appsItmstransporter: Server.IAppsItmstransporterServiceContract = this.$injector.resolve(AppsItmstransporterService);
 	public itmstransporter: Server.IItmstransporterServiceContract = this.$injector.resolve(ItmstransporterService);
 	public kendo: Server.IKendoServiceContract = this.$injector.resolve(KendoService);
+	public appsKendo: Server.IAppsKendoServiceContract = this.$injector.resolve(AppsKendoService);
 	public mobileprovisions: Server.IMobileprovisionsServiceContract = this.$injector.resolve(MobileprovisionsService);
 	public nativescript: Server.INativescriptServiceContract = this.$injector.resolve(NativescriptService);
-	public build: Server.IBuildServiceContract = this.$injector.resolve(BuildService);
-	public npm: Server.INpmServiceContract = this.$injector.resolve(NpmService);
+	public appsNativescript: Server.IAppsNativescriptServiceContract = this.$injector.resolve(AppsNativescriptService);
 	public projects: Server.IProjectsServiceContract = this.$injector.resolve(ProjectsService);
-	public packages: Server.IPackagesServiceContract = this.$injector.resolve(PackagesService);
+	public appsProjects: Server.IAppsProjectsServiceContract = this.$injector.resolve(AppsProjectsService);
+	public apps: Server.IAppsServiceContract = this.$injector.resolve(AppsService);
+	public appsBower: Server.IAppsBowerServiceContract = this.$injector.resolve(AppsBowerService);
+	public bower: Server.IBowerServiceContract = this.$injector.resolve(BowerService);
+	public build: Server.IBuildServiceContract = this.$injector.resolve(BuildService);
+	public appsBuild: Server.IAppsBuildServiceContract = this.$injector.resolve(AppsBuildService);
+	public npm: Server.INpmServiceContract = this.$injector.resolve(NpmService);
+	public appsPublish: Server.IAppsPublishServiceContract = this.$injector.resolve(AppsPublishService);
 	public publish: Server.IPublishServiceContract = this.$injector.resolve(PublishService);
 	public rawSettings: Server.IRawSettingsServiceContract = this.$injector.resolve(RawSettingsService);
+	public appsRawSettings: Server.IAppsRawSettingsServiceContract = this.$injector.resolve(AppsRawSettingsService);
+	public appsSettings: Server.IAppsSettingsServiceContract = this.$injector.resolve(AppsSettingsService);
 	public settings: Server.ISettingsServiceContract = this.$injector.resolve(SettingsService);
 	public status: Server.IStatusServiceContract = this.$injector.resolve(StatusService);
 	public tam: Server.ITamServiceContract = this.$injector.resolve(TamService);
+	public appsTam: Server.IAppsTamServiceContract = this.$injector.resolve(AppsTamService);
+	public appsTap: Server.IAppsTapServiceContract = this.$injector.resolve(AppsTapService);
 	public tap: Server.ITapServiceContract = this.$injector.resolve(TapService);
+	public appsVersioncontrol: Server.IAppsVersioncontrolServiceContract = this.$injector.resolve(AppsVersioncontrolService);
 	public versioncontrol: Server.IVersioncontrolServiceContract = this.$injector.resolve(VersioncontrolService);
 }
 $injector.register('server', ServiceContainer);

--- a/lib/services/remote-projects-service.ts
+++ b/lib/services/remote-projects-service.ts
@@ -5,48 +5,35 @@ import * as helpers from "../helpers";
 import temp = require("temp");
 
 export class RemoteProjectService implements IRemoteProjectService {
-	private clientSolutions: Server.TapSolutionData[];
+	private clientSolutions: ITapAppData[];
 	private clientProjectsPerSolution: IDictionary<Server.IWorkspaceItemData[]> = {};
+	private static NOT_MIGRATED_IDENTIFER = " (NOT MIGRATED)";
 
 	constructor(private $server: Server.IServer,
 				private $userDataStore: IUserDataStore,
-				private $serviceProxy: Server.IServiceProxy,
+				private $serviceProxy: Server.IAppBuilderServiceProxy,
+				private $serviceProxyBase: Server.IServiceProxy,
 				private $errors: IErrors,
 				private $project: Project.IProject,
 				private $projectConstants: Project.IProjectConstants,
 				private $fs: IFileSystem,
 				private $logger: ILogger) { }
 
-	public makeTapServiceCall<T>(call: () => IFuture<T>): IFuture<T> {
-		return (() => {
-			let user = this.$userDataStore.getUser().wait();
-			let tenantId = user.tenant.id;
-			this.$serviceProxy.setSolutionSpaceName(tenantId);
-			try {
-				return call().wait();
-			} finally {
-				this.$serviceProxy.setSolutionSpaceName(null);
-			}
-		}).future<T>()();
-	}
-
-	public getSolutionName(solutionId: string): IFuture<string> {
-		return ((): string => {
-			let clientSolutions = this.getSolutions().wait();
-
-			let result = helpers.findByNameOrIndex(solutionId, clientSolutions, (clientSolution: Server.TapSolutionData) => clientSolution.name);
-			if(!result) {
-				this.$errors.failWithoutHelp("Could not find solution named '%s' or was not given a valid index. List available solutions with 'cloud list' command", solutionId);
+	public getAvailableAppsAndSolutions(): IFuture<ITapAppData[]> {
+		return ((): ITapAppData[] => {
+			if(!this.clientSolutions || !this.clientSolutions.length) {
+				let apps = this.getApps().wait();
+				let solutions = this.getSolutions().wait();
+				this.clientSolutions = solutions.concat(apps);
 			}
 
-			return result.name;
-		}).future<string>()();
+			return this.clientSolutions;
+		}).future<ITapAppData[]>()();
 	}
 
 	public getProjectName(solutionId: string, projectId: string): IFuture<string> {
 		return ((): string => {
-			let slnName = this.getSolutionName(solutionId).wait();
-			let clientProjects = this.getProjectsForSolution(slnName).wait();
+			let clientProjects = this.getProjectsForSolution(solutionId).wait();
 			let result = helpers.findByNameOrIndex(projectId, clientProjects, (clientProject: Server.IWorkspaceItemData) => clientProject.Name);
 			if(!result) {
 				this.$errors.failWithoutHelp("Could not find project named '%s' inside '%s' solution or was not given a valid index. List available solutions with 'cloud list' command", projectId, solutionId);
@@ -56,42 +43,33 @@ export class RemoteProjectService implements IRemoteProjectService {
 		}).future<string>()();
 	}
 
-	public getSolutions(): IFuture<Server.TapSolutionData[]> {
-		return (() => {
-			if (!this.clientSolutions) {
-				let existingClientSolutions = this.makeTapServiceCall(() => this.$server.tap.getExistingClientSolutions()).wait();
-				this.clientSolutions = _.sortBy(existingClientSolutions, (clientSolution: Server.TapSolutionData) => clientSolution.name);
-			}
-
-			return this.clientSolutions;
-		}).future<Server.TapSolutionData[]>()();
-	}
-
 	public getProjectProperties(solutionId: string, projectId: string): IFuture<any> {
 		return (() => {
-			let solutionName = this.getSolutionName(solutionId).wait();
-			let projectName = this.getProjectName(solutionName, projectId).wait();
-			let properties = (<any>this.getProjectData(solutionName, projectName).wait())["Properties"];
+			let projectName = this.getProjectName(solutionId, projectId).wait();
+			let properties = (<any>this.getProjectData(solutionId, projectName).wait())["Properties"];
 			properties.ProjectName = projectName;
 			return properties;
 		}).future()();
 	}
 
-	public getProjectsForSolution(solutionName: string): IFuture<Server.IWorkspaceItemData[]> {
+	public getProjectsForSolution(appId: string): IFuture<Server.IWorkspaceItemData[]> {
 		return ((): Server.IWorkspaceItemData[] => {
-			let slnName = this.getSolutionName(solutionName).wait();
-			if(!(this.clientProjectsPerSolution[slnName] && this.clientProjectsPerSolution[slnName].length > 0)) {
-				this.clientProjectsPerSolution[slnName] = _.sortBy(this.getSolutionData(slnName).wait().Items, project => project.Name);
+			let app = this.getApp(appId).wait();
+
+			if(!(this.clientProjectsPerSolution[app.id] && this.clientProjectsPerSolution[app.id].length > 0)) {
+				this.clientProjectsPerSolution[app.id] = _.sortBy(this.getSolutionDataCore(app).wait().Items, project => project.Name);
 			}
 
-			return this.clientProjectsPerSolution[slnName];
+			return this.clientProjectsPerSolution[app.id];
 		}).future<Server.IWorkspaceItemData[]>()();
 	}
 
 	public exportProject(remoteSolutionName: string, remoteProjectName: string): IFuture<void> {
 		return (() => {
-			let projectDir = this.getExportDir(remoteSolutionName, (tenantId: string, dirName: string, unzipStream: any) => this.$server.projects.exportProject(tenantId, remoteSolutionName, remoteProjectName, false, unzipStream)).wait();
-			this.createProjectFile(projectDir, remoteSolutionName, remoteProjectName).wait();
+			let app = this.getApp(remoteSolutionName).wait();
+			let slnName = app.isApp ? app.id : app.name;
+			let projectDir = this.getExportDir(app.name,  (unzipStream: any) => this.$server.appsProjects.exportProject(slnName, remoteProjectName, false, unzipStream), {discardSolutionSpaceHeader: app.isApp}).wait();
+			this.createProjectFile(projectDir, slnName, remoteProjectName).wait();
 
 			this.$logger.info("%s has been successfully exported to %s", remoteProjectName, projectDir);
 		}).future<void>()();
@@ -99,7 +77,9 @@ export class RemoteProjectService implements IRemoteProjectService {
 
 	public exportSolution(remoteSolutionName: string): IFuture<void> {
 		return (() => {
-			let solutionDir = this.getExportDir(remoteSolutionName, (tenantId: string, dirName: string, unzipStream: any) => this.$server.projects.exportSolution(tenantId, remoteSolutionName, false, unzipStream)).wait();
+			let app = this.getApp(remoteSolutionName).wait();
+			let slnName = app.isApp ? app.id : app.name;
+			let solutionDir = this.getExportDir(app.name, (unzipStream: any) => this.$server.apps.exportApplication(slnName, false, unzipStream), {discardSolutionSpaceHeader: app.isApp}).wait();
 
 			let projectsDirectories = this.$fs.readDirectory(solutionDir).wait();
 			projectsDirectories.forEach(projectName => this.createProjectFile(path.join(solutionDir, projectName), remoteSolutionName, projectName).wait());
@@ -108,8 +88,16 @@ export class RemoteProjectService implements IRemoteProjectService {
 		}).future<void>()();
 	}
 
-	private getSolutionData(projectName: string): IFuture<Server.SolutionData> {
-		return this.makeTapServiceCall(() => this.$server.projects.getSolution(projectName, true));
+	public getSolutionData(solutionIdentifier: string): IFuture<Server.SolutionData> {
+		return ((): Server.SolutionData => {
+			let app = this.getApp(solutionIdentifier).wait();
+			return this.getSolutionDataCore(app).wait();
+		}).future<Server.SolutionData>()();
+	}
+
+	private getSolutionDataCore(app: ITapAppData): IFuture<Server.SolutionData> {
+		let name = app.isApp ? app.id : app.name;
+		return this.$serviceProxy.makeTapServiceCall(() => this.$server.apps.getApplication(name, true), {discardSolutionSpaceHeader: app.isApp});
 	}
 
 	private getProjectData(solutionName: string, projectName: string): IFuture<Server.IWorkspaceItemData> {
@@ -118,7 +106,7 @@ export class RemoteProjectService implements IRemoteProjectService {
 		}).future<Server.IWorkspaceItemData>()();
 	}
 
-	private getExportDir(dirName: string, tapServiceCall: (_tenantId: string, _dirName: string, _unzipStream: any) => IFuture<any>): IFuture<string> {
+	private getExportDir(dirName: string, tapServiceCall: (_unzipStream: any) => IFuture<any>, solutionSpaceHeaderOptions: {discardSolutionSpaceHeader: boolean}): IFuture<string> {
 		return ((): string =>{
 			let exportDir = path.join(this.$project.getNewProjectDir(), dirName);
 			if(this.$fs.exists(exportDir).wait()) {
@@ -128,19 +116,11 @@ export class RemoteProjectService implements IRemoteProjectService {
 			temp.track();
 			let solutionZipFilePath = temp.path({prefix: "appbuilder-cli-", suffix: '.zip'});
 			let unzipStream = this.$fs.createWriteStream(solutionZipFilePath);
-			let tenantId = this.getUserTenantId().wait();
 
-			this.makeTapServiceCall(() => tapServiceCall.apply(null, [tenantId, dirName, unzipStream])).wait();
+			this.$serviceProxy.makeTapServiceCall(() => tapServiceCall.apply(null, [unzipStream]), solutionSpaceHeaderOptions).wait();
 			this.$fs.unzip(solutionZipFilePath, exportDir).wait();
 
 			return exportDir;
-		}).future<string>()();
-	}
-
-	private getUserTenantId(): IFuture<string> {
-		return (() => {
-			let user = this.$userDataStore.getUser().wait();
-			return user.tenant.id;
 		}).future<string>()();
 	}
 
@@ -158,6 +138,56 @@ export class RemoteProjectService implements IRemoteProjectService {
 				this.$logger.trace(e);
 			}
 		}).future<void>()();
+	}
+
+	private getApps(): IFuture<ITapAppData[]> {
+		return ((): ITapAppData[] => {
+			let user = this.$userDataStore.getUser().wait();
+			let tenantId = user.tenant.id;
+			let existingClientApps = this.$serviceProxyBase.call<any>('', 'GET', ['api','accounts', tenantId, 'apps'].join('/'), 'application/json', null, null).wait();
+			return _.sortBy(existingClientApps, (clientSolution: ITapAppData) => clientSolution.name)
+					.map(app => {
+						app.displayName = app.name;
+						app.isApp = true;
+						app.colorizedDisplayName = app.displayName;
+						return app;
+					});
+		}).future<ITapAppData[]>()();
+	}
+
+	private getSolutions(): IFuture<ITapAppData[]> {
+		return ((): ITapAppData[] => {
+			let existingClientSolutions = this.$serviceProxy.makeTapServiceCall(() => this.$server.tap.getExistingClientSolutions()).wait();
+			return _.sortBy(existingClientSolutions, (clientSolution: Server.TapSolutionData) => clientSolution.name)
+					.map(sln => {
+						return {
+							accountId: sln.accountId,
+							id: sln.id,
+							type: null,
+							settings: null,
+							name: sln.name,
+							description: sln.description,
+							displayName: sln.name + RemoteProjectService.NOT_MIGRATED_IDENTIFER,
+							colorizedDisplayName: sln.name + `\x1B[31;1m${RemoteProjectService.NOT_MIGRATED_IDENTIFER}\x1B[0m`,
+							isApp: false
+						};
+					});
+		}).future<ITapAppData[]>()();
+	}
+
+	private getApp(key: string): IFuture<ITapAppData> {
+		return ((): ITapAppData => {
+			let matchingApp = helpers.findByNameOrIndex(key, this.getAvailableAppsAndSolutions().wait(), app => app.colorizedDisplayName) // from prompter we receive colorized message
+					|| helpers.findByNameOrIndex(key, this.getAvailableAppsAndSolutions().wait(), app => app.displayName) // in case the user writes the message on its own and adds '(NOT MIGRATED)'
+					|| helpers.findByNameOrIndex(key, this.getAvailableAppsAndSolutions().wait(), app => app.id)
+					|| helpers.findByNameOrIndex(key, this.getAvailableAppsAndSolutions().wait(), app => app.name);
+
+			if(!matchingApp) {
+				this.$errors.failWithoutHelp(`Unable to find app with identifier ${key}.`);
+			}
+
+			return matchingApp;
+		}).future<ITapAppData>()();
 	}
 }
 $injector.register("remoteProjectService", RemoteProjectService);

--- a/test/cloud-projects.ts
+++ b/test/cloud-projects.ts
@@ -85,38 +85,51 @@ function createTestInjector(promptSlnName?: string, promptPrjName?: string, isIn
 		getUser: () =>  Future.fromResult({tenant: {id: "id"}}),
 	});
 	testInjector.register("serviceProxy", {
-		setSolutionSpaceName: (tenantId: string) => {/* mock */}
+		makeTapServiceCall: (call: () => IFuture<any>, solutionSpaceHeaderOptions?: {discardSolutionSpaceHeader: boolean}) => {return call();}
 	});
-	testInjector.register("server", {
-		tap: {
-			getExistingClientSolutions: () => {
-				return Future.fromResult(
+
+	testInjector.register("serviceProxyBase", {
+		call: (tenantId: string) => { return Future.fromResult(
 				[{
 					"id": "id2",
 					"name": "Sln2",
+					"type": "Hybrid",
 					"accountId": "accountId",
-					"workspaceId": "workspaceId2",
+					"settings": {},
+					"isMigrating": false,
 					"description": "AppBuilder cross platform project"
 				},
 				{
 					"id": "id1",
 					"name": "Sln1",
+					"type": "Hybrid",
 					"accountId": "accountId",
-					"workspaceId": "workspaceId1",
+					"settings": {},
+					"isMigrating": false,
 					"description": "AppBuilder cross platform project"
 				},
 				{
 					"id": "id3",
 					"name": "Sln3",
+					"type": "Hybrid",
 					"accountId": "accountId",
-					"workspaceId": "workspaceId3",
+					"settings": {},
+					"isMigrating": false,
 					"description": "AppBuilder cross platform project"
 				}]);
+			},
+		setShouldAuthenticate: (shouldAuthenticate: boolean) => false
+	});
+
+	testInjector.register("server", {
+		tap: {
+			getExistingClientSolutions: () => {
+				return Future.fromResult();
 			}
 		},
-		projects: {
-			getSolution: (slnName: string, checkUpgradability: boolean) => {
-				if(slnName === "Sln1") {
+		apps: {
+			getApplication: (slnName: string, checkUpgradability: boolean) => {
+				if(slnName === "id1") {
 					return Future.fromResult({
 						"Name": "Sln1",
 						"Items": [
@@ -156,13 +169,13 @@ function createTestInjector(promptSlnName?: string, promptPrjName?: string, isIn
 						],
 						"IsUpgradeable": false
 					});
-				} else if (slnName === "Sln2") {
+				} else if (slnName === "id2") {
 					return Future.fromResult({
 						"Name": "Sln1",
 						"Items": [],
 						"IsUpgradeable": false
 					});
-				} else if(slnName === "Sln3") {
+				} else if(slnName === "id3") {
 					return Future.fromResult({
 						"Name": "Sln1",
 						"Items": [
@@ -185,10 +198,12 @@ function createTestInjector(promptSlnName?: string, promptPrjName?: string, isIn
 					});
 				}
 			},
-			exportProject: (solutionSpaceName: string, solutionName: string, projectName: string, skipMetadata: boolean, $resultStream: any) => {
+			exportApplication: (solutionName: string, skipMetadata: boolean, $resultStream: any) => {
 				return Future.fromResult();
-			},
-			exportSolution: (solutionSpaceName: string, solutionName: string, skipMetadata: boolean, $resultStream: any) => {
+			}
+		},
+		appsProjects: {
+			exportProject: (solutionName: string, projectName: string, skipMetadata: boolean, $resultStream: any) => {
 				return Future.fromResult();
 			}
 		}

--- a/test/service-util.ts
+++ b/test/service-util.ts
@@ -77,7 +77,7 @@ let httpClient = new MockHttpClient();
 testInjector.register("httpClient", httpClient);
 
 function makeProxy(): Server.IServiceProxy {
-	return testInjector.resolve(ServiceUtil.ServiceProxy);
+	return testInjector.resolve(ServiceUtil.AppBuilderServiceProxy);
 }
 
 describe("ServiceProxy", () => {


### PR DESCRIPTION
Due to changes in Server API, we have to allow exporting of apps and solutions.
In order to get projects from apps, we should call TAP endpoint.
For not migrated projects we should call the old server endpoint.
The export procedure requires calling same endpoint for migrated and not migrated projects.
When exporting old projects (from solutions), we should pass the solution name as appId and send the magic Header in the request.
When exporting new projects (from apps), we should pass real appId and DO NOT send the magic Header.
In order to achieve this, introduce new class - ServiceProxyBase and use it for TAP requests.
Introduce AppBuilderServiceProxy class that extends ServiceProxyBase and register it as "serviceProxy", so we'll keep current behavior for server calls.
Add new method in AppBuilderServiceProxy that allows sending server requests with passing "X-Icenium-SolutionSpace" header.
Add "NOT MIGRATED" string to solutions when they are listed.