### PR TITLE
Fix livesync

### DIFF
--- a/lib/providers/device-app-data-provider.ts
+++ b/lib/providers/device-app-data-provider.ts
@@ -81,7 +81,7 @@ export class AndroidNativeScriptCompanionAppIdentifier extends deviceAppDataBase
 	}
 
 	public get liveSyncFormat(): string {
-		return null;
+		return "%s/Mist/MobilePackage/nsredirect?token=%s";
 	}
 
 	public encodeLiveSyncHostUri(hostUri: string): string {

--- a/lib/services/livesync-service.ts
+++ b/lib/services/livesync-service.ts
@@ -167,16 +167,11 @@ export class AndroidLiveSyncService extends androidLiveSyncServiceLib.AndroidLiv
 
 			this.ensureFullAccessPermissions(liveSyncRoot).wait();
 
-			let commands: string[];
+			let commands = [ this.liveSyncCommands.SyncFilesCommand() ];
 			if(this.$options.watch || this.$options.file) {
-				commands = [ this.liveSyncCommands.SyncFilesCommand(), this.liveSyncCommands.RefreshCurrentViewCommand() ] ;
+				commands.push(this.liveSyncCommands.RefreshCurrentViewCommand());
 			} else {
-				let liveSyncToken = this.$server.cordova.getLiveSyncToken(this.$project.projectData.ProjectName, this.$project.projectData.ProjectName).wait();
-
-				let liveSyncDeviceAppData = (<ILiveSyncDeviceAppData>deviceAppData);
-				let liveSyncUrl = liveSyncDeviceAppData.liveSyncFormat ? util.format(liveSyncDeviceAppData.liveSyncFormat, this.$config.AB_SERVER, liveSyncToken) : this.$project.getLiveSyncUrl();
-
-				commands = [ this.liveSyncCommands.DeployProjectCommand(liveSyncUrl), this.liveSyncCommands.ReloadStartViewCommand() ];
+				commands.push(this.liveSyncCommands.ReloadStartViewCommand());
 			}
 
 			this.createCommandsFileOnDevice(liveSyncRoot, commands).wait();


### PR DESCRIPTION
Includes
+ Fixing for QR code generation for {N} Ion
+ Fix for cable LiveSync for both Cordova and {N}

After this commit every kind of LiveSync works as expected with the following limitation. **When one deploys code directly to any companion app without first scanning a QR code no subsequent cloud LiveSync-ing will work in said companion app.** This limitation comes from the fact that whenever cable LiveSync-ing to a companion app the companion app is only told to get the files and refresh - no livesync url is provided. In order to obtain a LiveSync url on the other hand, one must scan a QR code.

TP Refs: 
+ [Build android --companion generates an invalid QR code](http://teampulse.telerik.com/view#item/304910)
+ [Impossible to cloud livesync if initially cable livesynced](http://teampulse.telerik.com/view#item/305176) <- while this bug is not fixed the behavior between CLI and VSE is balanced out with this fix

Ping @Fatme @rosen-vladimirov @teobugslayer 