### PR TITLE
Show message after successful deploy on android 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "appbuilder",
   "preferGlobal": true,
-  "version": "2.14.0",
+  "version": "3.0.0",
   "author": "Telerik <support@telerik.com>",
   "description": "command line interface to Telerik AppBuilder",
   "bin": {


### PR DESCRIPTION
Get back the message that reports successful deploy on android device. We've deleted it a couple of commits ago.

Set version to 3.0.0