### PR TITLE
Do not show NOT MIGRATED string when user cannot migrate

### DIFF
--- a/test/cloud-projects.ts
+++ b/test/cloud-projects.ts
@@ -128,6 +128,10 @@ function createTestInjector(promptSlnName?: string, promptPrjName?: string, isIn
 		tap: {
 			getExistingClientSolutions: () => {
 				return Future.fromResult();
+			},
+
+			getFeatures: (accountId: string, serviceType: string) => {
+				return Future.fromResult(["projects-to-app"]);
 			}
 		},
 		apps: {

--- a/test/remote-projects-service.ts
+++ b/test/remote-projects-service.ts
@@ -44,6 +44,10 @@ function createTestInjector(): IInjector {
 		tap: {
 			getExistingClientSolutions: () => {
 				return Future.fromResult();
+			},
+
+			getFeatures: (accountId: string, serviceType: string) => {
+				return Future.fromResult(["projects-to-app"]);
 			}
 		},
 		apps: {


### PR DESCRIPTION
In case the user is not allowed to migrate his projects to apps, we shouldn't show NOT MIGRATED string when listing them.
Fixes http://teampulse.telerik.com/view#item/305450