### PR TITLE
Add support for node 5.1.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,14 +37,14 @@
     "colors": "0.6.2",
     "cookie": "0.1.0",
     "express": "4.8.5",
-    "ffi": "https://github.com/icenium/node-ffi/tarball/v2.0.0.0",
-    "fibers": "https://github.com/Icenium/node-fibers/tarball/v1.0.6.2",
+    "ffi": "https://github.com/icenium/node-ffi/tarball/v2.0.0.1",
+    "fibers": "https://github.com/Icenium/node-fibers/tarball/v1.0.6.3",
     "filesize": "2.0.3",
     "gaze": "0.5.1",
     "hex": "0.0.1",
     "iconv-lite": "0.4.3",
     "inquirer": "0.8.2",
-    "ios-sim-portable": "1.0.13-delta",
+    "ios-sim-portable": "1.0.13",
     "ip": "0.3.2",
     "lodash": "3.5.0",
     "log4js": "0.6.9",
@@ -64,8 +64,8 @@
     "properties-parser": "0.2.3",
     "pullstream": "https://github.com/icenium/node-pullstream/tarball/master",
     "qrcode-generator": "1.0.0",
-    "ref": "https://github.com/icenium/ref/tarball/v1.1.3.0",
-    "ref-struct": "https://github.com/telerik/ref-struct/tarball/v1.0.2.0",
+    "ref": "https://github.com/icenium/ref/tarball/v1.1.3.1",
+    "ref-struct": "https://github.com/telerik/ref-struct/tarball/v1.0.2.1",
     "rimraf": "2.2.6",
     "semver": "4.3.4",
     "shelljs": "0.5.1",
@@ -101,6 +101,6 @@
   "bundledDependencies": [],
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=0.10.40 <0.11.0 || >=0.12.7 <0.13.0 || >=4.2.1 <5.0.0"
+    "node": ">=0.10.40 <0.11.0 || >=0.12.7 <0.13.0 || >=4.2.1 <5.0.0 || >=5.1.0 <6.0.0"
   }
 }


### PR DESCRIPTION
Add support for node 5.1.x by updating references to native dependencies.
Add versions between 5.1.x and 6.0.0 as validated (we will not show warning for them).

The main problem with node 4.2.1 and 4.2.2 is that our prompter does not work as expected (arrow keys are not functioning). Node 5.1.0 fixes this behavior.