### PR TITLE
Fix support for node 5.1.0 by updating plugman

### DIFF
--- a/lib/definitions/plugman.d.ts
+++ b/lib/definitions/plugman.d.ts
@@ -1,5 +1,5 @@
 declare module "plugman" {
-	function config(params: string[], callback: (result: any) => void): void;
-	function fetch(plugin_dir:string, plugins_dir:string, link:boolean, subdir:string, git_ref:string, callback: (result: any) => void): void;
-	function search(keywords: string[], callback: (result: any) => void): void;
+	function config(params: string[], callback: (error: Error, result: any) => void): void;
+	function fetch(plugin_dir:string, plugins_dir:string, link:boolean, subdir:string, git_ref:string, callback: (error: Error, result: any) => void): void;
+	function search(keywords: string[], callback: (error: Error, result: any) => void): void;
 }

--- a/lib/services/cordova-plugins.ts
+++ b/lib/services/cordova-plugins.ts
@@ -39,8 +39,8 @@ export class CordovaPluginsService implements ICordovaPluginsService {
 
 	public search(keywords: string[]): IBasicPluginInformation[] {
 		let future = new Future<IBasicPluginInformation[]>();
-		plugman.search(keywords, (result) => {
-			if (this.isError(result)) {
+		plugman.search(keywords, (err: Error, result: any) => {
+			if (err) {
 				future.throw(result);
 			} else {
 				future.return(result);
@@ -59,10 +59,9 @@ export class CordovaPluginsService implements ICordovaPluginsService {
 				if (this.$fs.exists(pluginId).wait() && this.$fs.getFsStats(pluginId).wait().isFile()) {
 					pluginId = this.resolveLocalPluginDir(pluginId).wait();
 				}
-
-				plugman.fetch(pluginId, pluginDir, false, ".", "HEAD", (result) => {
-					if (this.isError(result)) {
-						future.throw(result);
+				plugman.fetch(pluginId, pluginDir, false, ".", "HEAD", (err: Error, result: any) => {
+					if (err) {
+						future.throw(err);
 					} else {
 						future.return("The plugin has been successfully fetched to " + result);
 					}
@@ -105,8 +104,8 @@ export class CordovaPluginsService implements ICordovaPluginsService {
 	public configure(): void {
 		let future = new Future();
 		let params = ["set", "registry", this.$config.CORDOVA_PLUGINS_REGISTRY];
-		plugman.config(params, (result) => {
-			if (this.isError(result)) {
+		plugman.config(params, (error: Error, result: any) => {
+			if (error) {
 				future.throw(result);
 			} else {
 				future.return(result);
@@ -137,10 +136,6 @@ export class CordovaPluginsService implements ICordovaPluginsService {
 		}
 
 		return pluginType;
-	}
-
-	private isError(object:any): boolean {
-		return object instanceof Error;
 	}
 
 	private getPluginsDir(): IFuture<string> {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "osenv": "0.1.0",
     "plist": "1.1.0",
     "plistlib": "0.2.1",
-    "plugman": "0.16.0",
+    "plugman": "1.0.5",
     "progress-stream": "0.5.0",
     "properties-parser": "0.2.3",
     "pullstream": "https://github.com/icenium/node-pullstream/tarball/master",


### PR DESCRIPTION
Fix support for node 5.1.0. Curently the installation is failling because we are using old plugman.
This old plugman depends on very old version of npm. During installation with npm 3.3.11 or later, the plugman fails.
This is a bug in npm itself (https://github.com/npm/npm/issues/10234). However updating our version of plugman is fixing the installation.
The new plugman had change the callback parameters - previously it was one parameter, now it has two - error and result.
Fix our callbacks to have two arguments.