### PR TITLE
Allow plugin fetch by identifier

### DIFF
--- a/lib/services/cordova-plugins.ts
+++ b/lib/services/cordova-plugins.ts
@@ -41,7 +41,7 @@ export class CordovaPluginsService implements ICordovaPluginsService {
 		let future = new Future<IBasicPluginInformation[]>();
 		plugman.search(keywords, (err: Error, result: any) => {
 			if (err) {
-				future.throw(result);
+				future.throw(err);
 			} else {
 				future.return(result);
 			}


### PR DESCRIPTION
Currently plugin fetch is not working when marketplace plugin identifier is passed.
Also it does not work for org.apache.cordova.inappbrowser (looks like the id has been changed, but plugman search still finds the old id, while plugman fetch fails).

Fixes http://teampulse.telerik.com/view#item/306489