### PR TITLE
Fix livesync/deploy to NS companion

### DIFF
--- a/lib/services/livesync-service.ts
+++ b/lib/services/livesync-service.ts
@@ -175,9 +175,7 @@ export class AndroidLiveSyncService extends androidLiveSyncServiceLib.AndroidLiv
 				commands.push(this.liveSyncCommands.ReloadStartViewCommand());
 			}
 
-			this.createCommandsFileOnDevice(liveSyncRoot, commands).wait();
-
-			this.device.adb.sendBroadcastToDevice("com.telerik.LiveSync", { "app-id": deviceAppData.appIdentifier }).wait();
+			this.livesync(deviceAppData.appIdentifier, liveSyncRoot, commands).wait();
 		}).future<void>()();
 	}
 


### PR DESCRIPTION
Result command file should be called `telerik.livesync.commands` instead of `temp.commands.file`
Ping @teobugslayer 
TP Reference: [[CLI][NativeScript] Fail to deploy/livesync to NS companion](http://teampulse.telerik.com/view#item/306613)