### PR TITLE
Make sure CLI works correctly with plugins

### DIFF
--- a/test/plugins-service.ts
+++ b/test/plugins-service.ts
@@ -303,7 +303,8 @@ describe("plugins-service", () => {
 			Versions: [{
 				Identifier: "com.telerik.stripe",
 				Name: "Stripe",
-				Version: "1.0.4"
+				Version: "1.0.4",
+				SupportedVersion: ">=3.5.0"
 			}]
 		}];
 
@@ -471,12 +472,14 @@ describe("plugins-service", () => {
 		let installedMarketplacePlugins = [{
 				Identifier: "com.telerik.stripe",
 				Name: "Stripe",
-				Version: "1.0.4"
+				Version: "1.0.4",
+				SupportedVersion: ">=3.5.0"
 			},
 			{
 				Identifier: "nl.x-services.plugins.toast",
 				Name: "Toast",
-				Version: "2.0.1"
+				Version: "2.0.1",
+				SupportedVersion: ">=3.5.0"
 			}
 		];
 		let availableMarketplacePlugins = [
@@ -486,7 +489,8 @@ describe("plugins-service", () => {
 				Versions: [{
 					Identifier: "com.telerik.stripe",
 					Name: "Stripe",
-					Version: "1.0.4"
+					Version: "1.0.4",
+					SupportedVersion: ">=3.5.0"
 				}]
 			},
 			{
@@ -495,7 +499,8 @@ describe("plugins-service", () => {
 				Versions: [{
 					Identifier: "nl.x-services.plugins.toast",
 					Name: "Toast",
-					Version: "2.0.1"
+					Version: "2.0.1",
+					SupportedVersion: ">=3.5.0"
 				}]
 			}
 		];
@@ -545,7 +550,8 @@ describe("plugins-service", () => {
 				Versions: [{
 					Identifier: "nl.x-services.plugins.toast",
 					Name: "Toast",
-					Version: "2.0.1"
+					Version: "2.0.1",
+					SupportedVersion: ">=3.5.0"
 				}]
 			},
 			{
@@ -554,7 +560,8 @@ describe("plugins-service", () => {
 				Versions: [{
 					Identifier: "com.telerik.stripe",
 					Name: "Stripe",
-					Version: "1.0.4"
+					Version: "1.0.4",
+					SupportedVersion: ">=3.5.0"
 				}]
 			}
 		];
@@ -587,7 +594,8 @@ describe("plugins-service", () => {
 				Versions: [{
 					Identifier: "com.telerik.stripe",
 					Name: "Stripe",
-					Version: "1.0.4"
+					Version: "1.0.4",
+					SupportedVersion: ">=3.5.0"
 				}]
 			}
 		];


### PR DESCRIPTION
When marketplace plugins and core plugins have same identifier, CLI does not work correctly.
Make sure to use the marketplace plugin whenever there's plugin with the same identifier in integrated plugins and in marketplace.
Make sure to remove all plugin instances when changing the version, for example if plugin is enabled from integrated plugins, and you try to update it, we will use the marketplace plugin.
So we will try to add new instance of the plugin in `.<config>.abproject`, for example:
Before:
```JSON
{
    "CorePlugins": [ "com.telerik.feedback"]
}
```

After `appbuilder plugin add com.telerik.feedback` the file should be:
```JSON
{
    "CorePlugins": [ "com.telerik.feedback@<selected_version>"]
}
```

More details for the issue - http://teampulse.telerik.com/view#item/307168