### PR TITLE
Require logger and update to latest common lib

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -1,4 +1,5 @@
 require("./common/bootstrap");
+$injector.require("logger", "./common/logger");
 $injector.require("staticConfig", "./config");
 $injector.require("config", "./config");
 $injector.require("dependencyConfigService", "./services/dependency-config");


### PR DESCRIPTION
`logger` has been required in common lib, but due to some Proton requirements, it should be required from each CLI.
Fix this by adding it to bootstrap and update to latest common lib.