### PR TITLE
Allow autocompletion of lowercased properties

### DIFF
--- a/lib/commands/prop/prop-command-base.ts
+++ b/lib/commands/prop/prop-command-base.ts
@@ -29,7 +29,8 @@ export class ProjectPropertyCommandBase {
 					return range;
 				}
 			} else {
-				return _.keys(this.projectSchema);
+				let properties = _.keys(this.projectSchema);
+				return properties.concat(properties.map(k => k.toLowerCase()));
 			}
 		}
 


### PR DESCRIPTION
In case user is using only lowercased values for properties, autocompletion is not working.
For example `appbuilder prop print core` is not autocompleted to coreplugins.
In fact the command will work with lowercased values, so enable using them.
Add lowercased values to the ones used for autocompletion.
With this change the above will work, but scenarios like `appbuilder prop print cOre` will not be autocompleted anyway.

Fixes http://teampulse.telerik.com/view#item/292405