### PR TITLE
Use plugin variables for NativeScript plugins

### DIFF
--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -711,7 +711,7 @@ interface IBasicPluginInformation {
 	name: string;
 	/**
 	 * The plugin's description
-	 * @type {[type]}
+	 * @type {string}
 	 */
 	description?: string;
 	/**
@@ -719,6 +719,12 @@ interface IBasicPluginInformation {
 	 * @type {string}
 	 */
 	version: string;
+
+	/**
+	 * Variables used by the plugin.
+	 * @type {any[]}
+	 */
+	variables?: any[];
 }
 
 /**


### PR DESCRIPTION
Allow usage of plugin variables of NativeScript plugins. Use `--var` option to pass values, for example:
`appbuilder plugin add plugin-var-plugin --var.APP_NAME test --var.FACEBOOK_APP_ID fb_appid`
For MarketPlace plugins we should use the Variables from Server, but currently it does not return correct info about them. So call registry.npmjs.org to get package.json and get variables info from there.
For plugins from npm, get the info from `registry.npmjs.org`
For local plugins get the info from its package.json.
For plugins passed as URLs get the info from the temp dir where it will be installed.

Use defaultValue specified in plugin for prompter's default value or when console is not interactive.

Implements http://teampulse.telerik.com/view#item/308123