### PR TITLE
Use obsoletedIntegratedPlugins object from cordova.json

### DIFF
--- a/lib/commands/plugin/add-plugin.ts
+++ b/lib/commands/plugin/add-plugin.ts
@@ -34,7 +34,7 @@ export class AddPluginCommand implements ICommand {
 
 					return _.any(installedPlugins, (installedPlugin: IPlugin) => installedPlugin.data.Name === plugin.data.Name);
 				});
-				this.$pluginsService.printPlugins(plugins);
+				this.$pluginsService.printPlugins(this.$pluginsService.filterPlugins(plugins).wait());
 			} else {
 				this.$pluginsService.addPlugin(args[0]).wait();
 			}

--- a/lib/commands/plugin/list-plugin.ts
+++ b/lib/commands/plugin/list-plugin.ts
@@ -8,7 +8,7 @@ export class ListPluginCommand implements ICommand {
 	public execute(args: string[]): IFuture<void> {
 		return (() => {
 			let plugins = this.$options.available ? this.$pluginsService.getAvailablePlugins(this.$options.count) : this.$pluginsService.getInstalledPlugins();
-			this.$pluginsService.printPlugins(plugins);
+			this.$pluginsService.printPlugins(this.$pluginsService.filterPlugins(plugins).wait());
 		}).future<void>()();
 	}
 

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -629,6 +629,13 @@ interface IPluginsService {
 	 * @return {IBasicPluginInformation[]} Array of information for all available plugins matching at least one of the specified keywords.
 	 */
 	findPlugins(keywords: string[]): IFuture<IBasicPluginInformation[]>;
+
+	/**
+	 * Filters plugin based on framework specific rules.
+	 * @param {IPlugin[]} plugins Array of plugins to be filtered.
+	 * @return {IPlugin[]} Plugins that pass the filter.
+	 */
+	filterPlugins(plugins: IPlugin[]): IFuture<IPlugin[]>;
 }
 
 interface IPlugin {

--- a/lib/services/nativescript-project-plugins-service.ts
+++ b/lib/services/nativescript-project-plugins-service.ts
@@ -204,6 +204,10 @@ export class NativeScriptProjectPluginsService implements IPluginsService {
 		}).future<void>()();
 	}
 
+	public filterPlugins(plugins: IPlugin[]): IFuture<IPlugin[]> {
+		return Future.fromResult(plugins);
+	}
+
 	private marketplacePlugins: IPlugin[];
 	private getMarketplacePlugins(): IFuture<IPlugin[]> {
 		return ((): IPlugin[] => {
@@ -337,7 +341,8 @@ export class NativeScriptProjectPluginsService implements IPluginsService {
 	private getDataForNpmPackage(packageName: string, version?: string): IFuture<IPlugin> {
 		return ((): IPlugin => {
 			try {
-				let url = NativeScriptProjectPluginsService.buildNpmRegistryUrl(packageName, version || "latest");
+				version = version || "latest";
+				let url = NativeScriptProjectPluginsService.buildNpmRegistryUrl(packageName, version);
 
 				// This call will return error with message '{}' in case there's no such package.
 				let result = this.$httpClient.httpRequest(url).wait().body;

--- a/lib/services/plugins-service.ts
+++ b/lib/services/plugins-service.ts
@@ -56,6 +56,10 @@ export class PluginsService implements IPluginsService {
 		}).future<void>()();
 	}
 
+	public filterPlugins(plugins: IPlugin[]): IFuture<IPlugin[]> {
+		return this.getPluginsService().wait().filterPlugins(plugins);
+	}
+
 	private getPluginsService(): IFuture<IPluginsService> {
 		return ((): IPluginsService => {
 			if(!this.frameworkProject) {


### PR DESCRIPTION
Use the new `obsoletedIntegratedPlugins` object when:
* adding plugin - any integrated plugin that you try to add and has been obsoleted by marketplace plugin will be treated as its marketplace value. For example `appbuilder plugin add com.telerik.plugin.eqatecanalytics` will add `com.telerik.plugin.telerikanalytics` plugin.
* removing plugin - this operation will remove both plugins (in case somehow you have them) - the integrated one and its marketplace friend
* adding marketplace plugin - when adding marketplace plugin that obsoletes integrated plugin, the operation will remove the integrated one.

Add new method to pluginsService in order to filter obsoleted plugins when printing them.

Fix an issue in nativescipt-project-plugins-service where plugin's version is not printed correctly when error is raised.

http://teampulse.telerik.com/view#item/306646