### PR TITLE
Fix compilation of NS TypeScript projects

### DIFF
--- a/lib/hooks/typescript-compilation.ts
+++ b/lib/hooks/typescript-compilation.ts
@@ -2,16 +2,22 @@
 "use strict";
 
 require("./../bootstrap");
+import * as path from "path";
 import fiberBootstrap = require("./../common/fiber-bootstrap");
 fiberBootstrap.run(() => {
 	$injector.require("typeScriptCompilationService", "./common/services/typescript-compilation-service");
 	let project: Project.IProject = $injector.resolve("project");
 	project.ensureProject();
-
 	let typeScriptFiles = project.getTypeScriptFiles().wait();
 	if(typeScriptFiles.typeScriptFiles.length > typeScriptFiles.definitionFiles.length) { // We need this check because some of non-typescript templates(for example KendoUI.Strip) contain typescript definition files
-		let typeScriptCompilationService = $injector.resolve("typeScriptCompilationService");
-		typeScriptCompilationService.initialize(typeScriptFiles.typeScriptFiles, typeScriptFiles.definitionFiles);
-		typeScriptCompilationService.compileAllFiles().wait();
+		let typeScriptCompilationService: ITypeScriptCompilationService = $injector.resolve("typeScriptCompilationService");
+		let $fs: IFileSystem = $injector.resolve("fs");
+		let pathToTsConfig = path.join(project.getProjectDir().wait(), "tsconfig.json");
+		if($fs.exists(pathToTsConfig).wait()) {
+			let json = $fs.readJson(pathToTsConfig).wait();
+			typeScriptCompilationService.compileWithDefaultOptions({ noEmitOnError: !!(json && json.compilerOptions && json.compilerOptions.noEmitOnError) }).wait();
+		} else {
+			typeScriptCompilationService.compileFiles({ noEmitOnError: false }, typeScriptFiles.typeScriptFiles, typeScriptFiles.definitionFiles).wait();
+		}
 	}
 });

--- a/lib/project.ts
+++ b/lib/project.ts
@@ -642,7 +642,11 @@ export class Project implements Project.IProject {
 
 	public getTypeScriptFiles(): IFuture<Project.ITypeScriptFiles> {
 		return ((): Project.ITypeScriptFiles => {
-			let projectFiles = this.$fs.enumerateFilesInDirectorySync(this.getProjectDir().wait());
+			let projectDir = this.getProjectDir().wait();
+			// Skip root's node_modules
+			let rootNodeModules = path.join(projectDir, "node_modules");
+			let projectFiles = this.$fs.enumerateFilesInDirectorySync(projectDir,
+																		(fileName: string, fstat: IFsStats) => fileName !== rootNodeModules);
 			let typeScriptFiles = _.filter(projectFiles, file => path.extname(file) === ".ts");
 			let definitionFiles = _.filter(typeScriptFiles, file => _.endsWith(file, ".d.ts"));
 			return { definitionFiles: definitionFiles, typeScriptFiles: typeScriptFiles };


### PR DESCRIPTION
When for NS TypeScript project user had called `npm install`, there are `*.d.ts` files inside `node_modules`.
But we also have definition files in `typings` directory, so the compilation fails.
Fix this by skipping `node_modules` dir when checking for `.ts` files. We do not want to compile files from `node_modules` dir.
Also add check if `tsconfig.json` exists to use it and just spawn tsc as all user options specified in tsconfig.json MUST be respected.

Fixes http://teampulse.telerik.com/view#item/306751