### PR TITLE
Fix plugins list for obosleted plugins

### DIFF
--- a/lib/services/cordova-project-plugins-service.ts
+++ b/lib/services/cordova-project-plugins-service.ts
@@ -335,7 +335,7 @@ export class CordovaProjectPluginsService implements IPluginsService {
 	public filterPlugins(plugins: IPlugin[]): IFuture<IPlugin[]> {
 		return ((): IPlugin[] => {
 			let obsoletedIntegratedPlugins = _.keys(this.getObsoletedIntegratedPlugins().wait()).map(pluginId => pluginId.toLowerCase());
-			return _.filter(plugins, pl => !_.any(obsoletedIntegratedPlugins, obsoletedId => obsoletedId === pl.data.Identifier.toLowerCase()));
+			return _.filter(plugins, pl => !_.any(obsoletedIntegratedPlugins, obsoletedId => obsoletedId === pl.data.Identifier.toLowerCase() && pl.type !== PluginType.MarketplacePlugin));
 		}).future<IPlugin[]>()();
 	}
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "appbuilder",
   "preferGlobal": true,
-  "version": "3.0.0",
+  "version": "3.1.0",
   "author": "Telerik <support@telerik.com>",
   "description": "command line interface to Telerik AppBuilder",
   "bin": {


### PR DESCRIPTION
When we have obsoleted plugin with the same identifier as its marketplace replacement, current code filters it.
For example in case you add `com.telerik.feedback` and execute `appbuilder plugin`, it will not be listed.
Filter only items where the replacement id is not the same as integrated plugin's id.