### PR TITLE
Fix getting information for some nativescript plugins

### DIFF
--- a/lib/services/nativescript-project-plugins-service.ts
+++ b/lib/services/nativescript-project-plugins-service.ts
@@ -405,7 +405,7 @@ export class NativeScriptProjectPluginsService implements IPluginsService {
 				Name: jsonResult.name,
 				Identifier: jsonResult.name,
 				Version: jsonResult.version,
-				Url: jsonResult.repository.url || jsonResult.homepage,
+				Url: (jsonResult.repository && jsonResult.repository.url) || jsonResult.homepage || '',
 				Platforms: platforms,
 				Description: jsonResult.description,
 				SupportedVersion: supportedVersion


### PR DESCRIPTION
Fix getting information for nativescript plugins, which do not have `repository` property in `package.json`.
Try adding `plugin-var-plugin` and executing `appbuilder plugin` after that. Error is raised because the plugin does not have repository property and we are trying to get repository.url.

No regression potential.