### PR TITLE
Print information about plugin variables

### DIFF
--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -648,6 +648,30 @@ interface IPlugin {
 }
 
 /**
+ * Describes information about one plugin variable.
+ * In NativeScript project the variable is described in plugin's package.json with name and object as value.
+ * @example
+ * {
+ *    "name": "my-plugin",
+ *    "version": "1.0.0",
+ *    "nativescript": {
+ *        "variables": {
+ *           "my-var": {
+ *              "default": "defaultValue"
+ *           }
+ *        }
+ *    }
+ * }
+ */
+interface INativeScriptPluginVariable {
+	/**
+	 * The default value of the variable that will be used in case user does not specify value for the variable.
+	 * @optional
+	 */
+	defaultValue?: string;
+}
+
+/**
  * Describes basic information for each plugin.
  */
 interface IPluginInfoBase {
@@ -690,6 +714,11 @@ interface IPluginInfoBase {
 	 * Plugin specific identifier. It can differ from plugin's name.
 	 */
 	Identifier: string;
+
+	/**
+	 * Variables that have to be set in the application in order to be able to use the plugin correctly.
+	 */
+	Variables?: string[]|IDictionary<INativeScriptPluginVariable>;
 }
 
 interface IPluginVersion {
@@ -802,11 +831,6 @@ interface IMarketplacePluginData extends IPluginInfoBase {
 	 * in order to use the plugin.
 	 */
 	AndroidRequiredPermissions?: string[];
-
-	/**
-	 * Variables, that have to be set in the application in order to be able to use the plugin correctly.
-	 */
-	Variables: string[];
 }
 
 interface IMarketplacePlugin extends IPlugin {

--- a/lib/plugins-data.ts
+++ b/lib/plugins-data.ts
@@ -55,24 +55,51 @@ export class CordovaPluginData implements IPlugin {
 
 	private getPluginVariablesInfo(): string[] {
 		let result: string[] = [];
-		_.each(this.configurations, (configuration: string) => {
-			let pluginVariablesData = this.$project.getProperty(this.$projectConstants.CORDOVA_PLUGIN_VARIABLES_PROPERTY_NAME, configuration);
+		if(this.configurations && this.configurations.length) {
+			_.each(this.configurations, (configuration: string) => {
+				let info = this.getPluginVarsStringInformation(configuration).wait();
+				result.push(...info);
+			});
+		} else {
+			let info = this.getPluginVarsStringInformation().wait();
+			result.push(...info);
+		}
+
+		return result;
+	}
+
+	private getPluginVarsStringInformation(configuration?: string): IFuture<string[]> {
+		return ((): string[] => {
+			let result: string[] = [];
+			let configString = configuration ? ` for ${configuration} configuration` : "";
+			let pluginVariablesData = this.$project.getPluginVariablesInfo(configuration).wait();
 			if(pluginVariablesData && pluginVariablesData[this.data.Identifier]) {
 				let variables = pluginVariablesData[this.data.Identifier];
 				let variableNames = _.keys(variables);
 				if(variableNames.length > 0) {
 					let output:string[] = [];
-					output.push(util.format("    Variables for %s configuration:", configuration));
+					output.push(`    Variables${configString}:`);
 					_.each(variableNames, (variableName:string) => {
 						output.push(util.format("        %s: %s", variableName, variables[variableName]));
 					});
 
 					result.push(output.join(EOL));
 				}
+			} else {
+				if(this.data.Variables) {
+					// We should never get here with anything that is not array, but anyway, lets assure we'll not throw some unexpected error.
+					if(_.isArray(this.data.Variables) && (<string[]>this.data.Variables).length) {
+						// cordova or marketplace plugins
+						result.push(`    Variables${configString}: ${(<string[]>this.data.Variables).join(", ")}`);
+					} else if(_.keys(this.data.Variables).length) {
+						// nativescript
+						result.push(`    Variables${configString}: ${_.keys(this.data.Variables).join(", ")}`);
+					}
+				}
 			}
-		});
 
-		return result;
+			return result;
+		}).future<string[]>()();
 	}
 }
 

--- a/lib/project.ts
+++ b/lib/project.ts
@@ -70,6 +70,12 @@ export class Project implements Project.IProject {
 		return this.frameworkProject.startPackageActivity;
 	}
 
+	public getPluginVariablesInfo(configuration?: string): IFuture<IDictionary<IStringDictionary>> {
+		return (() => {
+			return this.frameworkProject.getPluginVariablesInfo(this.projectInformation, this.getProjectDir().wait(), configuration).wait();
+		}).future<IDictionary<IStringDictionary>>()();
+	}
+
 	public getProjectTargets(): IFuture<string[]> {
 		return (() => {
 			let projectDir = this.getProjectDir().wait();

--- a/lib/project/cordova-project.ts
+++ b/lib/project/cordova-project.ts
@@ -96,6 +96,12 @@ export class CordovaProject extends frameworkProjectBaseLib.FrameworkProjectBase
 		return this.$jsonSchemaConstants.CORDOVA_VERSION_3_SCHEMA_ID;
 	}
 
+	public getPluginVariablesInfo(projectInformation: Project.IProjectInformation, projectDir?: string, configuration?: string): IFuture<IDictionary<IStringDictionary>> {
+		return (() => {
+			return this.getProperty(this.$projectConstants.CORDOVA_PLUGIN_VARIABLES_PROPERTY_NAME, configuration, projectInformation);
+		}).future<IDictionary<IStringDictionary>>()();
+	}
+
 	public getProjectTargets(projectDir: string): IFuture<string[]> {
 		let fileMask = /^cordova\.(\w*)\.js$/i;
 		return this.getProjectTargetsBase(projectDir, fileMask);

--- a/lib/project/framework-project-base.ts
+++ b/lib/project/framework-project-base.ts
@@ -54,7 +54,6 @@ export class FrameworkProjectBase implements Project.IFrameworkProjectBase {
 
 	public getProperty(propertyName: string, configuration: string, projectInformation: Project.IProjectInformation): any {
 		let propertyValue: any = null;
-
 		let configData = projectInformation.configurationSpecificData[configuration];
 		if(configData && configData[propertyName]) {
 			propertyValue = configData[propertyName];

--- a/lib/project/nativescript-project.ts
+++ b/lib/project/nativescript-project.ts
@@ -159,5 +159,27 @@ export class NativeScriptProject extends frameworkProjectBaseLib.FrameworkProjec
 
 		return updated;
 	}
+
+	public getPluginVariablesInfo(projectInformation: Project.IProjectInformation, projectDir?: string, configuration?: string): IFuture<IDictionary<IStringDictionary>> {
+		return (() => {
+			let packageJsonContent = this.$fs.readJson(path.join(projectDir, this.$projectConstants.PACKAGE_JSON_NAME)).wait();
+			let nativescript = packageJsonContent && packageJsonContent.nativescript;
+			let dependencies = packageJsonContent && packageJsonContent.dependencies;
+			if(nativescript && dependencies) {
+				let pluginsVariables: IStringDictionary = {};
+				_.keys(dependencies).forEach(dependency => {
+					let variablesKey = `${dependency}-variables`;
+					let variables = nativescript[variablesKey];
+					if(variables) {
+						pluginsVariables[dependency] = variables;
+					}
+				});
+
+				return pluginsVariables;
+			}
+
+			return null;
+		}).future<IDictionary<IStringDictionary>>()();
+	}
 }
 $injector.register("nativeScriptProject", NativeScriptProject);

--- a/lib/project/project.d.ts
+++ b/lib/project/project.d.ts
@@ -43,9 +43,9 @@ declare module Project {
 		 */
 		checkSdkVersions(platform: string): void;
 		/**
-		* Checks if the project language is TypeScript by enumerating all files and checking if there are at least one TypeScript file (.ts), that is not definition file(.d.ts)
-		* @return {IFuture<boolean>} true when the project contains .ts files and false otherwise.
-		*/
+		 * Checks if the project language is TypeScript by enumerating all files and checking if there are at least one TypeScript file (.ts), that is not definition file(.d.ts)
+		 * @return {IFuture<boolean>} true when the project contains .ts files and false otherwise.
+		 */
 		isTypeScriptProject(): IFuture<boolean>;
 
 		/**
@@ -58,6 +58,23 @@ declare module Project {
 		 * @return {IFuture<string>} The path to the App_Resources folder
 		 */
 		appResourcesPath(): IFuture<string>;
+
+		/**
+		 * Get information about plugin variables for current project.
+		 * @param {string} configuration Optional parameter that is specified the configuration for which plugin variables info will be returned.
+		 * @return {IFuture<IDictionary<IStringDictionary>>} Information about all plugins, their plugin variables and values of the variables.
+		 * @example
+		 * {
+		 *    "plugin1": {
+		 *       "variable1": "value1",
+		 *       "variable2": "value2",
+		 *    },
+		 *    "plugin2": {
+		 *       "variable3": "value3"
+		 *    }
+		 * }
+		 */
+		getPluginVariablesInfo(configuration?: string): IFuture<IDictionary<IStringDictionary>>;
 	}
 
 	interface IFrameworkProject {
@@ -95,6 +112,25 @@ declare module Project {
 		 * @param {IProjectData} projectData The project's data, needed to check an SDK version
 		 */
 		checkSdkVersions(platform: string, projectData: IProjectData): void;
+		/**
+		 * Get information about plugin variables for current project.
+		 * @param {Project.IProjectInformation} projectInformation Information about the project - values of properties from .abproject and configuration specific .abproject.
+		 * @param {string} projectDir Optional parameter that specifies the project directory. Required for NativeScript projects.
+		 * @param {string} configuration Optional parameter that is specified the configuration for which plugin variables info will be returned. Required for Cordova projects.
+		 * @return {IFuture<IDictionary<IStringDictionary>>} Information about all plugins, their plugin variables and values of the variables.
+		 * For NativeScript projects the values are taken from package.json. For Cordova project the information is read from .abproject (configuration specific .abproject).
+		 * @example
+		 * {
+		 *    "plugin1": {
+		 *       "variable1": "value1",
+		 *       "variable2": "value2",
+		 *    },
+		 *    "plugin2": {
+		 *       "variable3": "value3"
+		 *    }
+		 * }
+		 */
+		getPluginVariablesInfo(projectInformation: Project.IProjectInformation, projectDir?: string, configuration?: string): IFuture<IDictionary<IStringDictionary>>;
 	}
 
 	interface IFrameworkProjectBase {

--- a/lib/services/cordova-project-plugins-service.ts
+++ b/lib/services/cordova-project-plugins-service.ts
@@ -377,7 +377,7 @@ export class CordovaProjectPluginsService implements IPluginsService {
 			let pluginData = <IMarketplacePluginData>plugin.data;
 			let cordovaPluginVariables = this.$project.getProperty(CordovaProjectPluginsService.CORDOVA_PLUGIN_VARIABLES_PROPERTY_NAME, configuration) || {};
 
-			let variables = pluginData.Variables;
+			let variables = <string[]>pluginData.Variables;
 			if(variables && variables.length > 0) {
 				if(!cordovaPluginVariables[pluginData.Identifier]) {
 					cordovaPluginVariables[pluginData.Identifier] = {};
@@ -422,7 +422,7 @@ export class CordovaProjectPluginsService implements IPluginsService {
 			let cordovaPluginVariables = this.$project.getProperty(CordovaProjectPluginsService.CORDOVA_PLUGIN_VARIABLES_PROPERTY_NAME, configuration);
 
 			if (cordovaPluginVariables && _.keys(cordovaPluginVariables[pluginData.Identifier]).length > 0) {
-				_.each(pluginData.Variables, variableName => {
+				_.each(pluginData.Variables, (variableName: string) => {
 					delete cordovaPluginVariables[pluginData.Identifier][variableName];
 				});
 			}

--- a/lib/services/nativescript-project-plugins-service.ts
+++ b/lib/services/nativescript-project-plugins-service.ts
@@ -280,6 +280,7 @@ export class NativeScriptProjectPluginsService implements IPluginsService {
 								Description: this.getStringFromNpmSearchResult(pluginResult, "description"),
 								SupportedVersion: ""
 							};
+							pluginInfo.Variables = this.getPluginVariablesInfoFromNpm(pluginInfo.Name, pluginInfo.Version).wait() || [];
 
 							return new NativeScriptPluginData(pluginInfo, PluginType.NpmPlugin, this.$project);
 						}
@@ -408,7 +409,8 @@ export class NativeScriptProjectPluginsService implements IPluginsService {
 				Url: (jsonResult.repository && jsonResult.repository.url) || jsonResult.homepage || '',
 				Platforms: platforms,
 				Description: jsonResult.description,
-				SupportedVersion: supportedVersion
+				SupportedVersion: supportedVersion,
+				Variables: jsonResult.nativescript && jsonResult.nativescript.variables
 			};
 
 			return new NativeScriptPluginData(data, type, this.$project);
@@ -755,6 +757,19 @@ export class NativeScriptPluginData implements IPlugin {
 
 		if(this.configurations && this.configurations.length > 0) {
 			result.push(util.format("    Configuration: %s", this.configurations.join(", ")));
+		}
+
+		if(this.data.Variables && _.keys(this.data.Variables).length) {
+			let varInfo = this.$project.getPluginVariablesInfo().wait();
+			if(varInfo && varInfo[this.data.Identifier]) {
+				result.push("    Variables:");
+				_.each(varInfo[this.data.Identifier], (variableValue: any, variableName:string) => {
+					result.push(`        ${variableName}: ${variableValue}`);
+				});
+			} else {
+				let variables = _.keys(this.data.Variables).join(", ");
+				result.push(`    Variables: ${variables}`);
+			}
 		}
 
 		return result;

--- a/test/project-properties-service.ts
+++ b/test/project-properties-service.ts
@@ -67,6 +67,9 @@ class SampleProject implements Project.IFrameworkProject {
 		return Future.fromResult();
 	}
 	pluginsService: IPluginsService;
+	getPluginVariablesInfo(projectInformation: Project.IProjectInformation, projectDir?: string, configuration?: string): IFuture<IDictionary<IStringDictionary>> {
+		return Future.fromResult(null);
+	}
 }
 
 describe("projectPropertiesService", () => {

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -375,6 +375,10 @@ class FrameworkProjectStub implements Project.IFrameworkProject {
 	public completeProjectProperties(properties: any): boolean { return false; }
 
 	public pluginsService: IPluginsService;
+
+	public getPluginVariablesInfo(projectInformation: Project.IProjectInformation, projectDir?: string, configuration?: string): IFuture<IDictionary<IStringDictionary>> {
+		return Future.fromResult(null);
+	}
 }
 
 export class ProjectFilesManager implements IProjectFilesManager {


### PR DESCRIPTION
Print information about nativescript plugin variables.
Print the values when plugin is already added (`appbuilder plugin` command and when lisiting available plugins: `appbuilder plugin --available`).
Print plugins variables when listing available plugins (valid for Cordova and {N} Plugins) - even when plugin is not added, we know which are the required varialbes, show them to the user.