### PR TITLE
Fix help for plugin commands

### DIFF
--- a/docs/man_pages/lib-management/plugin-add.md
+++ b/docs/man_pages/lib-management/plugin-add.md
@@ -27,22 +27,28 @@ List custom npm or NativeScript modules | `$ appbuilder plugin add --available [
 Add custom npm or NativeScript modules | `$ appbuilder plugin add <Name or ID>`
 Add a specific version of a custom npm or NativeScript module | `$ appbuilder plugin add <Name or ID>@<Version>`
 Add a custom npm or NativeScript module from GitHub URL | `$ appbuilder plugin add <URL>`
-Add a custom npm or NativeScript module from local path | `$ appbuilder plugin add <Path>` 
+Add a custom npm or NativeScript module from local path | `$ appbuilder plugin add <Path>`
+Add custom npm or NativeScript module and set all variables from the command line | `$ appbuilder plugin add <Name or ID or URL or Path> --var.<Variable ID> <Variable Value>`[\*\*](#note)
+Add a specific version of a custom npm or NativeScript module and set all variables from the command line | `$ appbuilder plugin add <Name or ID>@<Version> --var.<Variable ID> <Variable Value>`[\*\*](#note)
+
+<% if(isHtml) { %><a id="note"></a><% } %>
+\*\* If the NativeScript plugin has multiple variables, you can set `--var` for each variable.
 <% } %>
 
 <% var plugins =""; if(isCordova) { plugins+="Apache Cordova plugins" } if(isHtml) { plugins+=" or " } if(isNativeScript) { plugins+="custom npm or NativeScript modules" } %>
 
 <% var plugin =""; if(isCordova) { plugin+="Apache Cordova plugin" } if(isHtml) { plugin+=" or " } if(isNativeScript) { plugin+="custom npm or NativeScript module" } %>
 
-Enables <%=plugins%> for your project. <% if(isHtml) { %>If the Apache Cordova plugin has plugin variables and you have not set one or more of them with `--var`, the Telerik AppBuilder CLI shows an interactive prompt to let you set their values.<% } %>
+Enables <%=plugins%> for your project. <% if(isHtml) { %>If the plugin has plugin variables and you have not set one or more of them with `--var`, the Telerik AppBuilder CLI shows an interactive prompt to let you set their values.<% } %>
 <% if((isConsole && (isCordova || isNativeScript)) || isHtml) { %>
 ### Options
 * `--available` - Lists all <%=plugins%> that you can enable in your project.
+* `--var.<Variable ID>` - Sets the value for the specified plugin variable in all configurations.
+	<% if(isHtml) { %><br /><% } %><% if(isCordova) { %>(Apache Cordova-only) If `--debug` or `--release` is specified, sets the variable for the respective configuration of the hybrid project.<% } %>
 <% if(isCordova) {%>* `--latest` - Enables the latest version of the specified Apache Cordova plugin.<% if(isHtml) { %> This option is applicable only to Apache Cordova projects.<% } %>
 * `--default` - Enables the default version of the specified Apache Cordova plugin.<% if(isHtml) { %> This option is applicable only to Apache Cordova projects.<% } %>
 * `--debug` - Enables the specified Apache Cordova plugin for the Debug build configuration only. If `--available` is set, lists all plugins that you can enable for the Debug build configuration.<% if(isHtml) { %> This option is applicable only to Apache Cordova projects.<% } %>
 * `--release` - Enables the specified Apache Cordova plugin for the Release build configuration only. If `--available` is set, lists all plugins that you can enable for the Release build configuration.<% if(isHtml) { %> This option is applicable only to Apache Cordova projects.<% } %>
-* `--var.<Variable ID>` - Sets the value for the specified Apache Cordova plugin variable in all configurations. If `--debug` or `--release` is specified, sets the variable for the respective configuration only.<% if(isHtml) { %> This option is applicable only to Apache Cordova projects.<% } %>
 * `--var.debug.<Variable ID>` - Sets the value for the specified Apache Cordova plugin variable for the Debug configuration only.<% if(isHtml) { %> This option is applicable only to Apache Cordova projects.<% } %>
 * `--var.release.<Variable ID>` - Sets the value for the specified Apache Cordova plugin variable for the Release configuration only.<% if(isHtml) { %> This option is applicable only to Apache Cordova projects.<% } %><% } %>
 <% if(isNativeScript) { %>* `--count` - When set along with `--available`, specifies the number of npm and NativeScript modules that will be listed.<% if(isHtml) { %> This option is applicable only to NativeScript projects.<% } %><% } %>

--- a/docs/man_pages/lib-management/plugin-configure.md
+++ b/docs/man_pages/lib-management/plugin-configure.md
@@ -5,32 +5,48 @@ Usage | Synopsis
 ------|-------
 Call the interactive prompt to set plugin variables | `$ appbuilder plugin configure <Name or ID> [--debug] [--release]`
 Set one value for all applicable configurations | `$ appbuilder plugin configure <Name or ID> [--debug] [--release] --var.<Variable ID> <Variable Value>`[\*\*](#note)
-Set different values for all configurations | `$ appbuilder plugin configure <Name or ID> --var.debug.<Variable ID> <Variable Value> --var.release.<Variable ID> <Variable Value>]*>]`[\*\*](#note)
+<% if(isCordova) { %>Set different values for all configurations | `$ appbuilder plugin configure <Name or ID> --var.debug.<Variable ID> <Variable Value> --var.release.<Variable ID> <Variable Value>]*>]`[\*\*\*](#cordovaNote)<% } %>
 
 <% var plugins =""; if(isCordova) { plugins+="Apache Cordova plugins" } if(isHtml) { plugins+=" or " } if(isNativeScript) { plugins+="custom npm or NativeScript modules" } %>
 
 <% if(isHtml) { %><a id="note"></a><% } %>
 \*\* If the plugin has multiple variables, you can set `--var` for each variable.
+<% if (isCordova) { %>
+<% if(isHtml) { %><a id="cordovaNote"></a><% } %>
+\*\*\* This command is available only for Apache Cordova plugins. If the plugin has multiple variables, you can set `--var` for each variable.
+<% } %>
 
-Configures plugin variables for the selected core, integrated or verified plugin.<% if(isHtml) { %>If you have not set one or more of the plugin variables with `--var`, the Telerik AppBuilder CLI shows an interactive prompt to let you set their values.<% } %>
-<% if(isConsole) { %>
-<% if(isNativeScript) { %>
-WARNING: This command is not applicable to NativeScript projects. To view the complete help for this command, run `$ appbuilder help plugin configure`
-<% } %>
-<% } %>
-<% if((isConsole && isCordova) || isHtml) { %>
+Configures plugin variables for the selected plugin.<% if(isHtml) { %>If you have not set one or more of the plugin variables with `--var`, the Telerik AppBuilder CLI shows an interactive prompt to let you set their values.<% } %>
+
+
 ### Options
+* `--var.<Variable ID>` - Sets the value for the specified plugin variable in all configurations. <% if(isCordova) { %>If `--debug` or `--release` is specified, sets the variable for the respective configuration only, if the plugin is already enabled for this configuration. <% } %>
+<% if((isConsole && isCordova) || isHtml) { %>
 * `--debug` - Sets the plugin variable for the Debug build configuration only. The plugin must be enabled for the specified configuration.
 * `--release` - Sets the plugin variable for the Release build configuration only. The plugin must be enabled for the specified configuration.
-* `--var.<Variable ID>` - Sets the value for the specified plugin variable in all configurations. If `--debug` or `--release` is specified, sets the variable for the respective configuration only, if the plugin is already enabled for this configuration.
 * `--var.debug.<Variable ID>` - Sets the value for the specified plugin variable for the Debug configuration only. The plugin must be enabled for the specified configuration.
 * `--var.release.<Variable ID>` - Sets the value for the specified plugin variable for the Release configuration only. The plugin must be enabled for the specified configuration.
+<% } %>
 
+<%
+	var configFileName = "";
+	if(isCordova) {
+		configFileName = "`plugin.xml`";
+	}
+
+	if(isCordova && isNativeScript) {
+		// In html help or outside of project.
+		configFileName += " or ";
+	}
+
+	if(isNativeScript) {
+		configFileName += "`package.json`";
+	}
+%>
 ### Attributes
 * `<Name or ID>` is the name or ID of the plugin as listed by `$ appbuilder plugin`
-* `<Variable ID>` is the plugin variable as listed in the `plugin.xml` of the plugin.
+* `<Variable ID>` is the plugin variable as listed in the <%= configFileName %> of the plugin.
 
-<% } %>
 <% if(isHtml) { %>
 ### Command Limitations
 

--- a/docs/man_pages/lib-management/plugin.md
+++ b/docs/man_pages/lib-management/plugin.md
@@ -21,7 +21,7 @@ Lists all <%=plugins%> that are currently enabled for your project. <% if(isHtml
 ### Attributes
 `<Command>` extends the `plugin` command. You can set the following values for this attribute.
 * `add` - Enables <%=plugins%> for your project.
-<% if(isCordova) { %>* `configure` - Configures plugin variables for the selected plugin.<% if(isHtml) { %> This command is applicable only to Apache Cordova projects.<% } %><% } %>
+* `configure` - Configures plugin variables for the selected plugin.
 * `remove` - Disables <%=plugins%> for your project.
 * `find` - Searches by keyword for <%=plugins%>.
 * `fetch` - Imports the selected <%=plugins%> into your project.


### PR DESCRIPTION
Fix the help for plugin commands in order to show that `plugin configure` works for NativeScript projects and you can use `--var` for NS Plugins.