### PR TITLE
Fix livesync --watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "appbuilder",
   "preferGlobal": true,
-  "version": "3.1.0",
+  "version": "3.1.1",
   "author": "Telerik <support@telerik.com>",
   "description": "command line interface to Telerik AppBuilder",
   "bin": {


### PR DESCRIPTION
`appbuilder livesync --watch` fails with error when file is saved. The problem is in code used for NS CLI, which returns null instead of future.