### PR TITLE
Fix overwriting DisplayName when iOSDisplayName is present and empty

### DIFF
--- a/lib/project/cordova-project.ts
+++ b/lib/project/cordova-project.ts
@@ -3,11 +3,11 @@
 
 import * as path from "path";
 import * as util from "util";
-import frameworkProjectBaseLib = require("./framework-project-base");
+import {FrameworkProjectBase} from "./framework-project-base";
 import helpers = require("./../common/helpers");
 import semver = require("semver");
 
-export class CordovaProject extends frameworkProjectBaseLib.FrameworkProjectBase implements Project.IFrameworkProject {
+export class CordovaProject extends FrameworkProjectBase implements Project.IFrameworkProject {
 	private static WP8_DEFAULT_PACKAGE_IDENTITY_NAME_PREFIX = "1234Telerik";
 	private static WP8_DEFAULT_WP8_WINDOWS_PUBLISHER_NAME = "CN=Telerik";
 
@@ -192,25 +192,8 @@ export class CordovaProject extends frameworkProjectBaseLib.FrameworkProjectBase
 	}
 
 	public completeProjectProperties(properties: any): boolean {
-		let updated = false;
-
-		if (_.has(properties, "name")) {
-			properties.ProjectName = properties.name;
-			delete properties.name;
-			updated = true;
-		}
-
-		if (_.has(properties, "iOSDisplayName")) {
-			properties.DisplayName = properties.iOSDisplayName;
-			delete properties.iOSDisplayName;
-			updated = true;
-		}
-		if (!properties.DisplayName) {
-			properties.DisplayName = properties.ProjectName;
-			updated = true;
-		}
-
-		["WP8PublisherID", "WP8ProductID"].forEach((wp8guid) => {
+		let updated = super.completeProjectProperties(properties);
+		["WP8PublisherID", "WP8ProductID"].forEach(wp8guid => {
 			if (!_.has(properties, wp8guid) || properties[wp8guid] === "") {
 				properties[wp8guid] = this.generateWP8GUID();
 				updated = true;

--- a/lib/project/framework-project-base.ts
+++ b/lib/project/framework-project-base.ts
@@ -64,6 +64,28 @@ export class FrameworkProjectBase implements Project.IFrameworkProjectBase {
 		return propertyValue;
 	}
 
+	public completeProjectProperties(properties: any): boolean {
+		let updated = false;
+
+		if (_.has(properties, "name")) {
+			properties.ProjectName = properties.name;
+			delete properties.name;
+			updated = true;
+		}
+
+		if (!properties.DisplayName) {
+			properties.DisplayName = properties.iOSDisplayName ? properties.iOSDisplayName : properties.ProjectName;
+			updated = true;
+		}
+
+		if (_.has(properties, "iOSDisplayName")) {
+			delete properties.iOSDisplayName;
+			updated = true;
+		}
+
+		return updated;
+	}
+
 	private generateDefaultAppId(appName: string): string {
 		let sanitizedName = _.filter(appName.split(""), c => /[a-zA-Z0-9]/.test(c)).join("");
 		if(sanitizedName) {

--- a/lib/project/nativescript-project.ts
+++ b/lib/project/nativescript-project.ts
@@ -4,10 +4,10 @@
 import * as path from "path";
 import * as util from "util";
 import Future = require("fibers/future");
-import frameworkProjectBaseLib = require("./framework-project-base");
+import {FrameworkProjectBase} from "./framework-project-base";
 import semver = require("semver");
 
-export class NativeScriptProject extends frameworkProjectBaseLib.FrameworkProjectBase implements Project.IFrameworkProject {
+export class NativeScriptProject extends FrameworkProjectBase implements Project.IFrameworkProject {
 	constructor(private $config: IConfiguration,
 		$errors: IErrors,
 		$fs: IFileSystem,
@@ -136,28 +136,6 @@ export class NativeScriptProject extends frameworkProjectBaseLib.FrameworkProjec
 				}
 			});
 		}).future<void>()();
-	}
-
-	public completeProjectProperties(properties: any): boolean {
-		let updated = false;
-
-		if (_.has(properties, "name")) {
-			properties.ProjectName = properties.name;
-			delete properties.name;
-			updated = true;
-		}
-
-		if (_.has(properties, "iOSDisplayName")) {
-			properties.DisplayName = properties.iOSDisplayName;
-			delete properties.iOSDisplayName;
-			updated = true;
-		}
-		if (!properties.DisplayName) {
-			properties.DisplayName = properties.ProjectName;
-			updated = true;
-		}
-
-		return updated;
 	}
 
 	public getPluginVariablesInfo(projectInformation: Project.IProjectInformation, projectDir?: string, configuration?: string): IFuture<IDictionary<IStringDictionary>> {

--- a/lib/project/project.d.ts
+++ b/lib/project/project.d.ts
@@ -139,6 +139,12 @@ declare module Project {
 		getProjectTargetsBase(projectDir: string, fileMask: RegExp): IFuture<string[]>;
 		printAssetUpdateMessage(): void;
 		getProperty(propertyName: string, configuration: string, projectInformation: Project.IProjectInformation): any;
+		/**
+		 * Completes any mandatory project properties which have default values.
+		 * @param  {any}	properties	object containing already parsed properties
+		 * @return {boolean}			whether or not the initial properties have been updated
+		 */
+		completeProjectProperties(properties: any): boolean;
 	}
 
 	interface IFrameworkProjectResolverBase {


### PR DESCRIPTION
If `iOSDisplayName` is present but an empty string, then our current logic sets the `DisplayName` to `iOSDisplayName` and right after that decides that no `DisplayName` is present and uses a default one.
Fix the issue, by checking if a `DisplayName` is already set and then fork the logic between `iOSDisplayName` and the default one.
Ping @teobugslayer @rosen-vladimirov 