### PR TITLE
Extract more files when initializing project

### DIFF
--- a/lib/project/cordova-project.ts
+++ b/lib/project/cordova-project.ts
@@ -92,6 +92,10 @@ export class CordovaProject extends FrameworkProjectBase implements Project.IFra
 		return 'App_Resources';
 	}
 
+	public get projectSpecificFiles(): string[] {
+		return this.$mobileHelper.platformNames.map(platform => `cordova.${platform.toLowerCase()}.js`);
+	}
+
 	public getValidationSchemaId(): string {
 		return this.$jsonSchemaConstants.CORDOVA_VERSION_3_SCHEMA_ID;
 	}

--- a/lib/project/nativescript-project.ts
+++ b/lib/project/nativescript-project.ts
@@ -77,6 +77,10 @@ export class NativeScriptProject extends FrameworkProjectBase implements Project
 		return path.join('app', 'App_Resources');
 	}
 
+	public get projectSpecificFiles(): string[] {
+		return [ this.$projectConstants.PACKAGE_JSON_NAME ];
+	}
+
 	public getValidationSchemaId(): string {
 		return this.$jsonSchemaConstants.NATIVESCRIPT_SCHEMA_ID;
 	}

--- a/lib/project/project-constants.ts
+++ b/lib/project/project-constants.ts
@@ -3,6 +3,7 @@
 
 export class ProjectConstants implements Project.IProjectConstants {
 	public PROJECT_FILE = ".abproject";
+	public PROJECT_IGNORE_FILE = ".abignore";
 	public DEBUG_CONFIGURATION_NAME = "debug";
 	public DEBUG_PROJECT_FILE_NAME = ".debug.abproject";
 	public RELEASE_CONFIGURATION_NAME = "release";

--- a/lib/project/project.d.ts
+++ b/lib/project/project.d.ts
@@ -96,6 +96,11 @@ declare module Project {
 		 */
 		pluginsService: IPluginsService;
 
+		/**
+		 * Project specific files that should exist after init.
+		 */
+		projectSpecificFiles: string[]
+
 		getTemplateFilename(name: string): string;
 		getValidationSchemaId(): string;
 		getProjectFileSchema(): IDictionary<any>;
@@ -171,6 +176,7 @@ declare module Project {
 
 	interface IProjectConstants {
 		PROJECT_FILE: string;
+		PROJECT_IGNORE_FILE: string;
 		DEBUG_CONFIGURATION_NAME: string;
 		DEBUG_PROJECT_FILE_NAME: string;
 		RELEASE_CONFIGURATION_NAME: string;

--- a/test/project-properties-service.ts
+++ b/test/project-properties-service.ts
@@ -40,6 +40,11 @@ class SampleProject implements Project.IFrameworkProject {
 	get relativeAppResourcesPath(): string {
 		return 'App_Resources';
 	}
+
+	get projectSpecificFiles(): string[] {
+		return [];
+	}
+
 	getTemplateFilename(name: string): string {
 		return "";
 	}

--- a/test/project.ts
+++ b/test/project.ts
@@ -317,11 +317,23 @@ describe("project integration tests", () => {
 		});
 
 		describe("NativeScript project", () => {
+			function assertProjectFilesExistAfterInit(projectDir: string): void {
+				assert.isTrue(fs.existsSync(path.join(projectDir, projectConstants.PROJECT_FILE)), "After initialization, project does not have .abproject file.");
+				assert.isTrue(fs.existsSync(path.join(projectDir, projectConstants.PROJECT_IGNORE_FILE)), "After initialization, project does not have .abignore file.");
+				assert.isTrue(fs.existsSync(path.join(projectDir, projectConstants.PACKAGE_JSON_NAME)), "After initialization, project does not have package.json file.");
+			};
+
+			function removeProjectFiles(projectDir: string): void {
+				fs.unlinkSync(path.join(projectDir, projectConstants.PROJECT_FILE));
+				fs.unlinkSync(path.join(projectDir, projectConstants.PROJECT_IGNORE_FILE));
+				fs.unlinkSync(path.join(projectDir, projectConstants.PACKAGE_JSON_NAME));
+			}
+
 			it("Blank template has all mandatory files", () => {
 				options.template = "Blank";
 				project.createNewProject(projectName, projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript).wait();
 				let projectDir = project.getProjectDir().wait();
-				let packageJson = path.join(projectDir, "package.json");
+				let packageJson = path.join(projectDir, projectConstants.PACKAGE_JSON_NAME);
 				assert.isTrue(fs.existsSync(packageJson), "NativeScript Blank template does not contain mandatory 'package.json' file. This file is required in init command. You should check if this is problem with the template or change init command to use another file.");
 			});
 
@@ -329,7 +341,7 @@ describe("project integration tests", () => {
 				options.template = "TypeScript.Blank";
 				project.createNewProject(projectName, projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript).wait();
 				let projectDir = project.getProjectDir().wait();
-				let packageJson = path.join(projectDir, "package.json");
+				let packageJson = path.join(projectDir, projectConstants.PACKAGE_JSON_NAME);
 				assert.isTrue(fs.existsSync(packageJson), "NativeScript TypeScript.Blank template does not contain mandatory 'package.json' file. This file is required in init command. You should check if this is problem with the template or change init command to use another file.");
 			});
 
@@ -337,50 +349,64 @@ describe("project integration tests", () => {
 				options.template = "TypeScript.Blank";
 				project.createNewProject(projectName, projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript).wait();
 				let projectDir = project.getProjectDir().wait();
-				let projectFile = path.join(projectDir, ".abproject");
-				let abignoreFile = path.join(projectDir, ".abignore");
-				fs.unlinkSync(projectFile);
-				fs.unlinkSync(abignoreFile);
+				removeProjectFiles(projectDir);
 				options.path = projectDir;
 				project.initializeProjectFromExistingFiles(projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript).wait();
-				assert.isTrue(fs.existsSync(projectFile), "After initialization, project does not have .abproject file.");
-				assert.isTrue(fs.existsSync(abignoreFile), "After initialization, project does not have .abignore file.");
+				assertProjectFilesExistAfterInit(projectDir);
 			});
 
-			it("existing project has .abproject and .abignore files after init",() => {
+			it("existing project has project files after init",() => {
 				options.template = "Blank";
 				project.createNewProject(projectName, projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript).wait();
 				let projectDir = project.getProjectDir().wait();
-				let projectFile = path.join(projectDir, ".abproject");
-				let abignoreFile = path.join(projectDir, ".abignore");
-				fs.unlinkSync(projectFile);
-				fs.unlinkSync(abignoreFile);
+				removeProjectFiles(projectDir);
 				options.path = projectDir;
 				project.initializeProjectFromExistingFiles(projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript).wait();
-				assert.isTrue(fs.existsSync(projectFile), "After initialization, project does not have .abproject file.");
-				assert.isTrue(fs.existsSync(abignoreFile), "After initialization, project does not have .abignore file.");
+				assertProjectFilesExistAfterInit(projectDir);
+			});
+
+			it("empty directory has project files after init",() => {
+				options.path = tempFolder;
+				project.initializeProjectFromExistingFiles(projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript).wait();
+				assertProjectFilesExistAfterInit(tempFolder);
 			});
 		});
 
 		describe("Cordova project",() => {
+			function assertProjectFilesExistAfterInit(projectDir: string): void {
+				assert.isTrue(fs.existsSync(path.join(projectDir, projectConstants.PROJECT_FILE)), "After initialization, project does not have .abproject file.");
+				assert.isTrue(fs.existsSync(path.join(projectDir, projectConstants.PROJECT_IGNORE_FILE)), "After initialization, project does not have .abignore file.");
+				assert.isTrue(fs.existsSync(path.join(projectDir, projectConstants.DEBUG_PROJECT_FILE_NAME)), "After initialization, project does not have .debug.abproject file.");
+				assert.isTrue(fs.existsSync(path.join(projectDir,  projectConstants.RELEASE_PROJECT_FILE_NAME)), "After initialization, project does not have .release.abproject file.");
+				assert.isTrue(fs.existsSync(path.join(projectDir, "cordova.android.js")), "After initialization, project does not have cordova.android.js file.");
+				assert.isTrue(fs.existsSync(path.join(projectDir, "cordova.ios.js")), "After initialization, project does not have cordova.ios.js file.");
+				assert.isTrue(fs.existsSync(path.join(projectDir, "cordova.wp8.js")), "After initialization, project does not have cordova.wp8.js file.");
+			};
+
+			function removeProjectFiles(projectDir: string): void {
+				fs.unlinkSync(path.join(projectDir, projectConstants.PROJECT_FILE));
+				fs.unlinkSync(path.join(projectDir, projectConstants.PROJECT_IGNORE_FILE));
+				fs.unlinkSync(path.join(projectDir, projectConstants.RELEASE_PROJECT_FILE_NAME));
+				fs.unlinkSync(path.join(projectDir, projectConstants.DEBUG_PROJECT_FILE_NAME));
+				mobileHelper.platformNames.forEach(platform => {
+					fs.unlinkSync(path.join(projectDir, `cordova.${platform.toLowerCase()}.js`));
+				});
+			}
+
 			it("existing project has configuration specific files and .abignore files after init",() => {
 				options.template = "Blank";
 				project.createNewProject(projectName, projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait();
 				let projectDir = project.getProjectDir().wait();
-				let projectFile = path.join(projectDir, projectConstants.PROJECT_FILE);
-				let releaseProjectFile = path.join(projectDir, projectConstants.RELEASE_PROJECT_FILE_NAME);
-				let debugProjectFile = path.join(projectDir, projectConstants.DEBUG_PROJECT_FILE_NAME);
-				let abignoreFile = path.join(projectDir, ".abignore");
-				fs.unlinkSync(projectFile);
-				fs.unlinkSync(releaseProjectFile);
-				fs.unlinkSync(debugProjectFile);
-				fs.unlinkSync(abignoreFile);
+				removeProjectFiles(projectDir);
 				options.path = projectDir;
 				project.initializeProjectFromExistingFiles(projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait();
-				assert.isTrue(fs.existsSync(projectFile), "After initialization, project does not have .abproject file.");
-				assert.isTrue(fs.existsSync(abignoreFile), "After initialization, project does not have .abignore file.");
-				assert.isTrue(fs.existsSync(debugProjectFile), "After initialization, project does not have .debug.abproject file.");
-				assert.isTrue(fs.existsSync(releaseProjectFile), "After initialization, project does not have .release.abproject file.");
+				assertProjectFilesExistAfterInit(projectDir);
+			});
+
+			it("empty directory has project files after init",() => {
+				options.path = tempFolder;
+				project.initializeProjectFromExistingFiles(projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait();
+				assertProjectFilesExistAfterInit(tempFolder);
 			});
 
 			it("Blank template has all mandatory files", () => {

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -348,6 +348,10 @@ class FrameworkProjectStub implements Project.IFrameworkProject {
 
 	public get relativeAppResourcesPath(): string { return ''; }
 
+	public get projectSpecificFiles(): string[] {
+		return [];
+	}
+
 	public getValidationSchemaId(): string { return ""; }
 
 	public getTemplateFilename(name: string): string {


### PR DESCRIPTION
When `appbuilder init hybrid` is called, we should extract:
* `.abproject`
* `.debug.abproject`
* `.release.abproject`
* `.abignore`
* `cordova.ios.js`
* `cordova.android.js`
* `cordova.wp8.js`

When `appbuilder init native` is called, we should extract:
* `.abproject`
* `.abignore`
* `package.json`

In case any of them exists, we should not overwrite it.
Add new property to frameworkProject - `projectSpecificFiles` - it should define the required files that should exist after initialization.
Always extract all `*.abproject` and `*.abignore` files no matter of project type.
Add tests for the new functionality.
Introduce new project constant for `.abignore` file name.

Fixes http://teampulse.telerik.com/view#item/310769