### PR TITLE
Fix QR code generations for iOS Companion

### DIFF
--- a/lib/providers/device-app-data-provider.ts
+++ b/lib/providers/device-app-data-provider.ts
@@ -176,8 +176,7 @@ export class IOSAppIdentifier extends deviceAppDataBaseLib.DeviceAppDataBase imp
 }
 
 export class IOSCompanionAppIdentifier extends deviceAppDataBaseLib.DeviceAppDataBase implements ILiveSyncDeviceAppData {
-	constructor(private servedApp: string,
-		public device: Mobile.IDevice,
+	constructor(public device: Mobile.IDevice,
 		public platform: string) {
 		super("com.telerik.Icenium");
 	}
@@ -204,8 +203,7 @@ export class IOSCompanionAppIdentifier extends deviceAppDataBaseLib.DeviceAppDat
 }
 
 export class IOSNativeScriptCompanionAppIdentifier extends deviceAppDataBaseLib.DeviceAppDataBase implements ILiveSyncDeviceAppData {
-	constructor(private servedApp: string,
-		public device: Mobile.IDevice,
+	constructor(public device: Mobile.IDevice,
 		public platform: string) {
 		super(NATIVESCRIPT_ION_APP_IDENTIFIER);
 	}


### PR DESCRIPTION
Remove unused property(servedApp) form iOSCompanion classes that breaks building for iOS companion apps.

http://teampulse.telerik.com/view#item/310864