### PR TITLE
Regenerate server-api

### DIFF
--- a/lib/project.ts
+++ b/lib/project.ts
@@ -710,9 +710,9 @@ export class Project implements Project.IProject {
 			if(fileSize > Project.CHUNK_UPLOAD_MIN_FILE_SIZE) {
 				this.$logger.trace("Start uploading file by chunks.");
 				this.$progressIndicator.showProgressIndicator(this.$multipartUploadService.uploadFileByChunks(projectZipFile, bucketKey), 2000, {surpressTrailingNewLine: true}).wait();
-				this.$progressIndicator.showProgressIndicator(this.$server.projects.importLocalProject(projectName, projectName, bucketKey), 2000).wait();
+				this.$progressIndicator.showProgressIndicator(this.$server.projects.importLocalProject(projectName, projectName, bucketKey, true), 2000).wait();
 			} else {
-				this.$progressIndicator.showProgressIndicator(this.$server.projects.importProject(projectName, projectName,
+				this.$progressIndicator.showProgressIndicator(this.$server.projects.importProject(projectName, projectName, true,
 					this.$fs.createReadStream(projectZipFile)), 2000).wait();
 			}
 

--- a/lib/server-api.d.ts
+++ b/lib/server-api.d.ts
@@ -47,10 +47,20 @@ declare module Server{
 		setActiveTenant(tenantId: string): IFuture<Server.IUser>;
 		agreeToEula(): IFuture<void>;
 	}
-	interface ProjectInfo{
+	interface ApplicationProjectInfo{
+		AppId: string;
 		ProjectName: string;
 		SolutionName: string;
 		SolutionSpaceName: string;
+	}
+	interface PropertyMigration{
+		BaseValue: string;
+		Type: string;
+		Values: IDictionary<string>;
+	}
+	interface MigrationResult{
+		MigratedFileEntries: IDictionary<MigrationType>;
+		MigratedProperties: IDictionary<PropertyMigration>;
 	}
 	interface CordovaPluginData{
 		Assets: string[];
@@ -62,6 +72,34 @@ declare module Server{
 		Url: string;
 		Platforms: Server.DevicePlatform[];
 		Variables: string[];
+	}
+	interface CordovaPluginVariablesData{
+		BaseVariables: any;
+		PerConfigurationVariables: any;
+	}
+	const enum MigrationType{
+		Create,
+		Update,
+		Delete,
+	}
+	const enum DevicePlatform{
+		iOS,
+		Android,
+		WP8,
+	}
+	interface IAppsCordovaServiceContract{
+		getLiveSyncToken(appId: string, projectName: string): IFuture<string>;
+		getCurrentPlatforms(appId: string, projectName: string): IFuture<Server.DevicePlatform[]>;
+		addPlatform(appId: string, projectName: string, platform: Server.DevicePlatform): IFuture<Server.MigrationResult>;
+		migrate(appId: string, projectName: string, targetVersion: string): IFuture<Server.MigrationResult>;
+		getProjectCordovaPlugins(appId: string, projectName: string): IFuture<Server.CordovaPluginData[]>;
+		getCordovaPluginVariables(appId: string, projectName: string): IFuture<Server.CordovaPluginVariablesData>;
+		setCordovaPluginVariable(appId: string, projectName: string, pluginId: string, variableName: string, configuration: string, value: string): IFuture<void>;
+	}
+	interface ProjectInfo{
+		ProjectName: string;
+		SolutionName: string;
+		SolutionSpaceName: string;
 	}
 	interface CordovaRenamedPlugin{
 		Version: string;
@@ -125,29 +163,6 @@ declare module Server{
 		Framework: string;
 		PageUrl: string;
 	}
-	interface PropertyMigration{
-		BaseValue: string;
-		Type: string;
-		Values: IDictionary<string>;
-	}
-	interface MigrationResult{
-		MigratedFileEntries: IDictionary<MigrationType>;
-		MigratedProperties: IDictionary<PropertyMigration>;
-	}
-	interface CordovaPluginVariablesData{
-		BaseVariables: any;
-		PerConfigurationVariables: any;
-	}
-	const enum MigrationType{
-		Create,
-		Update,
-		Delete,
-	}
-	const enum DevicePlatform{
-		iOS,
-		Android,
-		WP8,
-	}
 	interface ICordovaServiceContract{
 		getLiveSyncToken(solutionName: string, projectName: string): IFuture<string>;
 		getLiveSyncUrl(longUrl: string): IFuture<string>;
@@ -166,21 +181,6 @@ declare module Server{
 		getProjectCordovaPlugins(solutionName: string, projectName: string): IFuture<Server.CordovaPluginData[]>;
 		getCordovaPluginVariables(solutionName: string, projectName: string): IFuture<Server.CordovaPluginVariablesData>;
 		setCordovaPluginVariable(solutionName: string, projectName: string, pluginId: string, variableName: string, configuration: string, value: string): IFuture<void>;
-	}
-	interface ApplicationProjectInfo{
-		AppId: string;
-		ProjectName: string;
-		SolutionName: string;
-		SolutionSpaceName: string;
-	}
-	interface IAppsCordovaServiceContract{
-		getLiveSyncToken(appId: string, projectName: string): IFuture<string>;
-		getCurrentPlatforms(appId: string, projectName: string): IFuture<Server.DevicePlatform[]>;
-		addPlatform(appId: string, projectName: string, platform: Server.DevicePlatform): IFuture<Server.MigrationResult>;
-		migrate(appId: string, projectName: string, targetVersion: string): IFuture<Server.MigrationResult>;
-		getProjectCordovaPlugins(appId: string, projectName: string): IFuture<Server.CordovaPluginData[]>;
-		getCordovaPluginVariables(appId: string, projectName: string): IFuture<Server.CordovaPluginVariablesData>;
-		setCordovaPluginVariable(appId: string, projectName: string, pluginId: string, variableName: string, configuration: string, value: string): IFuture<void>;
 	}
 	interface CryptographicIdentityData{
 		Alias: string;
@@ -237,6 +237,18 @@ declare module Server{
 		initUpload(path: string): IFuture<void>;
 		uploadChunk(path: string, content: any): IFuture<void>;
 	}
+	interface ApplicationInfo{
+		AppId: string;
+		IsMigrated: boolean;
+		SolutionName: string;
+		SolutionSpaceName: string;
+	}
+	interface IAppsFilesServiceContract{
+		getFile(appId: string, path: string, $resultStream: any): IFuture<void>;
+		save(appId: string, path: string, content: any): IFuture<void>;
+		createDirectory(appId: string, path: string): IFuture<void>;
+		remove(appId: string, path: string): IFuture<void>;
+	}
 	interface SolutionInfo{
 		SolutionName: string;
 		SolutionSpaceName: string;
@@ -247,19 +259,6 @@ declare module Server{
 		save(solutionName: string, path: string, content: any): IFuture<void>;
 		createDirectory(solutionName: string, path: string): IFuture<void>;
 		remove(solutionName: string, path: string): IFuture<void>;
-	}
-	interface ApplicationInfo{
-		AppId: string;
-		SolutionName: string;
-		SolutionSpaceName: string;
-	}
-	interface IAppsFilesServiceContract{
-		getFile(appId: string, path: string, $resultStream: any): IFuture<void>;
-		save(appId: string, path: string, content: any): IFuture<void>;
-		createDirectory(appId: string, path: string): IFuture<void>;
-		remove(appId: string, path: string): IFuture<void>;
-		rename(appId: string, path: string, destinationAppId: string, newPath: string): IFuture<void>;
-		copy(appId: string, path: string, destinationAppId: string, destination: string): IFuture<void>;
 	}
 	interface Size{
 		Width: number;
@@ -279,8 +278,40 @@ declare module Server{
 		generate(solutionName: string, projectName: string, type: Server.ImageType, image: any): IFuture<string[]>;
 		generateArchive(type: Server.ImageType, image: any, $resultStream: any): IFuture<void>;
 	}
+	interface Uri{
+		AbsolutePath: string;
+		AbsoluteUri: string;
+		LocalPath: string;
+		Authority: string;
+		HostNameType: string;
+		IsDefaultPort: boolean;
+		IsFile: boolean;
+		IsLoopback: boolean;
+		PathAndQuery: string;
+		Segments: string[];
+		IsUnc: boolean;
+		Host: string;
+		Port: number;
+		Query: string;
+		Fragment: string;
+		Scheme: string;
+		OriginalString: string;
+		DnsSafeHost: string;
+		IdnHost: string;
+		IsAbsoluteUri: boolean;
+		UserEscaped: boolean;
+		UserInfo: string;
+	}
+	const enum UriHostNameType{
+		Unknown,
+		Basic,
+		Dns,
+		IPv4,
+		IPv6,
+	}
 	interface IAppsItmstransporterServiceContract{
-		uploadApplication(appId: string, projectName: string, relativePackagePath: string, adamId: number, username: string, password: string): IFuture<void>;
+		uploadApplication(appId: string, projectName: string, adamId: number, packageUri: Server.Uri, username: string, password: string): IFuture<void>;
+		uploadApplication1(appId: string, projectName: string, relativePackagePath: string, adamId: number, username: string, password: string): IFuture<void>;
 	}
 	interface Application{
 		AppleID: number;
@@ -292,7 +323,8 @@ declare module Server{
 	}
 	interface IItmstransporterServiceContract{
 		getApplicationsReadyForUpload(username: string, password: string): IFuture<Server.Application[]>;
-		uploadApplication(solutionName: string, projectName: string, relativePackagePath: string, adamId: number, username: string, password: string): IFuture<void>;
+		uploadApplication(solutionName: string, projectName: string, adamId: number, packageUri: Server.Uri, username: string, password: string): IFuture<void>;
+		uploadApplication1(solutionName: string, projectName: string, relativePackagePath: string, adamId: number, username: string, password: string): IFuture<void>;
 	}
 	interface KendoDownloadablePackageData{
 		Id: string;
@@ -330,9 +362,9 @@ declare module Server{
 	}
 	const enum ProvisionType{
 		Development,
+		AppStore,
 		AdHoc,
 		Enterprise,
-		AppStore,
 	}
 	interface IMobileprovisionsServiceContract{
 		getProvisions(): IFuture<Server.ProvisionData[]>;
@@ -366,6 +398,40 @@ declare module Server{
 	}
 	interface IAppsNativescriptServiceContract{
 		migrate(appId: string, projectName: string, targetVersion: string): IFuture<Server.MigrationResult>;
+		migrate1(appId: string, projectName: string, targetVersion: string): IFuture<Server.MigrationResult>;
+	}
+	interface IInternalAppsProjectsServiceContract{
+		getProjectPhysicalPaths(appId: string, projectName: string): IFuture<Server.Object>;
+	}
+	interface ProjectTemplateExpansionData{
+		ProjectName: string;
+		TemplateIdentifier: string;
+		Framework: string;
+		Arguments: IDictionary<string>;
+	}
+	interface ProjectItemInfo{
+		Project: Server.ProjectInfo;
+		Type: string;
+		Identifier: string;
+	}
+	interface ItemTemplateExpansionData{
+		TemplateIdentifier: string;
+		Framework: string;
+		Arguments: IDictionary<string>;
+	}
+	interface IAppsProjectsServiceContract{
+		exportProject(appId: string, projectName: string, skipMetadata: boolean, $resultStream: any): IFuture<void>;
+		importPackage(appId: string, projectName: string, parentIdentifier: string, archivePackage: any): IFuture<void>;
+		importProject(appId: string, projectName: string, cleanImport: boolean, package_: any): IFuture<void>;
+		importLocalProject(appId: string, projectName: string, bucketKey: string, cleanImport: boolean): IFuture<void>;
+		getProjectContents(appId: string, projectName: string): IFuture<string>;
+		saveProjectContents(appId: string, projectName: string, projectContents: string): IFuture<void>;
+		getProjectConfiguraitons(appId: string, projectName: string): IFuture<string[]>;
+		createProject(appId: string, projectName: string, expansionData: Server.ProjectTemplateExpansionData): IFuture<void>;
+		deleteProject(appId: string, projectName: string): IFuture<void>;
+		setProjectProperty(appId: string, projectName: string, configuration: string, changeset: IDictionary<string>): IFuture<void>;
+		renameProject(appId: string, projectName: string, newProjectName: string): IFuture<void>;
+		createNewProjectItem(appId: string, projectName: string, itemIdentifier: string, expansionData: Server.ItemTemplateExpansionData): IFuture<Server.ProjectItemInfo[]>;
 	}
 	interface ProjectTemplateData{
 		CanCreateProject: boolean;
@@ -378,11 +444,12 @@ declare module Server{
 		Icon: string;
 		DownloadUri: string;
 		DefaultName: string;
+		SortOrder: number;
+		Hidden: boolean;
 		ShortDescription: string;
 	}
 	interface ItemTemplateData{
 		LanguageName: string;
-		SortOrder: number;
 		Name: string;
 		Description: string;
 		Category: string;
@@ -391,46 +458,37 @@ declare module Server{
 		Icon: string;
 		DownloadUri: string;
 		DefaultName: string;
+		SortOrder: number;
+		ProjectSubType: string;
+		Hidden: boolean;
 		ShortDescription: string;
 	}
 	interface IWorkspaceItemData{
 		Name: string;
+		Framework: string;
 	}
 	interface SolutionData{
 		Name: string;
 		Items: Server.IWorkspaceItemData[];
 		IsUpgradeable: boolean;
 	}
-	interface ProjectTemplateExpansionData{
-		ProjectName: string;
-		TemplateIdentifier: string;
-		Arguments: IDictionary<string>;
-	}
-	interface ProjectItemInfo{
-		Project: Server.ProjectInfo;
-		Type: string;
-		Identifier: string;
-	}
-	interface ItemTemplateExpansionData{
-		TemplateIdentifier: string;
-		Arguments: IDictionary<string>;
-	}
 	interface IProjectsServiceContract{
-		getProjectFileSchema($resultStream: any): IFuture<void>;
 		getProjectTemplates(): IFuture<Server.ProjectTemplateData[]>;
 		getItemTemplates(): IFuture<Server.ItemTemplateData[]>;
 		exportSolution(solutionSpaceName: string, solutionName: string, skipMetadata: boolean, $resultStream: any): IFuture<void>;
 		exportProject(solutionSpaceName: string, solutionName: string, projectName: string, skipMetadata: boolean, $resultStream: any): IFuture<void>;
 		importPackage(solutionName: string, projectName: string, parentIdentifier: string, archivePackage: any): IFuture<void>;
-		importProject(solutionName: string, projectName: string, package_: any): IFuture<void>;
-		importLocalProject(solutionName: string, projectName: string, bucketKey: string): IFuture<void>;
+		importProject(solutionName: string, projectName: string, cleanImport: boolean, package_: any): IFuture<void>;
+		importLocalProject(solutionName: string, projectName: string, bucketKey: string, cleanImport: boolean): IFuture<void>;
 		getProjectContents(solutionName: string, projectName: string): IFuture<string>;
 		saveProjectContents(solutionName: string, projectName: string, projectContents: string): IFuture<void>;
+		getProjectConfiguraitons(solutionName: string, projectName: string): IFuture<string[]>;
 		upgradeSolution(solutionName: string): IFuture<void>;
 		getSolution(solutionName: string, checkUpgradability: boolean): IFuture<Server.SolutionData>;
 		canLoadSolution(solutionName: string): IFuture<boolean>;
 		deleteSolution(solutionName: string): IFuture<void>;
 		createSolution(solutionName: string, expansionData: Server.ProjectTemplateExpansionData): IFuture<void>;
+		getSolutionType(solutionName: string): IFuture<string>;
 		renameSolution(solutionName: string, newSolutionName: string): IFuture<void>;
 		createProject(solutionName: string, projectName: string, expansionData: Server.ProjectTemplateExpansionData): IFuture<void>;
 		deleteProject(solutionName: string, projectName: string): IFuture<void>;
@@ -438,24 +496,12 @@ declare module Server{
 		renameProject(solutionName: string, projectName: string, newProjectName: string): IFuture<void>;
 		createNewProjectItem(solutionName: string, projectName: string, itemIdentifier: string, expansionData: Server.ItemTemplateExpansionData): IFuture<Server.ProjectItemInfo[]>;
 	}
-	interface IAppsProjectsServiceContract{
-		exportProject(appId: string, projectName: string, skipMetadata: boolean, $resultStream: any): IFuture<void>;
-		importPackage(appId: string, projectName: string, parentIdentifier: string, archivePackage: any): IFuture<void>;
-		importProject(appId: string, projectName: string, package_: any): IFuture<void>;
-		importLocalProject(appId: string, projectName: string, bucketKey: string): IFuture<void>;
-		getProjectContents(appId: string, projectName: string): IFuture<string>;
-		saveProjectContents(appId: string, projectName: string, projectContents: string): IFuture<void>;
-		createProject(appId: string, projectName: string, expansionData: Server.ProjectTemplateExpansionData): IFuture<void>;
-		deleteProject(appId: string, projectName: string): IFuture<void>;
-		setProjectProperty(appId: string, projectName: string, configuration: string, changeset: IDictionary<string>): IFuture<void>;
-		renameProject(appId: string, projectName: string, newProjectName: string): IFuture<void>;
-		createNewProjectItem(appId: string, projectName: string, itemIdentifier: string, expansionData: Server.ItemTemplateExpansionData): IFuture<Server.ProjectItemInfo[]>;
-	}
 	interface ApplicationCreationData{
 		AccountId: string;
 		AppData: IDictionary<Object>;
 		ProjectName: string;
 		TemplateIdentifier: string;
+		Framework: string;
 		Arguments: IDictionary<string>;
 	}
 	interface ApplicationServiceData{
@@ -474,17 +520,14 @@ declare module Server{
 		canLoadApplication(appId: string): IFuture<boolean>;
 		deleteApplication(appId: string): IFuture<void>;
 		upgradeApplication(appId: string): IFuture<void>;
-		getApplicationServices(appId: string): IFuture<Server.ApplicationServiceData[]>;
+		getApplicationServices(appId: string, serviceNames: string[]): IFuture<Server.ApplicationServiceData[]>;
 		enableApplicationService(appId: string, serviceData: IDictionary<Object>): IFuture<IDictionary<Object>>;
+		getApplicationType(appId: string): IFuture<string>;
+		deleteApplicationCache(appId: string): IFuture<void>;
 	}
 	interface PackageData{
 		Name: string;
 		Version: string;
-	}
-	interface IAppsBowerServiceContract{
-		installDependencies(appId: string, projectName: string): IFuture<void>;
-		installPackage(appId: string, projectName: string, packageName: string, version: string): IFuture<void>;
-		getInstalledPackages(appId: string, projectName: string): IFuture<Server.PackageData[]>;
 	}
 	interface BowerPackagesFilters{
 		Blacklist: string[];
@@ -495,6 +538,11 @@ declare module Server{
 		installPackage(solutionName: string, projectName: string, packageName: string, version: string): IFuture<void>;
 		getInstalledPackages(solutionName: string, projectName: string): IFuture<Server.PackageData[]>;
 		getFilters(): IFuture<Server.BowerPackagesFilters>;
+	}
+	interface IAppsBowerServiceContract{
+		installDependencies(appId: string, projectName: string): IFuture<void>;
+		installPackage(appId: string, projectName: string, packageName: string, version: string): IFuture<void>;
+		getInstalledPackages(appId: string, projectName: string): IFuture<Server.PackageData[]>;
 	}
 	interface BuildIssueData{
 		Code: string;
@@ -561,12 +609,20 @@ declare module Server{
 		Type: string;
 		Url: string;
 	}
+	interface NpmPluginVariablesData{
+		DefaultValue: string;
+	}
+	interface NpmPluginNativeScriptData{
+		Platforms: IDictionary<string>;
+		Variables: IDictionary<NpmPluginVariablesData>;
+	}
 	interface NpmVersion{
 		Name: string;
 		Description: string;
 		HomePage: string;
 		Repository: Server.Repository;
 		Version: string;
+		NativeScriptData: Server.NpmPluginNativeScriptData;
 	}
 	interface NpmPackage{
 		Name: string;
@@ -645,9 +701,14 @@ declare module Server{
 		setActiveBuildConfiguration(buildConfiguration: string, solutionName: string): IFuture<void>;
 		updateSettingsProjectIdentifier(solutionName: string, projectIdentity: string, newProjectIdentity: string): IFuture<void>;
 	}
+	interface StorageMachineStatus{
+		Path: string;
+		Elapsed: number;
+	}
 	interface IStatusServiceContract{
 		getLinuxBuildMachineStatus(): IFuture<string>;
 		getMacBuildMachineStatus(): IFuture<string>;
+		getStorageStatus(): IFuture<Server.StorageMachineStatus[]>;
 	}
 	interface TamGroupData{
 		Name: string;
@@ -667,6 +728,7 @@ declare module Server{
 	interface PatchData{
 		Platforms: Server.DevicePlatform[];
 		IsMandatory: boolean;
+		ProjectConfiguration: string;
 	}
 	interface FeatureStatus{
 		IsAvailable: boolean;
@@ -676,18 +738,15 @@ declare module Server{
 	interface ITamServiceContract{
 		verifyStoreCreated(): IFuture<void>;
 		getGroups(): IFuture<Server.TamGroupData[]>;
-		uploadApplication(solutionName: string, projectName: string, relativePackagePath: string, settings: Server.PublishSettings): IFuture<Server.UploadedAppData>;
+		uploadApplication(solutionName: string, projectName: string, packageUri: Server.Uri, settings: Server.PublishSettings): IFuture<Server.UploadedAppData>;
+		uploadApplication1(solutionName: string, projectName: string, relativePackagePath: string, settings: Server.PublishSettings): IFuture<Server.UploadedAppData>;
 		uploadPatch(solutionName: string, projectName: string, patchData: Server.PatchData): IFuture<void>;
 		getAccountStatus(): IFuture<Server.FeatureStatus>;
 	}
 	interface IAppsTamServiceContract{
-		uploadApplication(appId: string, projectName: string, relativePackagePath: string, settings: Server.PublishSettings): IFuture<Server.UploadedAppData>;
+		uploadApplication(appId: string, projectName: string, packageUri: Server.Uri, settings: Server.PublishSettings): IFuture<Server.UploadedAppData>;
+		uploadApplication1(appId: string, projectName: string, relativePackagePath: string, settings: Server.PublishSettings): IFuture<Server.UploadedAppData>;
 		uploadPatch(appId: string, projectName: string, patchData: Server.PatchData): IFuture<void>;
-	}
-	interface IAppsTapServiceContract{
-		getRemote(appId: string): IFuture<string>;
-		setRemote(appId: string, remoteUrl: string): IFuture<void>;
-		initCurrentUserSharedRepository(appId: string): IFuture<boolean>;
 	}
 	interface TapSolutionData{
 		id: string;
@@ -723,6 +782,7 @@ declare module Server{
 		setRemote(solutionName: string, remoteUrl: string): IFuture<void>;
 		getUsersForProject(solutionName: string): IFuture<Server.Collaborator[]>;
 		initCurrentUserSharedRepository(solutionName: string): IFuture<boolean>;
+		migrate(solutionName: string, appId: string): IFuture<void>;
 		getWorkspaces(accountId: string): IFuture<Server.TapWorkspaceData[]>;
 		getServiceApplications(serviceType: string, accountId: string): IFuture<Server.TapSolutionData[]>;
 		getServiceApplicationProjectKey(serviceType: string, id: string): IFuture<string>;
@@ -730,6 +790,11 @@ declare module Server{
 		getNotificationSummary(accountId: string): IFuture<Server.TapNotificationSummaryData>;
 		getUnreadNotifications(accountId: string): IFuture<Server.TapNotificationData[]>;
 		getReadNotifications(accountId: string, fromDate: Date): IFuture<Server.TapNotificationData[]>;
+	}
+	interface IAppsTapServiceContract{
+		getRemote(appId: string): IFuture<string>;
+		setRemote(appId: string, remoteUrl: string): IFuture<void>;
+		initCurrentUserSharedRepository(appId: string): IFuture<boolean>;
 	}
 	interface BranchItemData{
 		BranchName: string;
@@ -818,34 +883,6 @@ declare module Server{
 		Hard,
 		Soft,
 	}
-	interface IAppsVersioncontrolServiceContract{
-		init(appId: string): IFuture<void>;
-		rollback(appId: string, versionName: string): IFuture<void>;
-		reset(appId: string, resetMode: Server.ResetMode, versionName: string): IFuture<void>;
-		merge(appId: string, versionName: string): IFuture<Server.BranchItemData>;
-		revert(appId: string, versionName: string, filePaths: string[]): IFuture<void>;
-		resolve(appId: string, versionName: string, filePaths: string[]): IFuture<void>;
-		checkout(appId: string, versionName: string, filePaths: string[]): IFuture<void>;
-		add(appId: string, filePaths: string[]): IFuture<void>;
-		remove(appId: string, filePaths: string[]): IFuture<void>;
-		getBranches(appId: string): IFuture<Server.BranchItemData[]>;
-		getCurrentBranch(appId: string): IFuture<Server.BranchItemData>;
-		checkoutBranch(appId: string, branchName: string, createBranch: boolean, versionName: string): IFuture<Server.BranchItemData>;
-		createBranch(appId: string, branchName: string, versionName: string): IFuture<Server.BranchItemData>;
-		deleteBranch(appId: string, branchName: string, forceDelete: boolean): IFuture<void>;
-		getRemote(appId: string): IFuture<string>;
-		setRemote(appId: string, remoteData: Server.GitRemoteData): IFuture<void>;
-		getInfo(appId: string): IFuture<Server.VersionControlData>;
-		track(appId: string): IFuture<Server.ChangeItemData[]>;
-		getStatus(appId: string, filePaths: string[]): IFuture<Server.ChangeItemData[]>;
-		getDiff(appId: string, versionName: string, contextSize: number, otherVersionName: string, filePaths: string[]): IFuture<Server.DiffLineResultData[]>;
-		getConflicts(appId: string, contextSize: number, filePaths: string[]): IFuture<Server.DiffLineResultData[]>;
-		getCommits(appId: string, endDate: Date, startDate: Date): IFuture<Server.ChangeSetData[]>;
-		getCommit(appId: string, versionName: string): IFuture<Server.ChangeSetData>;
-		getChanges(appId: string, versionName: string): IFuture<Server.ChangeItemData[]>;
-		getContents(appId: string, versionName: string, filePath: string): IFuture<string>;
-		getHistory(appId: string, versionName: string, filePath: string): IFuture<Server.HistoryItemData[]>;
-	}
 	interface IVersioncontrolServiceContract{
 		init(solutionName: string): IFuture<void>;
 		rollback(solutionName: string, versionName: string): IFuture<void>;
@@ -874,17 +911,45 @@ declare module Server{
 		getContents(solutionName: string, versionName: string, filePath: string): IFuture<string>;
 		getHistory(solutionName: string, versionName: string, filePath: string): IFuture<Server.HistoryItemData[]>;
 	}
+	interface IAppsVersioncontrolServiceContract{
+		init(appId: string): IFuture<void>;
+		rollback(appId: string, versionName: string): IFuture<void>;
+		reset(appId: string, resetMode: Server.ResetMode, versionName: string): IFuture<void>;
+		merge(appId: string, versionName: string): IFuture<Server.BranchItemData>;
+		revert(appId: string, versionName: string, filePaths: string[]): IFuture<void>;
+		resolve(appId: string, versionName: string, filePaths: string[]): IFuture<void>;
+		checkout(appId: string, versionName: string, filePaths: string[]): IFuture<void>;
+		add(appId: string, filePaths: string[]): IFuture<void>;
+		remove(appId: string, filePaths: string[]): IFuture<void>;
+		getBranches(appId: string): IFuture<Server.BranchItemData[]>;
+		getCurrentBranch(appId: string): IFuture<Server.BranchItemData>;
+		checkoutBranch(appId: string, branchName: string, createBranch: boolean, versionName: string): IFuture<Server.BranchItemData>;
+		createBranch(appId: string, branchName: string, versionName: string): IFuture<Server.BranchItemData>;
+		deleteBranch(appId: string, branchName: string, forceDelete: boolean): IFuture<void>;
+		getRemote(appId: string): IFuture<string>;
+		setRemote(appId: string, remoteData: Server.GitRemoteData): IFuture<void>;
+		getInfo(appId: string): IFuture<Server.VersionControlData>;
+		track(appId: string): IFuture<Server.ChangeItemData[]>;
+		getStatus(appId: string, filePaths: string[]): IFuture<Server.ChangeItemData[]>;
+		getDiff(appId: string, versionName: string, contextSize: number, otherVersionName: string, filePaths: string[]): IFuture<Server.DiffLineResultData[]>;
+		getConflicts(appId: string, contextSize: number, filePaths: string[]): IFuture<Server.DiffLineResultData[]>;
+		getCommits(appId: string, endDate: Date, startDate: Date): IFuture<Server.ChangeSetData[]>;
+		getCommit(appId: string, versionName: string): IFuture<Server.ChangeSetData>;
+		getChanges(appId: string, versionName: string): IFuture<Server.ChangeItemData[]>;
+		getContents(appId: string, versionName: string, filePath: string): IFuture<string>;
+		getHistory(appId: string, versionName: string, filePath: string): IFuture<Server.HistoryItemData[]>;
+	}
 	interface IServer{
 		authentication: Server.IAuthenticationServiceContract;
-		cordova: Server.ICordovaServiceContract;
 		appsCordova: Server.IAppsCordovaServiceContract;
+		cordova: Server.ICordovaServiceContract;
 		identityStore: Server.IIdentityStoreServiceContract;
 		everlive: Server.IEverliveServiceContract;
 		extensions: Server.IExtensionsServiceContract;
 		internalExtensions: Server.IInternalExtensionsServiceContract;
 		upload: Server.IUploadServiceContract;
-		filesystem: Server.IFilesystemServiceContract;
 		appsFiles: Server.IAppsFilesServiceContract;
+		filesystem: Server.IFilesystemServiceContract;
 		appsImages: Server.IAppsImagesServiceContract;
 		images: Server.IImagesServiceContract;
 		appsItmstransporter: Server.IAppsItmstransporterServiceContract;
@@ -894,11 +959,12 @@ declare module Server{
 		mobileprovisions: Server.IMobileprovisionsServiceContract;
 		nativescript: Server.INativescriptServiceContract;
 		appsNativescript: Server.IAppsNativescriptServiceContract;
-		projects: Server.IProjectsServiceContract;
+		internalAppsProjects: Server.IInternalAppsProjectsServiceContract;
 		appsProjects: Server.IAppsProjectsServiceContract;
+		projects: Server.IProjectsServiceContract;
 		apps: Server.IAppsServiceContract;
-		appsBower: Server.IAppsBowerServiceContract;
 		bower: Server.IBowerServiceContract;
+		appsBower: Server.IAppsBowerServiceContract;
 		build: Server.IBuildServiceContract;
 		appsBuild: Server.IAppsBuildServiceContract;
 		npm: Server.INpmServiceContract;
@@ -911,10 +977,10 @@ declare module Server{
 		status: Server.IStatusServiceContract;
 		tam: Server.ITamServiceContract;
 		appsTam: Server.IAppsTamServiceContract;
-		appsTap: Server.IAppsTapServiceContract;
 		tap: Server.ITapServiceContract;
-		appsVersioncontrol: Server.IAppsVersioncontrolServiceContract;
+		appsTap: Server.IAppsTapServiceContract;
 		versioncontrol: Server.IVersioncontrolServiceContract;
+		appsVersioncontrol: Server.IAppsVersioncontrolServiceContract;
 	}
 }
 

--- a/lib/server-api.ts
+++ b/lib/server-api.ts
@@ -28,6 +28,31 @@ export class AuthenticationService implements Server.IAuthenticationServiceContr
 		return this.$serviceProxy.call<void>('AgreeToEula', 'POST', ['api','authentication','eula'].join('/'), null, null, null);
 	}
 }
+export class AppsCordovaService implements Server.IAppsCordovaServiceContract{
+	constructor(private $serviceProxy: Server.IServiceProxy){
+	}
+	public getLiveSyncToken(appId: string, projectName: string): IFuture<string>{
+		return this.$serviceProxy.call<string>('GetLiveSyncToken', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'cordova',encodeURI(projectName.replace(/\\/g, '/')),'liveSyncToken'].join('/'), 'application/json', null, null);
+	}
+	public getCurrentPlatforms(appId: string, projectName: string): IFuture<Server.DevicePlatform[]>{
+		return this.$serviceProxy.call<Server.DevicePlatform[]>('GetCurrentPlatforms', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'cordova',encodeURI(projectName.replace(/\\/g, '/')),'platforms'].join('/'), 'application/json', null, null);
+	}
+	public addPlatform(appId: string, projectName: string, platform: Server.DevicePlatform): IFuture<Server.MigrationResult>{
+		return this.$serviceProxy.call<Server.MigrationResult>('AddPlatform', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'cordova',encodeURI(projectName.replace(/\\/g, '/')),'platforms',encodeURI((<any>platform).replace(/\\/g, '/'))].join('/'), 'application/json', null, null);
+	}
+	public migrate(appId: string, projectName: string, targetVersion: string): IFuture<Server.MigrationResult>{
+		return this.$serviceProxy.call<Server.MigrationResult>('Migrate', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'cordova',encodeURI(projectName.replace(/\\/g, '/')),'migrate'].join('/') + '?' + querystring.stringify({ 'targetVersion': targetVersion }), 'application/json', null, null);
+	}
+	public getProjectCordovaPlugins(appId: string, projectName: string): IFuture<Server.CordovaPluginData[]>{
+		return this.$serviceProxy.call<Server.CordovaPluginData[]>('GetProjectCordovaPlugins', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'cordova',encodeURI(projectName.replace(/\\/g, '/')),'plugins'].join('/'), 'application/json', null, null);
+	}
+	public getCordovaPluginVariables(appId: string, projectName: string): IFuture<Server.CordovaPluginVariablesData>{
+		return this.$serviceProxy.call<Server.CordovaPluginVariablesData>('GetCordovaPluginVariables', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'cordova',encodeURI(projectName.replace(/\\/g, '/')),'plugins','variables'].join('/'), 'application/json', null, null);
+	}
+	public setCordovaPluginVariable(appId: string, projectName: string, pluginId: string, variableName: string, configuration: string, value: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('SetCordovaPluginVariable', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'cordova',encodeURI(projectName.replace(/\\/g, '/')),'plugins','variables',encodeURI(pluginId.replace(/\\/g, '/')),encodeURI(variableName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'configuration': configuration }), null, [{name: 'value', value: JSON.stringify(value), contentType: 'application/json'}], null);
+	}
+}
 export class CordovaService implements Server.ICordovaServiceContract{
 	constructor(private $serviceProxy: Server.IServiceProxy){
 	}
@@ -81,31 +106,6 @@ export class CordovaService implements Server.ICordovaServiceContract{
 	}
 	public setCordovaPluginVariable(solutionName: string, projectName: string, pluginId: string, variableName: string, configuration: string, value: string): IFuture<void>{
 		return this.$serviceProxy.call<void>('SetCordovaPluginVariable', 'POST', ['api','cordova','plugins',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(projectName.replace(/\\/g, '/')),'variables',encodeURI(pluginId.replace(/\\/g, '/')),encodeURI(variableName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'configuration': configuration }), null, [{name: 'value', value: JSON.stringify(value), contentType: 'application/json'}], null);
-	}
-}
-export class AppsCordovaService implements Server.IAppsCordovaServiceContract{
-	constructor(private $serviceProxy: Server.IServiceProxy){
-	}
-	public getLiveSyncToken(appId: string, projectName: string): IFuture<string>{
-		return this.$serviceProxy.call<string>('GetLiveSyncToken', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'cordova',encodeURI(projectName.replace(/\\/g, '/')),'liveSyncToken'].join('/'), 'application/json', null, null);
-	}
-	public getCurrentPlatforms(appId: string, projectName: string): IFuture<Server.DevicePlatform[]>{
-		return this.$serviceProxy.call<Server.DevicePlatform[]>('GetCurrentPlatforms', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'cordova',encodeURI(projectName.replace(/\\/g, '/')),'platforms'].join('/'), 'application/json', null, null);
-	}
-	public addPlatform(appId: string, projectName: string, platform: Server.DevicePlatform): IFuture<Server.MigrationResult>{
-		return this.$serviceProxy.call<Server.MigrationResult>('AddPlatform', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'cordova',encodeURI(projectName.replace(/\\/g, '/')),'platforms',encodeURI((<any>platform).replace(/\\/g, '/'))].join('/'), 'application/json', null, null);
-	}
-	public migrate(appId: string, projectName: string, targetVersion: string): IFuture<Server.MigrationResult>{
-		return this.$serviceProxy.call<Server.MigrationResult>('Migrate', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'cordova',encodeURI(projectName.replace(/\\/g, '/')),'migrate'].join('/') + '?' + querystring.stringify({ 'targetVersion': targetVersion }), 'application/json', null, null);
-	}
-	public getProjectCordovaPlugins(appId: string, projectName: string): IFuture<Server.CordovaPluginData[]>{
-		return this.$serviceProxy.call<Server.CordovaPluginData[]>('GetProjectCordovaPlugins', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'cordova',encodeURI(projectName.replace(/\\/g, '/')),'plugins'].join('/'), 'application/json', null, null);
-	}
-	public getCordovaPluginVariables(appId: string, projectName: string): IFuture<Server.CordovaPluginVariablesData>{
-		return this.$serviceProxy.call<Server.CordovaPluginVariablesData>('GetCordovaPluginVariables', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'cordova',encodeURI(projectName.replace(/\\/g, '/')),'plugins','variables'].join('/'), 'application/json', null, null);
-	}
-	public setCordovaPluginVariable(appId: string, projectName: string, pluginId: string, variableName: string, configuration: string, value: string): IFuture<void>{
-		return this.$serviceProxy.call<void>('SetCordovaPluginVariable', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'cordova',encodeURI(projectName.replace(/\\/g, '/')),'plugins','variables',encodeURI(pluginId.replace(/\\/g, '/')),encodeURI(variableName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'configuration': configuration }), null, [{name: 'value', value: JSON.stringify(value), contentType: 'application/json'}], null);
 	}
 }
 export class IdentityStoreService implements Server.IIdentityStoreServiceContract{
@@ -182,6 +182,22 @@ export class UploadService implements Server.IUploadServiceContract{
 		return this.$serviceProxy.call<void>('UploadChunk', 'PUT', ['api','upload',encodeURI(path.replace(/\\/g, '/'))].join('/'), null, [{name: 'content', value: content, contentType: 'application/octet-stream'}], null);
 	}
 }
+export class AppsFilesService implements Server.IAppsFilesServiceContract{
+	constructor(private $serviceProxy: Server.IServiceProxy){
+	}
+	public getFile(appId: string, path: string, $resultStream: any): IFuture<void>{
+		return this.$serviceProxy.call<void>('GetFile', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'files',encodeURI(path.replace(/\\/g, '/'))].join('/'), 'application/octet-stream', null, $resultStream);
+	}
+	public save(appId: string, path: string, content: any): IFuture<void>{
+		return this.$serviceProxy.call<void>('Save', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'files',encodeURI(path.replace(/\\/g, '/'))].join('/'), null, [{name: 'content', value: content, contentType: 'application/octet-stream'}], null);
+	}
+	public createDirectory(appId: string, path: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('CreateDirectory', 'MKDIR', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'files',encodeURI(path.replace(/\\/g, '/'))].join('/'), null, null, null);
+	}
+	public remove(appId: string, path: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('Remove', 'DELETE', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'files',encodeURI(path.replace(/\\/g, '/'))].join('/'), null, null, null);
+	}
+}
 export class FilesystemService implements Server.IFilesystemServiceContract{
 	constructor(private $serviceProxy: Server.IServiceProxy){
 	}
@@ -199,28 +215,6 @@ export class FilesystemService implements Server.IFilesystemServiceContract{
 	}
 	public remove(solutionName: string, path: string): IFuture<void>{
 		return this.$serviceProxy.call<void>('Remove', 'DELETE', ['api','filesystem',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(path.replace(/\\/g, '/'))].join('/'), null, null, null);
-	}
-}
-export class AppsFilesService implements Server.IAppsFilesServiceContract{
-	constructor(private $serviceProxy: Server.IServiceProxy){
-	}
-	public getFile(appId: string, path: string, $resultStream: any): IFuture<void>{
-		return this.$serviceProxy.call<void>('GetFile', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'files',encodeURI(path.replace(/\\/g, '/'))].join('/'), 'application/octet-stream', null, $resultStream);
-	}
-	public save(appId: string, path: string, content: any): IFuture<void>{
-		return this.$serviceProxy.call<void>('Save', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'files',encodeURI(path.replace(/\\/g, '/'))].join('/'), null, [{name: 'content', value: content, contentType: 'application/octet-stream'}], null);
-	}
-	public createDirectory(appId: string, path: string): IFuture<void>{
-		return this.$serviceProxy.call<void>('CreateDirectory', 'MKDIR', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'files',encodeURI(path.replace(/\\/g, '/'))].join('/'), null, null, null);
-	}
-	public remove(appId: string, path: string): IFuture<void>{
-		return this.$serviceProxy.call<void>('Remove', 'DELETE', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'files',encodeURI(path.replace(/\\/g, '/'))].join('/'), null, null, null);
-	}
-	public rename(appId: string, path: string, destinationAppId: string, newPath: string): IFuture<void>{
-		return this.$serviceProxy.call<void>('Rename', 'MOVE', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'files',encodeURI(path.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'destinationAppId': destinationAppId }), null, [{name: 'newPath', value: JSON.stringify(newPath), contentType: 'application/json'}], null);
-	}
-	public copy(appId: string, path: string, destinationAppId: string, destination: string): IFuture<void>{
-		return this.$serviceProxy.call<void>('Copy', 'COPY', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'files',encodeURI(path.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'destinationAppId': destinationAppId }), null, [{name: 'destination', value: JSON.stringify(destination), contentType: 'application/json'}], null);
 	}
 }
 export class AppsImagesService implements Server.IAppsImagesServiceContract{
@@ -249,8 +243,11 @@ export class ImagesService implements Server.IImagesServiceContract{
 export class AppsItmstransporterService implements Server.IAppsItmstransporterServiceContract{
 	constructor(private $serviceProxy: Server.IServiceProxy){
 	}
-	public uploadApplication(appId: string, projectName: string, relativePackagePath: string, adamId: number, username: string, password: string): IFuture<void>{
-		return this.$serviceProxy.call<void>('UploadApplication', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'itmstransporter','upload',encodeURI(projectName.replace(/\\/g, '/')),encodeURI(relativePackagePath.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'adamId': adamId, 'username': username }), null, [{name: 'password', value: JSON.stringify(password), contentType: 'application/json'}], null);
+	public uploadApplication(appId: string, projectName: string, adamId: number, packageUri: Server.Uri, username: string, password: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('UploadApplication', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'itmstransporter','upload',encodeURI(projectName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'adamId': adamId, 'packageUri': packageUri, 'username': username }), null, [{name: 'password', value: JSON.stringify(password), contentType: 'application/json'}], null);
+	}
+	public uploadApplication1(appId: string, projectName: string, relativePackagePath: string, adamId: number, username: string, password: string): IFuture<void>{
+			return this.$serviceProxy.call<void>('UploadApplication', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'itmstransporter','upload',encodeURI(projectName.replace(/\\/g, '/')),encodeURI(relativePackagePath.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'adamId': adamId, 'username': username }), null, [{name: 'password', value: JSON.stringify(password), contentType: 'application/json'}], null);
 	}
 }
 export class ItmstransporterService implements Server.IItmstransporterServiceContract{
@@ -259,8 +256,11 @@ export class ItmstransporterService implements Server.IItmstransporterServiceCon
 	public getApplicationsReadyForUpload(username: string, password: string): IFuture<Server.Application[]>{
 		return this.$serviceProxy.call<Server.Application[]>('GetApplicationsReadyForUpload', 'POST', ['api','itmstransporter','applications'].join('/') + '?' + querystring.stringify({ 'username': username }), 'application/json', [{name: 'password', value: JSON.stringify(password), contentType: 'application/json'}], null);
 	}
-	public uploadApplication(solutionName: string, projectName: string, relativePackagePath: string, adamId: number, username: string, password: string): IFuture<void>{
-		return this.$serviceProxy.call<void>('UploadApplication', 'POST', ['api','itmstransporter','upload',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(projectName.replace(/\\/g, '/')),encodeURI(relativePackagePath.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'adamId': adamId, 'username': username }), null, [{name: 'password', value: JSON.stringify(password), contentType: 'application/json'}], null);
+	public uploadApplication(solutionName: string, projectName: string, adamId: number, packageUri: Server.Uri, username: string, password: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('UploadApplication', 'POST', ['api','itmstransporter','upload',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(projectName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'adamId': adamId, 'packageUri': packageUri, 'username': username }), null, [{name: 'password', value: JSON.stringify(password), contentType: 'application/json'}], null);
+	}
+	public uploadApplication1(solutionName: string, projectName: string, relativePackagePath: string, adamId: number, username: string, password: string): IFuture<void>{
+			return this.$serviceProxy.call<void>('UploadApplication', 'POST', ['api','itmstransporter','upload',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(projectName.replace(/\\/g, '/')),encodeURI(relativePackagePath.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'adamId': adamId, 'username': username }), null, [{name: 'password', value: JSON.stringify(password), contentType: 'application/json'}], null);
 	}
 }
 export class KendoService implements Server.IKendoServiceContract{
@@ -318,12 +318,59 @@ export class AppsNativescriptService implements Server.IAppsNativescriptServiceC
 	public migrate(appId: string, projectName: string, targetVersion: string): IFuture<Server.MigrationResult>{
 		return this.$serviceProxy.call<Server.MigrationResult>('Migrate', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'nativescript','migrate',encodeURI(projectName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'targetVersion': targetVersion }), 'application/json', null, null);
 	}
+	public migrate1(appId: string, projectName: string, targetVersion: string): IFuture<Server.MigrationResult>{
+			return this.$serviceProxy.call<Server.MigrationResult>('Migrate', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'nativescript',encodeURI(projectName.replace(/\\/g, '/')),'migrate'].join('/') + '?' + querystring.stringify({ 'targetVersion': targetVersion }), 'application/json', null, null);
+	}
+}
+export class InternalAppsProjectsService implements Server.IInternalAppsProjectsServiceContract{
+	constructor(private $serviceProxy: Server.IServiceProxy){
+	}
+	public getProjectPhysicalPaths(appId: string, projectName: string): IFuture<Server.Object>{
+		return this.$serviceProxy.call<Server.Object>('GetProjectPhysicalPaths', 'GET', ['api','internal','apps',encodeURI(appId.replace(/\\/g, '/')),'projects',encodeURI(projectName.replace(/\\/g, '/')),'path'].join('/'), 'application/json', null, null);
+	}
+}
+export class AppsProjectsService implements Server.IAppsProjectsServiceContract{
+	constructor(private $serviceProxy: Server.IServiceProxy){
+	}
+	public exportProject(appId: string, projectName: string, skipMetadata: boolean, $resultStream: any): IFuture<void>{
+		return this.$serviceProxy.call<void>('ExportProject', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'projects','export',encodeURI(projectName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'skipMetadata': skipMetadata }), 'application/octet-stream', null, $resultStream);
+	}
+	public importPackage(appId: string, projectName: string, parentIdentifier: string, archivePackage: any): IFuture<void>{
+		return this.$serviceProxy.call<void>('ImportPackage', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'projects','import',encodeURI(projectName.replace(/\\/g, '/')),encodeURI(parentIdentifier.replace(/\\/g, '/'))].join('/'), null, [{name: 'archivePackage', value: archivePackage, contentType: 'application/octet-stream'}], null);
+	}
+	public importProject(appId: string, projectName: string, cleanImport: boolean, package_: any): IFuture<void>{
+		return this.$serviceProxy.call<void>('ImportProject', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'projects','importProject',encodeURI(projectName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'cleanImport': cleanImport }), null, [{name: 'package_', value: package_, contentType: 'application/octet-stream'}], null);
+	}
+	public importLocalProject(appId: string, projectName: string, bucketKey: string, cleanImport: boolean): IFuture<void>{
+		return this.$serviceProxy.call<void>('ImportLocalProject', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'projects','importProject',encodeURI(projectName.replace(/\\/g, '/')),encodeURI(bucketKey.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'cleanImport': cleanImport }), null, null, null);
+	}
+	public getProjectContents(appId: string, projectName: string): IFuture<string>{
+		return this.$serviceProxy.call<string>('GetProjectContents', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'projects','contents',encodeURI(projectName.replace(/\\/g, '/'))].join('/'), 'application/json', null, null);
+	}
+	public saveProjectContents(appId: string, projectName: string, projectContents: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('SaveProjectContents', 'PUT', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'projects','contents',encodeURI(projectName.replace(/\\/g, '/'))].join('/'), null, [{name: 'projectContents', value: JSON.stringify(projectContents), contentType: 'application/json'}], null);
+	}
+	public getProjectConfiguraitons(appId: string, projectName: string): IFuture<string[]>{
+		return this.$serviceProxy.call<string[]>('GetProjectConfiguraitons', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'projects','configurations',encodeURI(projectName.replace(/\\/g, '/'))].join('/'), 'application/json', null, null);
+	}
+	public createProject(appId: string, projectName: string, expansionData: Server.ProjectTemplateExpansionData): IFuture<void>{
+		return this.$serviceProxy.call<void>('CreateProject', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'projects',encodeURI(projectName.replace(/\\/g, '/'))].join('/'), null, [{name: 'expansionData', value: JSON.stringify(expansionData), contentType: 'application/json'}], null);
+	}
+	public deleteProject(appId: string, projectName: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('DeleteProject', 'DELETE', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'projects',encodeURI(projectName.replace(/\\/g, '/'))].join('/'), null, null, null);
+	}
+	public setProjectProperty(appId: string, projectName: string, configuration: string, changeset: IDictionary<string>): IFuture<void>{
+		return this.$serviceProxy.call<void>('SetProjectProperty', 'PATCH', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'projects',encodeURI(projectName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'configuration': configuration }), null, [{name: 'changeset', value: JSON.stringify(changeset), contentType: 'application/json'}], null);
+	}
+	public renameProject(appId: string, projectName: string, newProjectName: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('RenameProject', 'PUT', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'projects','rename',encodeURI(projectName.replace(/\\/g, '/')),encodeURI(newProjectName.replace(/\\/g, '/'))].join('/'), null, null, null);
+	}
+	public createNewProjectItem(appId: string, projectName: string, itemIdentifier: string, expansionData: Server.ItemTemplateExpansionData): IFuture<Server.ProjectItemInfo[]>{
+		return this.$serviceProxy.call<Server.ProjectItemInfo[]>('CreateNewProjectItem', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'projects',encodeURI(projectName.replace(/\\/g, '/')),encodeURI(itemIdentifier.replace(/\\/g, '/'))].join('/'), 'application/json', [{name: 'expansionData', value: JSON.stringify(expansionData), contentType: 'application/json'}], null);
+	}
 }
 export class ProjectsService implements Server.IProjectsServiceContract{
 	constructor(private $serviceProxy: Server.IServiceProxy){
-	}
-	public getProjectFileSchema($resultStream: any): IFuture<void>{
-		return this.$serviceProxy.call<void>('GetProjectFileSchema', 'GET', ['api','projects','projectFileSchema'].join('/'), 'application/octet-stream', null, $resultStream);
 	}
 	public getProjectTemplates(): IFuture<Server.ProjectTemplateData[]>{
 		return this.$serviceProxy.call<Server.ProjectTemplateData[]>('GetProjectTemplates', 'GET', ['api','projects','projectTemplates'].join('/'), 'application/json', null, null);
@@ -340,17 +387,20 @@ export class ProjectsService implements Server.IProjectsServiceContract{
 	public importPackage(solutionName: string, projectName: string, parentIdentifier: string, archivePackage: any): IFuture<void>{
 		return this.$serviceProxy.call<void>('ImportPackage', 'POST', ['api','projects','import',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(projectName.replace(/\\/g, '/')),encodeURI(parentIdentifier.replace(/\\/g, '/'))].join('/'), null, [{name: 'archivePackage', value: archivePackage, contentType: 'application/octet-stream'}], null);
 	}
-	public importProject(solutionName: string, projectName: string, package_: any): IFuture<void>{
-		return this.$serviceProxy.call<void>('ImportProject', 'POST', ['api','projects','importProject',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(projectName.replace(/\\/g, '/'))].join('/'), null, [{name: 'package_', value: package_, contentType: 'application/octet-stream'}], null);
+	public importProject(solutionName: string, projectName: string, cleanImport: boolean, package_: any): IFuture<void>{
+		return this.$serviceProxy.call<void>('ImportProject', 'POST', ['api','projects','importProject',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(projectName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'cleanImport': cleanImport }), null, [{name: 'package_', value: package_, contentType: 'application/octet-stream'}], null);
 	}
-	public importLocalProject(solutionName: string, projectName: string, bucketKey: string): IFuture<void>{
-		return this.$serviceProxy.call<void>('ImportLocalProject', 'POST', ['api','projects','importProject',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(projectName.replace(/\\/g, '/')),encodeURI(bucketKey.replace(/\\/g, '/'))].join('/'), null, null, null);
+	public importLocalProject(solutionName: string, projectName: string, bucketKey: string, cleanImport: boolean): IFuture<void>{
+		return this.$serviceProxy.call<void>('ImportLocalProject', 'POST', ['api','projects','importProject',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(projectName.replace(/\\/g, '/')),encodeURI(bucketKey.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'cleanImport': cleanImport }), null, null, null);
 	}
 	public getProjectContents(solutionName: string, projectName: string): IFuture<string>{
 		return this.$serviceProxy.call<string>('GetProjectContents', 'GET', ['api','projects','contents',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(projectName.replace(/\\/g, '/'))].join('/'), 'application/json', null, null);
 	}
 	public saveProjectContents(solutionName: string, projectName: string, projectContents: string): IFuture<void>{
 		return this.$serviceProxy.call<void>('SaveProjectContents', 'PUT', ['api','projects','contents',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(projectName.replace(/\\/g, '/'))].join('/'), null, [{name: 'projectContents', value: JSON.stringify(projectContents), contentType: 'application/json'}], null);
+	}
+	public getProjectConfiguraitons(solutionName: string, projectName: string): IFuture<string[]>{
+		return this.$serviceProxy.call<string[]>('GetProjectConfiguraitons', 'GET', ['api','projects','configurations',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(projectName.replace(/\\/g, '/'))].join('/'), 'application/json', null, null);
 	}
 	public upgradeSolution(solutionName: string): IFuture<void>{
 		return this.$serviceProxy.call<void>('UpgradeSolution', 'UPGRADE', ['api','projects','upgrade',encodeURI(solutionName.replace(/\\/g, '/'))].join('/'), null, null, null);
@@ -366,6 +416,9 @@ export class ProjectsService implements Server.IProjectsServiceContract{
 	}
 	public createSolution(solutionName: string, expansionData: Server.ProjectTemplateExpansionData): IFuture<void>{
 		return this.$serviceProxy.call<void>('CreateSolution', 'POST', ['api','projects',encodeURI(solutionName.replace(/\\/g, '/'))].join('/'), null, [{name: 'expansionData', value: JSON.stringify(expansionData), contentType: 'application/json'}], null);
+	}
+	public getSolutionType(solutionName: string): IFuture<string>{
+		return this.$serviceProxy.call<string>('GetSolutionType', 'GET', ['api','projects',encodeURI(solutionName.replace(/\\/g, '/')),'type'].join('/'), 'application/json', null, null);
 	}
 	public renameSolution(solutionName: string, newSolutionName: string): IFuture<void>{
 		return this.$serviceProxy.call<void>('RenameSolution', 'PUT', ['api','projects','rename',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(newSolutionName.replace(/\\/g, '/'))].join('/'), null, null, null);
@@ -384,43 +437,6 @@ export class ProjectsService implements Server.IProjectsServiceContract{
 	}
 	public createNewProjectItem(solutionName: string, projectName: string, itemIdentifier: string, expansionData: Server.ItemTemplateExpansionData): IFuture<Server.ProjectItemInfo[]>{
 		return this.$serviceProxy.call<Server.ProjectItemInfo[]>('CreateNewProjectItem', 'POST', ['api','projects',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(projectName.replace(/\\/g, '/')),encodeURI(itemIdentifier.replace(/\\/g, '/'))].join('/'), 'application/json', [{name: 'expansionData', value: JSON.stringify(expansionData), contentType: 'application/json'}], null);
-	}
-}
-export class AppsProjectsService implements Server.IAppsProjectsServiceContract{
-	constructor(private $serviceProxy: Server.IServiceProxy){
-	}
-	public exportProject(appId: string, projectName: string, skipMetadata: boolean, $resultStream: any): IFuture<void>{
-		return this.$serviceProxy.call<void>('ExportProject', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'projects','export',encodeURI(projectName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'skipMetadata': skipMetadata }), 'application/octet-stream', null, $resultStream);
-	}
-	public importPackage(appId: string, projectName: string, parentIdentifier: string, archivePackage: any): IFuture<void>{
-		return this.$serviceProxy.call<void>('ImportPackage', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'projects','import',encodeURI(projectName.replace(/\\/g, '/')),encodeURI(parentIdentifier.replace(/\\/g, '/'))].join('/'), null, [{name: 'archivePackage', value: archivePackage, contentType: 'application/octet-stream'}], null);
-	}
-	public importProject(appId: string, projectName: string, package_: any): IFuture<void>{
-		return this.$serviceProxy.call<void>('ImportProject', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'projects','importProject',encodeURI(projectName.replace(/\\/g, '/'))].join('/'), null, [{name: 'package_', value: package_, contentType: 'application/octet-stream'}], null);
-	}
-	public importLocalProject(appId: string, projectName: string, bucketKey: string): IFuture<void>{
-		return this.$serviceProxy.call<void>('ImportLocalProject', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'projects','importProject',encodeURI(projectName.replace(/\\/g, '/')),encodeURI(bucketKey.replace(/\\/g, '/'))].join('/'), null, null, null);
-	}
-	public getProjectContents(appId: string, projectName: string): IFuture<string>{
-		return this.$serviceProxy.call<string>('GetProjectContents', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'projects','contents',encodeURI(projectName.replace(/\\/g, '/'))].join('/'), 'application/json', null, null);
-	}
-	public saveProjectContents(appId: string, projectName: string, projectContents: string): IFuture<void>{
-		return this.$serviceProxy.call<void>('SaveProjectContents', 'PUT', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'projects','contents',encodeURI(projectName.replace(/\\/g, '/'))].join('/'), null, [{name: 'projectContents', value: JSON.stringify(projectContents), contentType: 'application/json'}], null);
-	}
-	public createProject(appId: string, projectName: string, expansionData: Server.ProjectTemplateExpansionData): IFuture<void>{
-		return this.$serviceProxy.call<void>('CreateProject', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'projects',encodeURI(projectName.replace(/\\/g, '/'))].join('/'), null, [{name: 'expansionData', value: JSON.stringify(expansionData), contentType: 'application/json'}], null);
-	}
-	public deleteProject(appId: string, projectName: string): IFuture<void>{
-		return this.$serviceProxy.call<void>('DeleteProject', 'DELETE', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'projects',encodeURI(projectName.replace(/\\/g, '/'))].join('/'), null, null, null);
-	}
-	public setProjectProperty(appId: string, projectName: string, configuration: string, changeset: IDictionary<string>): IFuture<void>{
-		return this.$serviceProxy.call<void>('SetProjectProperty', 'PATCH', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'projects',encodeURI(projectName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'configuration': configuration }), null, [{name: 'changeset', value: JSON.stringify(changeset), contentType: 'application/json'}], null);
-	}
-	public renameProject(appId: string, projectName: string, newProjectName: string): IFuture<void>{
-		return this.$serviceProxy.call<void>('RenameProject', 'PUT', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'projects','rename',encodeURI(projectName.replace(/\\/g, '/')),encodeURI(newProjectName.replace(/\\/g, '/'))].join('/'), null, null, null);
-	}
-	public createNewProjectItem(appId: string, projectName: string, itemIdentifier: string, expansionData: Server.ItemTemplateExpansionData): IFuture<Server.ProjectItemInfo[]>{
-		return this.$serviceProxy.call<Server.ProjectItemInfo[]>('CreateNewProjectItem', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'projects',encodeURI(projectName.replace(/\\/g, '/')),encodeURI(itemIdentifier.replace(/\\/g, '/'))].join('/'), 'application/json', [{name: 'expansionData', value: JSON.stringify(expansionData), contentType: 'application/json'}], null);
 	}
 }
 export class AppsService implements Server.IAppsServiceContract{
@@ -447,24 +463,17 @@ export class AppsService implements Server.IAppsServiceContract{
 	public upgradeApplication(appId: string): IFuture<void>{
 		return this.$serviceProxy.call<void>('UpgradeApplication', 'PUT', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'upgrade'].join('/'), null, null, null);
 	}
-	public getApplicationServices(appId: string): IFuture<Server.ApplicationServiceData[]>{
-		return this.$serviceProxy.call<Server.ApplicationServiceData[]>('GetApplicationServices', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'services'].join('/'), 'application/json', null, null);
+	public getApplicationServices(appId: string, serviceNames: string[]): IFuture<Server.ApplicationServiceData[]>{
+		return this.$serviceProxy.call<Server.ApplicationServiceData[]>('GetApplicationServices', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'services'].join('/') + '?' + querystring.stringify({ 'serviceNames': serviceNames }), 'application/json', null, null);
 	}
 	public enableApplicationService(appId: string, serviceData: IDictionary<Object>): IFuture<IDictionary<Object>>{
 		return this.$serviceProxy.call<IDictionary<Object>>('EnableApplicationService', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'services'].join('/'), 'application/json', [{name: 'serviceData', value: JSON.stringify(serviceData), contentType: 'application/json'}], null);
 	}
-}
-export class AppsBowerService implements Server.IAppsBowerServiceContract{
-	constructor(private $serviceProxy: Server.IServiceProxy){
+	public getApplicationType(appId: string): IFuture<string>{
+		return this.$serviceProxy.call<string>('GetApplicationType', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'type'].join('/'), 'application/json', null, null);
 	}
-	public installDependencies(appId: string, projectName: string): IFuture<void>{
-		return this.$serviceProxy.call<void>('InstallDependencies', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'bower','dependencies',encodeURI(projectName.replace(/\\/g, '/'))].join('/'), null, null, null);
-	}
-	public installPackage(appId: string, projectName: string, packageName: string, version: string): IFuture<void>{
-		return this.$serviceProxy.call<void>('InstallPackage', 'PUT', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'bower',encodeURI(projectName.replace(/\\/g, '/')),encodeURI(packageName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'version': version }), null, null, null);
-	}
-	public getInstalledPackages(appId: string, projectName: string): IFuture<Server.PackageData[]>{
-		return this.$serviceProxy.call<Server.PackageData[]>('GetInstalledPackages', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'bower',encodeURI(projectName.replace(/\\/g, '/'))].join('/'), 'application/json', null, null);
+	public deleteApplicationCache(appId: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('DeleteApplicationCache', 'DELETE', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'cache'].join('/'), null, null, null);
 	}
 }
 export class BowerService implements Server.IBowerServiceContract{
@@ -481,6 +490,19 @@ export class BowerService implements Server.IBowerServiceContract{
 	}
 	public getFilters(): IFuture<Server.BowerPackagesFilters>{
 		return this.$serviceProxy.call<Server.BowerPackagesFilters>('GetFilters', 'GET', ['api','bower','filters'].join('/'), 'application/json', null, null);
+	}
+}
+export class AppsBowerService implements Server.IAppsBowerServiceContract{
+	constructor(private $serviceProxy: Server.IServiceProxy){
+	}
+	public installDependencies(appId: string, projectName: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('InstallDependencies', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'bower','dependencies',encodeURI(projectName.replace(/\\/g, '/'))].join('/'), null, null, null);
+	}
+	public installPackage(appId: string, projectName: string, packageName: string, version: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('InstallPackage', 'PUT', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'bower',encodeURI(projectName.replace(/\\/g, '/')),encodeURI(packageName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'version': version }), null, null, null);
+	}
+	public getInstalledPackages(appId: string, projectName: string): IFuture<Server.PackageData[]>{
+		return this.$serviceProxy.call<Server.PackageData[]>('GetInstalledPackages', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'bower',encodeURI(projectName.replace(/\\/g, '/'))].join('/'), 'application/json', null, null);
 	}
 }
 export class BuildService implements Server.IBuildServiceContract{
@@ -597,6 +619,9 @@ export class StatusService implements Server.IStatusServiceContract{
 	public getMacBuildMachineStatus(): IFuture<string>{
 		return this.$serviceProxy.call<string>('GetMacBuildMachineStatus', 'GET', ['api','status','build','iOS'].join('/'), 'application/json', null, null);
 	}
+	public getStorageStatus(): IFuture<Server.StorageMachineStatus[]>{
+		return this.$serviceProxy.call<Server.StorageMachineStatus[]>('GetStorageStatus', 'GET', ['api','status','storage'].join('/'), 'application/json', null, null);
+	}
 }
 export class TamService implements Server.ITamServiceContract{
 	constructor(private $serviceProxy: Server.IServiceProxy){
@@ -607,8 +632,11 @@ export class TamService implements Server.ITamServiceContract{
 	public getGroups(): IFuture<Server.TamGroupData[]>{
 		return this.$serviceProxy.call<Server.TamGroupData[]>('GetGroups', 'GET', ['api','tam','groups'].join('/'), 'application/json', null, null);
 	}
-	public uploadApplication(solutionName: string, projectName: string, relativePackagePath: string, settings: Server.PublishSettings): IFuture<Server.UploadedAppData>{
-		return this.$serviceProxy.call<Server.UploadedAppData>('UploadApplication', 'POST', ['api','tam','applications',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(projectName.replace(/\\/g, '/')),encodeURI(relativePackagePath.replace(/\\/g, '/'))].join('/'), 'application/json', [{name: 'settings', value: JSON.stringify(settings), contentType: 'application/json'}], null);
+	public uploadApplication(solutionName: string, projectName: string, packageUri: Server.Uri, settings: Server.PublishSettings): IFuture<Server.UploadedAppData>{
+		return this.$serviceProxy.call<Server.UploadedAppData>('UploadApplication', 'POST', ['api','tam','applications',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(projectName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'packageUri': packageUri }), 'application/json', [{name: 'settings', value: JSON.stringify(settings), contentType: 'application/json'}], null);
+	}
+	public uploadApplication1(solutionName: string, projectName: string, relativePackagePath: string, settings: Server.PublishSettings): IFuture<Server.UploadedAppData>{
+			return this.$serviceProxy.call<Server.UploadedAppData>('UploadApplication', 'POST', ['api','tam','applications',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(projectName.replace(/\\/g, '/')),encodeURI(relativePackagePath.replace(/\\/g, '/'))].join('/'), 'application/json', [{name: 'settings', value: JSON.stringify(settings), contentType: 'application/json'}], null);
 	}
 	public uploadPatch(solutionName: string, projectName: string, patchData: Server.PatchData): IFuture<void>{
 		return this.$serviceProxy.call<void>('UploadPatch', 'POST', ['api','tam',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(projectName.replace(/\\/g, '/')),'patches'].join('/'), null, [{name: 'patchData', value: JSON.stringify(patchData), contentType: 'application/json'}], null);
@@ -620,24 +648,14 @@ export class TamService implements Server.ITamServiceContract{
 export class AppsTamService implements Server.IAppsTamServiceContract{
 	constructor(private $serviceProxy: Server.IServiceProxy){
 	}
-	public uploadApplication(appId: string, projectName: string, relativePackagePath: string, settings: Server.PublishSettings): IFuture<Server.UploadedAppData>{
-		return this.$serviceProxy.call<Server.UploadedAppData>('UploadApplication', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'tam','applications',encodeURI(projectName.replace(/\\/g, '/')),encodeURI(relativePackagePath.replace(/\\/g, '/'))].join('/'), 'application/json', [{name: 'settings', value: JSON.stringify(settings), contentType: 'application/json'}], null);
+	public uploadApplication(appId: string, projectName: string, packageUri: Server.Uri, settings: Server.PublishSettings): IFuture<Server.UploadedAppData>{
+		return this.$serviceProxy.call<Server.UploadedAppData>('UploadApplication', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'tam','applications',encodeURI(projectName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'packageUri': packageUri }), 'application/json', [{name: 'settings', value: JSON.stringify(settings), contentType: 'application/json'}], null);
+	}
+	public uploadApplication1(appId: string, projectName: string, relativePackagePath: string, settings: Server.PublishSettings): IFuture<Server.UploadedAppData>{
+			return this.$serviceProxy.call<Server.UploadedAppData>('UploadApplication', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'tam','applications',encodeURI(projectName.replace(/\\/g, '/')),encodeURI(relativePackagePath.replace(/\\/g, '/'))].join('/'), 'application/json', [{name: 'settings', value: JSON.stringify(settings), contentType: 'application/json'}], null);
 	}
 	public uploadPatch(appId: string, projectName: string, patchData: Server.PatchData): IFuture<void>{
 		return this.$serviceProxy.call<void>('UploadPatch', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'tam','patches',encodeURI(projectName.replace(/\\/g, '/'))].join('/'), null, [{name: 'patchData', value: JSON.stringify(patchData), contentType: 'application/json'}], null);
-	}
-}
-export class AppsTapService implements Server.IAppsTapServiceContract{
-	constructor(private $serviceProxy: Server.IServiceProxy){
-	}
-	public getRemote(appId: string): IFuture<string>{
-		return this.$serviceProxy.call<string>('GetRemote', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'tap','versioncontrol','remote'].join('/'), 'application/json', null, null);
-	}
-	public setRemote(appId: string, remoteUrl: string): IFuture<void>{
-		return this.$serviceProxy.call<void>('SetRemote', 'PUT', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'tap','versioncontrol','remote'].join('/'), null, [{name: 'remoteUrl', value: JSON.stringify(remoteUrl), contentType: 'application/json'}], null);
-	}
-	public initCurrentUserSharedRepository(appId: string): IFuture<boolean>{
-		return this.$serviceProxy.call<boolean>('InitCurrentUserSharedRepository', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'tap','userProjects','initSharedRepository'].join('/'), 'application/json', null, null);
 	}
 }
 export class TapService implements Server.ITapServiceContract{
@@ -661,6 +679,9 @@ export class TapService implements Server.ITapServiceContract{
 	public initCurrentUserSharedRepository(solutionName: string): IFuture<boolean>{
 		return this.$serviceProxy.call<boolean>('InitCurrentUserSharedRepository', 'POST', ['api','tap','userProjects',encodeURI(solutionName.replace(/\\/g, '/')),'initSharedRepository'].join('/'), 'application/json', null, null);
 	}
+	public migrate(solutionName: string, appId: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('Migrate', 'POST', ['api','tap','migrate',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(appId.replace(/\\/g, '/'))].join('/'), null, null, null);
+	}
 	public getWorkspaces(accountId: string): IFuture<Server.TapWorkspaceData[]>{
 		return this.$serviceProxy.call<Server.TapWorkspaceData[]>('GetWorkspaces', 'GET', ['api','tap','workspaces',encodeURI(accountId.replace(/\\/g, '/'))].join('/'), 'application/json', null, null);
 	}
@@ -683,86 +704,17 @@ export class TapService implements Server.ITapServiceContract{
 		return this.$serviceProxy.call<Server.TapNotificationData[]>('GetReadNotifications', 'GET', ['api','tap','notifications',encodeURI(accountId.replace(/\\/g, '/')),'read'].join('/') + '?' + querystring.stringify({ 'fromDate': fromDate }), 'application/json', null, null);
 	}
 }
-export class AppsVersioncontrolService implements Server.IAppsVersioncontrolServiceContract{
+export class AppsTapService implements Server.IAppsTapServiceContract{
 	constructor(private $serviceProxy: Server.IServiceProxy){
 	}
-	public init(appId: string): IFuture<void>{
-		return this.$serviceProxy.call<void>('Init', 'INIT', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol'].join('/'), null, null, null);
-	}
-	public rollback(appId: string, versionName: string): IFuture<void>{
-		return this.$serviceProxy.call<void>('Rollback', 'ROLLBACK', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol'].join('/') + '?' + querystring.stringify({ 'versionName': versionName }), null, null, null);
-	}
-	public reset(appId: string, resetMode: Server.ResetMode, versionName: string): IFuture<void>{
-		return this.$serviceProxy.call<void>('Reset', 'RESET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol'].join('/') + '?' + querystring.stringify({ 'resetMode': resetMode, 'versionName': versionName }), null, null, null);
-	}
-	public merge(appId: string, versionName: string): IFuture<Server.BranchItemData>{
-		return this.$serviceProxy.call<Server.BranchItemData>('Merge', 'MERGE', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol'].join('/') + '?' + querystring.stringify({ 'versionName': versionName }), 'application/json', null, null);
-	}
-	public revert(appId: string, versionName: string, filePaths: string[]): IFuture<void>{
-		return this.$serviceProxy.call<void>('Revert', 'REVERT', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','files'].join('/') + '?' + querystring.stringify({ 'versionName': versionName }), null, [{name: 'filePaths', value: JSON.stringify(filePaths), contentType: 'application/json'}], null);
-	}
-	public resolve(appId: string, versionName: string, filePaths: string[]): IFuture<void>{
-		return this.$serviceProxy.call<void>('Resolve', 'RESOLVE', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','files'].join('/') + '?' + querystring.stringify({ 'versionName': versionName }), null, [{name: 'filePaths', value: JSON.stringify(filePaths), contentType: 'application/json'}], null);
-	}
-	public checkout(appId: string, versionName: string, filePaths: string[]): IFuture<void>{
-		return this.$serviceProxy.call<void>('Checkout', 'CHECKOUT', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','files'].join('/') + '?' + querystring.stringify({ 'versionName': versionName }), null, [{name: 'filePaths', value: JSON.stringify(filePaths), contentType: 'application/json'}], null);
-	}
-	public add(appId: string, filePaths: string[]): IFuture<void>{
-		return this.$serviceProxy.call<void>('Add', 'ADD', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','files'].join('/'), null, [{name: 'filePaths', value: JSON.stringify(filePaths), contentType: 'application/json'}], null);
-	}
-	public remove(appId: string, filePaths: string[]): IFuture<void>{
-		return this.$serviceProxy.call<void>('Remove', 'REMOVE', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','files'].join('/'), null, [{name: 'filePaths', value: JSON.stringify(filePaths), contentType: 'application/json'}], null);
-	}
-	public getBranches(appId: string): IFuture<Server.BranchItemData[]>{
-		return this.$serviceProxy.call<Server.BranchItemData[]>('GetBranches', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','branches'].join('/'), 'application/json', null, null);
-	}
-	public getCurrentBranch(appId: string): IFuture<Server.BranchItemData>{
-		return this.$serviceProxy.call<Server.BranchItemData>('GetCurrentBranch', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','branch'].join('/'), 'application/json', null, null);
-	}
-	public checkoutBranch(appId: string, branchName: string, createBranch: boolean, versionName: string): IFuture<Server.BranchItemData>{
-		return this.$serviceProxy.call<Server.BranchItemData>('CheckoutBranch', 'CHECKOUT', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','branches',encodeURI(branchName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'createBranch': createBranch, 'versionName': versionName }), 'application/json', null, null);
-	}
-	public createBranch(appId: string, branchName: string, versionName: string): IFuture<Server.BranchItemData>{
-		return this.$serviceProxy.call<Server.BranchItemData>('CreateBranch', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','branches',encodeURI(branchName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'versionName': versionName }), 'application/json', null, null);
-	}
-	public deleteBranch(appId: string, branchName: string, forceDelete: boolean): IFuture<void>{
-		return this.$serviceProxy.call<void>('DeleteBranch', 'DELETE', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','branches',encodeURI(branchName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'forceDelete': forceDelete }), null, null, null);
-	}
 	public getRemote(appId: string): IFuture<string>{
-		return this.$serviceProxy.call<string>('GetRemote', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','remote'].join('/'), 'application/json', null, null);
+		return this.$serviceProxy.call<string>('GetRemote', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'tap','versioncontrol','remote'].join('/'), 'application/json', null, null);
 	}
-	public setRemote(appId: string, remoteData: Server.GitRemoteData): IFuture<void>{
-		return this.$serviceProxy.call<void>('SetRemote', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','remote'].join('/'), null, [{name: 'remoteData', value: JSON.stringify(remoteData), contentType: 'application/json'}], null);
+	public setRemote(appId: string, remoteUrl: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('SetRemote', 'PUT', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'tap','versioncontrol','remote'].join('/'), null, [{name: 'remoteUrl', value: JSON.stringify(remoteUrl), contentType: 'application/json'}], null);
 	}
-	public getInfo(appId: string): IFuture<Server.VersionControlData>{
-		return this.$serviceProxy.call<Server.VersionControlData>('GetInfo', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','info'].join('/'), 'application/json', null, null);
-	}
-	public track(appId: string): IFuture<Server.ChangeItemData[]>{
-		return this.$serviceProxy.call<Server.ChangeItemData[]>('Track', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','status'].join('/'), 'application/json', null, null);
-	}
-	public getStatus(appId: string, filePaths: string[]): IFuture<Server.ChangeItemData[]>{
-		return this.$serviceProxy.call<Server.ChangeItemData[]>('GetStatus', 'XGET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','status','files'].join('/'), 'application/json', [{name: 'filePaths', value: JSON.stringify(filePaths), contentType: 'application/json'}], null);
-	}
-	public getDiff(appId: string, versionName: string, contextSize: number, otherVersionName: string, filePaths: string[]): IFuture<Server.DiffLineResultData[]>{
-		return this.$serviceProxy.call<Server.DiffLineResultData[]>('GetDiff', 'XGET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol',encodeURI(versionName.replace(/\\/g, '/')),'diff','files'].join('/') + '?' + querystring.stringify({ 'contextSize': contextSize, 'otherVersionName': otherVersionName }), 'application/json', [{name: 'filePaths', value: JSON.stringify(filePaths), contentType: 'application/json'}], null);
-	}
-	public getConflicts(appId: string, contextSize: number, filePaths: string[]): IFuture<Server.DiffLineResultData[]>{
-		return this.$serviceProxy.call<Server.DiffLineResultData[]>('GetConflicts', 'XGET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','conflicts','files'].join('/') + '?' + querystring.stringify({ 'contextSize': contextSize }), 'application/json', [{name: 'filePaths', value: JSON.stringify(filePaths), contentType: 'application/json'}], null);
-	}
-	public getCommits(appId: string, endDate: Date, startDate: Date): IFuture<Server.ChangeSetData[]>{
-		return this.$serviceProxy.call<Server.ChangeSetData[]>('GetCommits', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','commits'].join('/') + '?' + querystring.stringify({ 'endDate': endDate, 'startDate': startDate }), 'application/json', null, null);
-	}
-	public getCommit(appId: string, versionName: string): IFuture<Server.ChangeSetData>{
-		return this.$serviceProxy.call<Server.ChangeSetData>('GetCommit', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','commit'].join('/') + '?' + querystring.stringify({ 'versionName': versionName }), 'application/json', null, null);
-	}
-	public getChanges(appId: string, versionName: string): IFuture<Server.ChangeItemData[]>{
-		return this.$serviceProxy.call<Server.ChangeItemData[]>('GetChanges', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol',encodeURI(versionName.replace(/\\/g, '/')),'changes'].join('/'), 'application/json', null, null);
-	}
-	public getContents(appId: string, versionName: string, filePath: string): IFuture<string>{
-		return this.$serviceProxy.call<string>('GetContents', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol',encodeURI(versionName.replace(/\\/g, '/')),'contents',encodeURI(filePath.replace(/\\/g, '/'))].join('/'), 'application/json', null, null);
-	}
-	public getHistory(appId: string, versionName: string, filePath: string): IFuture<Server.HistoryItemData[]>{
-		return this.$serviceProxy.call<Server.HistoryItemData[]>('GetHistory', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol',encodeURI(versionName.replace(/\\/g, '/')),'history',encodeURI(filePath.replace(/\\/g, '/'))].join('/'), 'application/json', null, null);
+	public initCurrentUserSharedRepository(appId: string): IFuture<boolean>{
+		return this.$serviceProxy.call<boolean>('InitCurrentUserSharedRepository', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'tap','userProjects','initSharedRepository'].join('/'), 'application/json', null, null);
 	}
 }
 export class VersioncontrolService implements Server.IVersioncontrolServiceContract{
@@ -847,18 +799,100 @@ export class VersioncontrolService implements Server.IVersioncontrolServiceContr
 		return this.$serviceProxy.call<Server.HistoryItemData[]>('GetHistory', 'GET', ['api','versioncontrol',encodeURI(solutionName.replace(/\\/g, '/')),encodeURI(versionName.replace(/\\/g, '/')),'history',encodeURI(filePath.replace(/\\/g, '/'))].join('/'), 'application/json', null, null);
 	}
 }
+export class AppsVersioncontrolService implements Server.IAppsVersioncontrolServiceContract{
+	constructor(private $serviceProxy: Server.IServiceProxy){
+	}
+	public init(appId: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('Init', 'INIT', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol'].join('/'), null, null, null);
+	}
+	public rollback(appId: string, versionName: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('Rollback', 'ROLLBACK', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol'].join('/') + '?' + querystring.stringify({ 'versionName': versionName }), null, null, null);
+	}
+	public reset(appId: string, resetMode: Server.ResetMode, versionName: string): IFuture<void>{
+		return this.$serviceProxy.call<void>('Reset', 'RESET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol'].join('/') + '?' + querystring.stringify({ 'resetMode': resetMode, 'versionName': versionName }), null, null, null);
+	}
+	public merge(appId: string, versionName: string): IFuture<Server.BranchItemData>{
+		return this.$serviceProxy.call<Server.BranchItemData>('Merge', 'MERGE', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol'].join('/') + '?' + querystring.stringify({ 'versionName': versionName }), 'application/json', null, null);
+	}
+	public revert(appId: string, versionName: string, filePaths: string[]): IFuture<void>{
+		return this.$serviceProxy.call<void>('Revert', 'REVERT', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','files'].join('/') + '?' + querystring.stringify({ 'versionName': versionName }), null, [{name: 'filePaths', value: JSON.stringify(filePaths), contentType: 'application/json'}], null);
+	}
+	public resolve(appId: string, versionName: string, filePaths: string[]): IFuture<void>{
+		return this.$serviceProxy.call<void>('Resolve', 'RESOLVE', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','files'].join('/') + '?' + querystring.stringify({ 'versionName': versionName }), null, [{name: 'filePaths', value: JSON.stringify(filePaths), contentType: 'application/json'}], null);
+	}
+	public checkout(appId: string, versionName: string, filePaths: string[]): IFuture<void>{
+		return this.$serviceProxy.call<void>('Checkout', 'CHECKOUT', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','files'].join('/') + '?' + querystring.stringify({ 'versionName': versionName }), null, [{name: 'filePaths', value: JSON.stringify(filePaths), contentType: 'application/json'}], null);
+	}
+	public add(appId: string, filePaths: string[]): IFuture<void>{
+		return this.$serviceProxy.call<void>('Add', 'ADD', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','files'].join('/'), null, [{name: 'filePaths', value: JSON.stringify(filePaths), contentType: 'application/json'}], null);
+	}
+	public remove(appId: string, filePaths: string[]): IFuture<void>{
+		return this.$serviceProxy.call<void>('Remove', 'REMOVE', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','files'].join('/'), null, [{name: 'filePaths', value: JSON.stringify(filePaths), contentType: 'application/json'}], null);
+	}
+	public getBranches(appId: string): IFuture<Server.BranchItemData[]>{
+		return this.$serviceProxy.call<Server.BranchItemData[]>('GetBranches', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','branches'].join('/'), 'application/json', null, null);
+	}
+	public getCurrentBranch(appId: string): IFuture<Server.BranchItemData>{
+		return this.$serviceProxy.call<Server.BranchItemData>('GetCurrentBranch', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','branch'].join('/'), 'application/json', null, null);
+	}
+	public checkoutBranch(appId: string, branchName: string, createBranch: boolean, versionName: string): IFuture<Server.BranchItemData>{
+		return this.$serviceProxy.call<Server.BranchItemData>('CheckoutBranch', 'CHECKOUT', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','branches',encodeURI(branchName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'createBranch': createBranch, 'versionName': versionName }), 'application/json', null, null);
+	}
+	public createBranch(appId: string, branchName: string, versionName: string): IFuture<Server.BranchItemData>{
+		return this.$serviceProxy.call<Server.BranchItemData>('CreateBranch', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','branches',encodeURI(branchName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'versionName': versionName }), 'application/json', null, null);
+	}
+	public deleteBranch(appId: string, branchName: string, forceDelete: boolean): IFuture<void>{
+		return this.$serviceProxy.call<void>('DeleteBranch', 'DELETE', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','branches',encodeURI(branchName.replace(/\\/g, '/'))].join('/') + '?' + querystring.stringify({ 'forceDelete': forceDelete }), null, null, null);
+	}
+	public getRemote(appId: string): IFuture<string>{
+		return this.$serviceProxy.call<string>('GetRemote', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','remote'].join('/'), 'application/json', null, null);
+	}
+	public setRemote(appId: string, remoteData: Server.GitRemoteData): IFuture<void>{
+		return this.$serviceProxy.call<void>('SetRemote', 'POST', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','remote'].join('/'), null, [{name: 'remoteData', value: JSON.stringify(remoteData), contentType: 'application/json'}], null);
+	}
+	public getInfo(appId: string): IFuture<Server.VersionControlData>{
+		return this.$serviceProxy.call<Server.VersionControlData>('GetInfo', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','info'].join('/'), 'application/json', null, null);
+	}
+	public track(appId: string): IFuture<Server.ChangeItemData[]>{
+		return this.$serviceProxy.call<Server.ChangeItemData[]>('Track', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','status'].join('/'), 'application/json', null, null);
+	}
+	public getStatus(appId: string, filePaths: string[]): IFuture<Server.ChangeItemData[]>{
+		return this.$serviceProxy.call<Server.ChangeItemData[]>('GetStatus', 'XGET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','status','files'].join('/'), 'application/json', [{name: 'filePaths', value: JSON.stringify(filePaths), contentType: 'application/json'}], null);
+	}
+	public getDiff(appId: string, versionName: string, contextSize: number, otherVersionName: string, filePaths: string[]): IFuture<Server.DiffLineResultData[]>{
+		return this.$serviceProxy.call<Server.DiffLineResultData[]>('GetDiff', 'XGET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol',encodeURI(versionName.replace(/\\/g, '/')),'diff','files'].join('/') + '?' + querystring.stringify({ 'contextSize': contextSize, 'otherVersionName': otherVersionName }), 'application/json', [{name: 'filePaths', value: JSON.stringify(filePaths), contentType: 'application/json'}], null);
+	}
+	public getConflicts(appId: string, contextSize: number, filePaths: string[]): IFuture<Server.DiffLineResultData[]>{
+		return this.$serviceProxy.call<Server.DiffLineResultData[]>('GetConflicts', 'XGET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','conflicts','files'].join('/') + '?' + querystring.stringify({ 'contextSize': contextSize }), 'application/json', [{name: 'filePaths', value: JSON.stringify(filePaths), contentType: 'application/json'}], null);
+	}
+	public getCommits(appId: string, endDate: Date, startDate: Date): IFuture<Server.ChangeSetData[]>{
+		return this.$serviceProxy.call<Server.ChangeSetData[]>('GetCommits', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','commits'].join('/') + '?' + querystring.stringify({ 'endDate': endDate, 'startDate': startDate }), 'application/json', null, null);
+	}
+	public getCommit(appId: string, versionName: string): IFuture<Server.ChangeSetData>{
+		return this.$serviceProxy.call<Server.ChangeSetData>('GetCommit', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol','commit'].join('/') + '?' + querystring.stringify({ 'versionName': versionName }), 'application/json', null, null);
+	}
+	public getChanges(appId: string, versionName: string): IFuture<Server.ChangeItemData[]>{
+		return this.$serviceProxy.call<Server.ChangeItemData[]>('GetChanges', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol',encodeURI(versionName.replace(/\\/g, '/')),'changes'].join('/'), 'application/json', null, null);
+	}
+	public getContents(appId: string, versionName: string, filePath: string): IFuture<string>{
+		return this.$serviceProxy.call<string>('GetContents', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol',encodeURI(versionName.replace(/\\/g, '/')),'contents',encodeURI(filePath.replace(/\\/g, '/'))].join('/'), 'application/json', null, null);
+	}
+	public getHistory(appId: string, versionName: string, filePath: string): IFuture<Server.HistoryItemData[]>{
+		return this.$serviceProxy.call<Server.HistoryItemData[]>('GetHistory', 'GET', ['api','apps',encodeURI(appId.replace(/\\/g, '/')),'versioncontrol',encodeURI(versionName.replace(/\\/g, '/')),'history',encodeURI(filePath.replace(/\\/g, '/'))].join('/'), 'application/json', null, null);
+	}
+}
 export class ServiceContainer implements Server.IServer{
 	constructor(private $injector: IInjector){ }
 	public authentication: Server.IAuthenticationServiceContract = this.$injector.resolve(AuthenticationService);
-	public cordova: Server.ICordovaServiceContract = this.$injector.resolve(CordovaService);
 	public appsCordova: Server.IAppsCordovaServiceContract = this.$injector.resolve(AppsCordovaService);
+	public cordova: Server.ICordovaServiceContract = this.$injector.resolve(CordovaService);
 	public identityStore: Server.IIdentityStoreServiceContract = this.$injector.resolve(IdentityStoreService);
 	public everlive: Server.IEverliveServiceContract = this.$injector.resolve(EverliveService);
 	public extensions: Server.IExtensionsServiceContract = this.$injector.resolve(ExtensionsService);
 	public internalExtensions: Server.IInternalExtensionsServiceContract = this.$injector.resolve(InternalExtensionsService);
 	public upload: Server.IUploadServiceContract = this.$injector.resolve(UploadService);
-	public filesystem: Server.IFilesystemServiceContract = this.$injector.resolve(FilesystemService);
 	public appsFiles: Server.IAppsFilesServiceContract = this.$injector.resolve(AppsFilesService);
+	public filesystem: Server.IFilesystemServiceContract = this.$injector.resolve(FilesystemService);
 	public appsImages: Server.IAppsImagesServiceContract = this.$injector.resolve(AppsImagesService);
 	public images: Server.IImagesServiceContract = this.$injector.resolve(ImagesService);
 	public appsItmstransporter: Server.IAppsItmstransporterServiceContract = this.$injector.resolve(AppsItmstransporterService);
@@ -868,11 +902,12 @@ export class ServiceContainer implements Server.IServer{
 	public mobileprovisions: Server.IMobileprovisionsServiceContract = this.$injector.resolve(MobileprovisionsService);
 	public nativescript: Server.INativescriptServiceContract = this.$injector.resolve(NativescriptService);
 	public appsNativescript: Server.IAppsNativescriptServiceContract = this.$injector.resolve(AppsNativescriptService);
-	public projects: Server.IProjectsServiceContract = this.$injector.resolve(ProjectsService);
+	public internalAppsProjects: Server.IInternalAppsProjectsServiceContract = this.$injector.resolve(InternalAppsProjectsService);
 	public appsProjects: Server.IAppsProjectsServiceContract = this.$injector.resolve(AppsProjectsService);
+	public projects: Server.IProjectsServiceContract = this.$injector.resolve(ProjectsService);
 	public apps: Server.IAppsServiceContract = this.$injector.resolve(AppsService);
-	public appsBower: Server.IAppsBowerServiceContract = this.$injector.resolve(AppsBowerService);
 	public bower: Server.IBowerServiceContract = this.$injector.resolve(BowerService);
+	public appsBower: Server.IAppsBowerServiceContract = this.$injector.resolve(AppsBowerService);
 	public build: Server.IBuildServiceContract = this.$injector.resolve(BuildService);
 	public appsBuild: Server.IAppsBuildServiceContract = this.$injector.resolve(AppsBuildService);
 	public npm: Server.INpmServiceContract = this.$injector.resolve(NpmService);
@@ -885,10 +920,10 @@ export class ServiceContainer implements Server.IServer{
 	public status: Server.IStatusServiceContract = this.$injector.resolve(StatusService);
 	public tam: Server.ITamServiceContract = this.$injector.resolve(TamService);
 	public appsTam: Server.IAppsTamServiceContract = this.$injector.resolve(AppsTamService);
-	public appsTap: Server.IAppsTapServiceContract = this.$injector.resolve(AppsTapService);
 	public tap: Server.ITapServiceContract = this.$injector.resolve(TapService);
-	public appsVersioncontrol: Server.IAppsVersioncontrolServiceContract = this.$injector.resolve(AppsVersioncontrolService);
+	public appsTap: Server.IAppsTapServiceContract = this.$injector.resolve(AppsTapService);
 	public versioncontrol: Server.IVersioncontrolServiceContract = this.$injector.resolve(VersioncontrolService);
+	public appsVersioncontrol: Server.IAppsVersioncontrolServiceContract = this.$injector.resolve(AppsVersioncontrolService);
 }
 $injector.register('server', ServiceContainer);
 

--- a/lib/services/appmanager-service.ts
+++ b/lib/services/appmanager-service.ts
@@ -77,7 +77,7 @@ class AppManagerService implements IAppManagerService {
 				this.$logger.warn("You have not set the --publish switch. Your users will not receive a push notification.");
 			}
 
-			let uploadedAppData: Server.UploadedAppData = this.$server.tam.uploadApplication(projectName, projectName, projectPath, publishSettings).wait();
+			let uploadedAppData: Server.UploadedAppData = this.$server.tam.uploadApplication1(projectName, projectName, projectPath, publishSettings).wait();
 			this.$logger.info("Successfully uploaded package.");
 
 			if(this.$options.publish && this.$options.public){

--- a/lib/services/appstore-service.ts
+++ b/lib/services/appstore-service.ts
@@ -34,7 +34,7 @@ export class AppStoreService implements IAppStoreService {
 			let projectPath = solutionPath.substr(solutionPath.indexOf("/") + 1);
 
 			let projectData = this.$project.projectData;
-			this.$server.itmstransporter.uploadApplication(projectData.ProjectName, projectData.ProjectName,
+			this.$server.itmstransporter.uploadApplication1(projectData.ProjectName, projectData.ProjectName,
 				projectPath, theApp.AppleID, userName, password).wait();
 
 			this.$logger.info("Upload complete.");

--- a/lib/swagger/service-contract-generator.ts
+++ b/lib/swagger/service-contract-generator.ts
@@ -110,10 +110,13 @@ export class ServiceContractGenerator implements IServiceContractGenerator {
 
 	private getNameWithoutSlash(name: string) {
 		let result = name;
-		let index = name.indexOf("/");
-		if(index !== -1) {
-			result = name.substring(0, index) + name[index + 1].toUpperCase() + name.substr(index + 2);
-		}
+		let index: number;
+		do {
+			index = result.indexOf("/");
+			if(~index) {
+				result = result.substring(0, index) + result[index + 1].toUpperCase() + result.substr(index + 2);
+			}
+		} while(~index);
 
 		return result;
 	}
@@ -171,6 +174,7 @@ export class ServiceContractGenerator implements IServiceContractGenerator {
 	private generateService(swaggerService: Swagger.ISwaggerServiceContract, serverModuleName: string): CodeGeneration.IService {
 		let swaggerServiceContractName = this.getSwaggerServiceContractName(swaggerService);
 		let serviceInterface = new Block(`interface ${swaggerServiceContractName}`);
+
 		let serviceImplementation = new Block(`export class ${this.getSwaggerServiceName(swaggerService)} implements ${serverModuleName}.${swaggerServiceContractName}`);
 		serviceImplementation.addBlock(new Block(`constructor(private $serviceProxy: ${serverModuleName}.IServiceProxy)`));
 


### PR DESCRIPTION
A minor bug inside our swagger did not allow for a clean api regeneration from endpoints containing multiple slashes (e.g. internal/apps/projects). Fix said bug and regenerate-api.
Api regeneration lead to some compilation issues - fix them by calling correct method overloads.
Ping @rosen-vladimirov