### PR TITLE
Fixed bug in commands fail if executed outside project.

### DIFF
--- a/lib/commands/build.ts
+++ b/lib/commands/build.ts
@@ -1,32 +1,9 @@
 ///<reference path="../.d.ts"/>
 "use strict";
 
-import Future = require("fibers/future");
-import assert = require("assert");
+import { EnsureProjectCommand } from "./ensure-project-command";
 
-class BuildCommandBase implements ICommand {
-	constructor(private $project: Project.IProject,
-		protected $errors: IErrors) { }
-
-	allowedParameters: ICommandParameter[] = [];
-
-	execute(args: string[]): IFuture<void> {
-		assert.fail("","", "You should never get here. Please contact Telerik support and send the output of your command, executed with `--log trace`.");
-		return Future.fromResult();
-	}
-
-	canExecute(args: string[]): IFuture<boolean> {
-		return (() => {
-			this.$project.ensureProject();
-			if(args.length) {
-				this.$errors.fail("This command doesn't accept parameters.");
-			}
-			return true;
-		}).future<boolean>()();
-	}
-}
-
-export class BuildAndroidCommand extends BuildCommandBase {
+export class BuildAndroidCommand extends EnsureProjectCommand {
 	constructor(private $buildService: Project.IBuildService,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		$project: Project.IProject,
@@ -41,7 +18,7 @@ export class BuildAndroidCommand extends BuildCommandBase {
 }
 $injector.registerCommand("build|android", BuildAndroidCommand);
 
-export class BuildIosCommand extends BuildCommandBase {
+export class BuildIosCommand extends EnsureProjectCommand {
 	constructor(private $buildService: Project.IBuildService,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		private $options: IOptions,
@@ -56,7 +33,7 @@ export class BuildIosCommand extends BuildCommandBase {
 }
 $injector.registerCommand("build|ios", BuildIosCommand);
 
-export class BuildWP8Command extends BuildCommandBase {
+export class BuildWP8Command extends EnsureProjectCommand {
 	constructor(private $buildService: Project.IBuildService,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		$project: Project.IProject,

--- a/lib/commands/deploy.ts
+++ b/lib/commands/deploy.ts
@@ -2,6 +2,7 @@
 "use strict";
 
 import * as helpers from "../common/helpers";
+import { EnsureProjectCommand } from "./ensure-project-command";
 
 export class DeployHelper implements IDeployHelper {
 	constructor(protected $devicesService: Mobile.IDevicesService,
@@ -21,7 +22,7 @@ export class DeployHelper implements IDeployHelper {
 		if (!this.$project.capabilities.deploy) {
 			this.$errors.failWithoutHelp("You will be able to deploy %s based applications in a future release of the Telerik AppBuilder CLI.", this.$project.projectData.Framework);
 		}
-		if(platform && !this.$mobileHelper.isPlatformSupported(platform)) {
+		if (platform && !this.$mobileHelper.isPlatformSupported(platform)) {
 			this.$errors.failWithoutHelp("On your current OS, you cannot deploy apps on connected %s devices.", this.$mobileHelper.normalizePlatformName(platform));
 		}
 
@@ -39,7 +40,7 @@ export class DeployHelper implements IDeployHelper {
 
 	private deployCore(platform: string): IFuture<void> {
 		return ((): void => {
-			this.$devicesService.initialize({ platform: platform, deviceId: this.$options.device}).wait();
+			this.$devicesService.initialize({ platform: platform, deviceId: this.$options.device }).wait();
 			platform = platform || this.$devicesService.platform;
 			let packageName = this.$project.projectData.AppIdentifier;
 			let packageFile: string = null;
@@ -92,8 +93,12 @@ export class DeployHelper implements IDeployHelper {
 }
 $injector.register("deployHelper", DeployHelper);
 
-export class DeployCommand implements ICommand {
-	constructor(private $deployHelper: IDeployHelper) { }
+export class DeployCommand extends EnsureProjectCommand {
+	constructor(private $deployHelper: IDeployHelper,
+		$project: Project.IProject,
+		$errors: IErrors) {
+		super($project, $errors);
+	}
 
 	public allowedParameters: ICommandParameter[] = [];
 
@@ -103,9 +108,13 @@ export class DeployCommand implements ICommand {
 }
 $injector.registerCommand("deploy|*devices", DeployCommand);
 
-export class DeployAndroidCommand implements ICommand {
+export class DeployAndroidCommand extends EnsureProjectCommand {
 	constructor(private $deployHelper: IDeployHelper,
-		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) { }
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
+		$project: Project.IProject,
+		$errors: IErrors) {
+		super($project, $errors);
+	}
 
 	public allowedParameters: ICommandParameter[] = [];
 
@@ -115,9 +124,13 @@ export class DeployAndroidCommand implements ICommand {
 }
 $injector.registerCommand("deploy|android", DeployAndroidCommand);
 
-export class DeployIosCommand implements ICommand {
+export class DeployIosCommand extends EnsureProjectCommand {
 	constructor(private $deployHelper: IDeployHelper,
-		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) {	}
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
+		$project: Project.IProject,
+		$errors: IErrors) {
+		super($project, $errors);
+	}
 
 	public allowedParameters: ICommandParameter[] = [];
 
@@ -127,10 +140,14 @@ export class DeployIosCommand implements ICommand {
 }
 $injector.registerCommand("deploy|ios", DeployIosCommand);
 
-export class DeployWP8Command implements ICommand {
+export class DeployWP8Command extends EnsureProjectCommand {
 	constructor(private $deployHelper: IDeployHelper,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
-		private $config: Config.IConfig) { }
+		private $config: Config.IConfig,
+		$project: Project.IProject,
+		$errors: IErrors) {
+		super($project, $errors);
+	}
 
 	public allowedParameters: ICommandParameter[] = [];
 

--- a/lib/commands/emulate.ts
+++ b/lib/commands/emulate.ts
@@ -2,13 +2,17 @@
 "use strict";
 
 import * as path from "path";
+import { EnsureProjectCommand } from "./ensure-project-command";
 
-export class EmulateAndroidCommand implements ICommand {
-	constructor(private $project: Project.IProject,
-				private $buildService: Project.IBuildService,
-				private $androidEmulatorServices: Mobile.IEmulatorPlatformServices,
-				private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
-				private $options: IOptions) { }
+export class EmulateAndroidCommand extends EnsureProjectCommand {
+	constructor(private $buildService: Project.IBuildService,
+		private $androidEmulatorServices: Mobile.IEmulatorPlatformServices,
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
+		private $options: IOptions,
+		$project: Project.IProject,
+		$errors: IErrors) {
+		super($project, $errors);
+	}
 
 	public allowedParameters: ICommandParameter[] = [];
 
@@ -31,7 +35,7 @@ export class EmulateAndroidCommand implements ICommand {
 
 	public canExecute(args: string[]): IFuture<boolean> {
 		return ((): boolean => {
-			this.$project.ensureProject();
+			super.canExecute(args).wait();
 			this.$androidEmulatorServices.checkDependencies().wait();
 			return true;
 		}).future<boolean>()();
@@ -39,14 +43,16 @@ export class EmulateAndroidCommand implements ICommand {
 }
 $injector.registerCommand("emulate|android", EmulateAndroidCommand);
 
-export class EmulateIosCommand implements ICommand {
+export class EmulateIosCommand extends EnsureProjectCommand {
 	constructor(private $fs: IFileSystem,
-				private $project: Project.IProject,
-				private $buildService: Project.IBuildService,
-				private $iOSEmulatorServices: Mobile.IEmulatorPlatformServices,
-				private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
-				private $options: IOptions) {
-		this.$project.ensureProject();
+		private $buildService: Project.IBuildService,
+		private $iOSEmulatorServices: Mobile.IEmulatorPlatformServices,
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
+		private $options: IOptions,
+		$project: Project.IProject,
+		$errors: IErrors) {
+		super($project, $errors);
+
 	}
 
 	public allowedParameters: ICommandParameter[] = [];
@@ -67,23 +73,17 @@ export class EmulateIosCommand implements ICommand {
 
 		}).future<void>()();
 	}
-
-	public canExecute(args: string[]): IFuture<boolean> {
-		return ((): boolean => {
-			this.$project.ensureProject();
-			return true;
-		}).future<boolean>()();
-	}
 }
 $injector.registerCommand("emulate|ios", EmulateIosCommand);
 
-export class EmulateWp8Command implements ICommand {
-	constructor(private $project: Project.IProject,
-		private $buildService: Project.IBuildService,
+export class EmulateWp8Command extends EnsureProjectCommand {
+	constructor(private $buildService: Project.IBuildService,
 		private $wp8EmulatorServices: Mobile.IEmulatorPlatformServices,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
-		private $config: Config.IConfig) {
-		this.$project.ensureProject();
+		private $config: Config.IConfig,
+		$project: Project.IProject,
+		$errors: IErrors) {
+		super($project, $errors);
 	}
 
 	public allowedParameters: ICommandParameter[] = [];
@@ -106,13 +106,6 @@ export class EmulateWp8Command implements ICommand {
 
 			this.$wp8EmulatorServices.runApplicationOnEmulator(packageFilePath).wait();
 		}).future<void>()();
-	}
-
-	public canExecute(args: string[]): IFuture<boolean> {
-		return ((): boolean => {
-			this.$project.ensureProject();
-			return true;
-		}).future<boolean>()();
 	}
 
 	public isDisabled = this.$config.ON_PREM;

--- a/lib/commands/ensure-project-command.ts
+++ b/lib/commands/ensure-project-command.ts
@@ -1,0 +1,28 @@
+"use strict";
+
+import Future = require("fibers/future");
+import assert = require("assert");
+
+export class EnsureProjectCommand implements ICommand {
+	constructor(protected $project: Project.IProject,
+		protected $errors: IErrors) { }
+
+	allowedParameters: ICommandParameter[] = [];
+
+	execute(args: string[]): IFuture<void> {
+		assert.fail("","", "You should never get here. Please contact Telerik support and send the output of your command, executed with `--log trace`.");
+		return Future.fromResult();
+	}
+
+	canExecute(args: string[]): IFuture<boolean> {
+		return (() => {
+			if(args.length) {
+  				this.$errors.fail("This command doesn't accept parameters.");
+				return false;
+  			}
+
+			this.$project.ensureProject();
+			return true;
+		}).future<boolean>()();
+	}
+}

--- a/lib/commands/live-sync.ts
+++ b/lib/commands/live-sync.ts
@@ -1,8 +1,14 @@
 ///<reference path="../.d.ts"/>
 "use strict";
 
-class LiveSyncDevicesCommand implements ICommand {
-	constructor(private $liveSyncService: ILiveSyncService) { }
+import { EnsureProjectCommand } from "./ensure-project-command";
+
+class LiveSyncDevicesCommand extends EnsureProjectCommand {
+	constructor(private $liveSyncService: ILiveSyncService,
+		$project: Project.IProject,
+		$errors: IErrors) {
+		super($project, $errors);
+	}
 	execute(args: string[]): IFuture<void> {
 		return this.$liveSyncService.livesync();
 	}
@@ -11,9 +17,13 @@ class LiveSyncDevicesCommand implements ICommand {
 }
 $injector.registerCommand(["livesync|*devices", "live-sync|*devices"], LiveSyncDevicesCommand);
 
-class LiveSyncAndroidCommand implements ICommand {
+class LiveSyncAndroidCommand extends EnsureProjectCommand {
 	constructor(private $liveSyncService: ILiveSyncService,
-		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) { }
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
+		$project: Project.IProject,
+		$errors: IErrors) {
+		super($project, $errors);
+	}
 	execute(args: string[]): IFuture<void> {
 		return this.$liveSyncService.livesync(this.$devicePlatformsConstants.Android);
 	}
@@ -22,9 +32,13 @@ class LiveSyncAndroidCommand implements ICommand {
 }
 $injector.registerCommand(["livesync|android", "live-sync|android"], LiveSyncAndroidCommand);
 
-class LiveSyncIosCommand implements ICommand {
+class LiveSyncIosCommand extends EnsureProjectCommand {
 	constructor(private $liveSyncService: ILiveSyncService,
-		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) { }
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
+		$project: Project.IProject,
+		$errors: IErrors) {
+		super($project, $errors);
+	}
 	execute(args: string[]): IFuture<void> {
 		return this.$liveSyncService.livesync(this.$devicePlatformsConstants.iOS);
 	}
@@ -33,10 +47,14 @@ class LiveSyncIosCommand implements ICommand {
 }
 $injector.registerCommand(["livesync|ios", "live-sync|ios"], LiveSyncIosCommand);
 
-class LiveSyncWP8Command implements ICommand {
+class LiveSyncWP8Command extends EnsureProjectCommand {
 	constructor(private $liveSyncService: ILiveSyncService,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
-		private $config: Config.IConfig) { }
+		private $config: Config.IConfig,
+		$project: Project.IProject,
+		$errors: IErrors) {
+		super($project, $errors);
+	}
 	execute(args: string[]): IFuture<void> {
 		return this.$liveSyncService.livesync(this.$devicePlatformsConstants.WP8);
 	}

--- a/lib/commands/livesync-cloud.ts
+++ b/lib/commands/livesync-cloud.ts
@@ -1,8 +1,13 @@
 ///<reference path="../.d.ts"/>
 "use strict";
 
-export class ImportProjectCommand implements ICommand {
-	constructor(private $project: Project.IProject) { }
+import { EnsureProjectCommand } from "./ensure-project-command";
+
+export class ImportProjectCommand extends EnsureProjectCommand {
+	constructor($project: Project.IProject,
+		$errors: IErrors) {
+		super($project, $errors);
+	}
 
 	allowedParameters: ICommandParameter[] = [];
 


### PR DESCRIPTION
Created base ensure project command class to extract the common can execute method which checks if there is project when the command depends on project.
Refactored the other similar commands to remove the repeating can execute method.