### PR TITLE
Fix plugin configure command

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,13 +9,13 @@
 			// Type of configuration. Possible values: "node", "mono".
 			"type": "node",
 			// Workspace relative or absolute path to the program.
-			"program": "./bin/appbuilder.js",
+			"program": "${workspaceRoot}/bin/appbuilder.js",
 			// Automatically stop program after launch.
 			"stopOnEntry": true,
 			// Command line arguments passed to the program.
 			"args": [],
 			// Workspace relative or absolute path to the working directory of the program being debugged. Default is the current workspace.
-			"cwd": ".",
+			"cwd": "${workspaceRoot}",
 			// Workspace relative or absolute path to the runtime executable to be used. Default is the runtime executable on the PATH.
 			"runtimeExecutable": null,
 			// Optional arguments passed to the runtime executable.

--- a/lib/services/cordova-project-plugins-service.ts
+++ b/lib/services/cordova-project-plugins-service.ts
@@ -375,7 +375,8 @@ export class CordovaProjectPluginsService implements IPluginsService {
 		return (() => {
 			let plugin = this.getBestMatchingPlugin(pluginName, version);
 			let pluginData = <IMarketplacePluginData>plugin.data;
-			let cordovaPluginVariables = this.$project.getProperty(CordovaProjectPluginsService.CORDOVA_PLUGIN_VARIABLES_PROPERTY_NAME, configuration) || {};
+			let originalPluginVariables = this.$project.getProperty(CordovaProjectPluginsService.CORDOVA_PLUGIN_VARIABLES_PROPERTY_NAME, configuration) || {};
+			let cordovaPluginVariables: any = JSON.parse(JSON.stringify(originalPluginVariables));
 
 			let variables = <string[]>pluginData.Variables;
 			if(variables && variables.length > 0) {
@@ -456,7 +457,6 @@ export class CordovaProjectPluginsService implements IPluginsService {
 						if (pluginData && pluginData.data) {
 							let projectDataRecord = pluginData.toProjectDataRecord();
 							let configurations = this.$project.configurationSpecificData;
-
 							_.each(configurations, (configData: IDictionary<any>, configuration:string) => {
 								if (configData) {
 									let corePlugins = configData[CordovaProjectPluginsService.CORE_PLUGINS_PROPERTY_NAME];
@@ -694,7 +694,7 @@ export class CordovaProjectPluginsService implements IPluginsService {
 	 */
 	private getPluginVariableFromVarOption(variableName: string, configuration: string): any {
 		let varOption = this.$options.var;
-		configuration = configuration.toLowerCase();
+		configuration = configuration && configuration.toLowerCase();
 		let lowerCasedVariableName = variableName.toLowerCase();
 		if(varOption) {
 			let configVariableValue: string;


### PR DESCRIPTION
When the .debug.abproject and the .release.abproject files are deleted and then plugin is installed without specified configuration and the plugin variables are set in the .abproject file. When configuring the plugin variables for specific configuration the original plugin variables must be cloned because the changes must be saved in the configuration specific file only.
When getting the plugin variable from var option the configuration needs to be checked because if there is no specified configuration in the command it will be undefined.

Fixes http://teampulse.telerik.com/view#item/282804