### PR TITLE
Fix bug in commands fail if executed outside project

### DIFF
--- a/lib/hooks/typescript-compilation.ts
+++ b/lib/hooks/typescript-compilation.ts
@@ -7,13 +7,16 @@ import fiberBootstrap = require("./../common/fiber-bootstrap");
 fiberBootstrap.run(() => {
 	$injector.require("typeScriptCompilationService", "./common/services/typescript-compilation-service");
 	let project: Project.IProject = $injector.resolve("project");
-	project.ensureProject();
+	if (!project.projectData) {
+		return;
+	}
+
 	let typeScriptFiles = project.getTypeScriptFiles().wait();
-	if(typeScriptFiles.typeScriptFiles.length > typeScriptFiles.definitionFiles.length) { // We need this check because some of non-typescript templates(for example KendoUI.Strip) contain typescript definition files
+	if (typeScriptFiles.typeScriptFiles.length > typeScriptFiles.definitionFiles.length) { // We need this check because some of non-typescript templates(for example KendoUI.Strip) contain typescript definition files
 		let typeScriptCompilationService: ITypeScriptCompilationService = $injector.resolve("typeScriptCompilationService");
 		let $fs: IFileSystem = $injector.resolve("fs");
 		let pathToTsConfig = path.join(project.getProjectDir().wait(), "tsconfig.json");
-		if($fs.exists(pathToTsConfig).wait()) {
+		if ($fs.exists(pathToTsConfig).wait()) {
 			let json = $fs.readJson(pathToTsConfig).wait();
 			typeScriptCompilationService.compileWithDefaultOptions({ noEmitOnError: !!(json && json.compilerOptions && json.compilerOptions.noEmitOnError) }).wait();
 		} else {


### PR DESCRIPTION
When checking if command is executed in project in the typescript-compilation hook need to return not to throw error because the not in project message and command help will not be shown.

Fixes http://teampulse.telerik.com/view#item/308947