### PR TITLE
Fix LiveSync for iOS Simulator

### DIFF
--- a/postinstall.js
+++ b/postinstall.js
@@ -1,4 +1,19 @@
 "use strict";
+
+var shelljs = require("shelljs"),
+	path = require("path"),
+	nodeModulesDirName = "node_modules",
+	iosSimPortableDirName = "ios-sim-portable",
+	fibersDirName = "fibers";
+
+try {
+	// In case there are fibers in ios-sim-portable's node_modules dir, we should remove them in order to make LiveSync work:
+	var pathToIOSSimFibersModule = path.join(__dirname, nodeModulesDirName, iosSimPortableDirName, nodeModulesDirName, fibersDirName);
+	shelljs.rm("-rf", pathToIOSSimFibersModule);
+} catch (err) {
+	// Ignore the error.
+}
+
 var skipPostinstallTasks = process.env["APPBUILDER_SKIP_POSTINSTALL_TASKS"];
 if (skipPostinstallTasks) {
 	return;


### PR DESCRIPTION
Fix LiveSync for iOS Simulator by changing:
* Root Project Path for NativeScript applications, which was incorrectly including "app" dir.
* Fix path where we copy files to be the iOS LiveSync Dir (/Library/Application Support/LiveSync) - for Cordova projects, the LiveSync plugin automatically gets all files from bundle to this directory, so next time when CLI livesyncs to simulator, we place the new files in the bundle. LiveSync plugin will not pull these changes in the LiveSync dir, so we have to do it manually.

Move LiveSync constants in the constants file.

**Regression potential:** None, changes are only in code used for iOS Simulator LiveSync. Currently it is not working, so we cannot break it more.