### PR TITLE
Rename `Blank` template name to `JavaScript.Blank`

### DIFF
--- a/lib/definitions/templates-service.d.ts
+++ b/lib/definitions/templates-service.d.ts
@@ -1,7 +1,7 @@
 interface ITemplatesService {
 	projectTemplatesDir: string;
 	itemTemplatesDir: string;
-	getTemplatesString(regexp: RegExp): IFuture<string>;
+	getTemplatesString(regexp: RegExp, replacementNames: IStringDictionary): IFuture<string>;
 	downloadProjectTemplates(): IFuture<void>;
 	downloadItemTemplates(): IFuture<void>;
 	unpackAppResources(): IFuture<void>;

--- a/lib/project.ts
+++ b/lib/project.ts
@@ -16,7 +16,8 @@ export class Project implements Project.IProject {
 	private static CONFIGURATION_FROM_FILE_NAME_REGEX = new RegExp("^[.](" + Project.VALID_CONFIGURATION_CHARACTERS_REGEX + "+?)" + Project.JSON_PROJECT_FILE_NAME_REGEX + "$", "i");
 	private static INDENTATION = "     ";
 	private static UI_TEMPLATE_NAMES:IStringDictionary = {
-		"kendoui.blank": "KendoUI.Empty"
+		"kendoui.blank": "KendoUI.Empty",
+		"javascript.blank": "Blank"
 	};
 
 	private _hasBuildConfigurations: boolean = false;
@@ -871,12 +872,7 @@ export class Project implements Project.IProject {
 				}
 			} else {
 				let templates = this.frameworkProject.projectTemplatesString().wait();
-
-				let message = util.format("The specified template %s does not exist. You can use any of the following templates: %s",
-					this.$options.template,
-					EOL,
-					templates);
-				this.$errors.fail({ formatStr: message, suppressCommandHelp: true });
+				this.$errors.failWithoutHelp(`The specified template ${this.$options.template} does not exist. You can use any of the following templates:${EOL}${templates}`);
 			}
 		}).future<void>()();
 	}

--- a/lib/project/cordova-project.ts
+++ b/lib/project/cordova-project.ts
@@ -122,7 +122,7 @@ export class CordovaProject extends FrameworkProjectBase implements Project.IFra
 	}
 
 	public projectTemplatesString(): IFuture<string> {
-		return this.$templatesService.getTemplatesString(/.*Telerik\.Mobile\.Cordova\.(.+)\.zip/);
+		return this.$templatesService.getTemplatesString(/.*Telerik\.Mobile\.Cordova\.(.+)\.zip/, { "blank": "JavaScript.Blank", "kendoui.empty": "KendoUI.Blank" });
 	}
 
 	public getProjectFileSchema(): IDictionary<any> {

--- a/lib/project/nativescript-project.ts
+++ b/lib/project/nativescript-project.ts
@@ -84,7 +84,7 @@ export class NativeScriptProject extends FrameworkProjectBase implements Project
 
 	public projectTemplatesString(): IFuture<string> {
 		return ((): string => {
-			let templateStrings = this.$templatesService.getTemplatesString(/.*Telerik\.Mobile\.NS\.(.+)\.zip/).wait();
+			let templateStrings = this.$templatesService.getTemplatesString(/.*Telerik\.Mobile\.NS\.(.+)\.zip/, { "blank": "JavaScript.Blank" }).wait();
 			return templateStrings.replace(/TS[.]/g, "TypeScript.");
 		}).future<string>()();
 	}

--- a/lib/templates-service.ts
+++ b/lib/templates-service.ts
@@ -27,12 +27,15 @@ export class TemplatesService implements ITemplatesService {
 		return this.$resources.resolvePath("ItemTemplates");
 	}
 
-	public getTemplatesString(regexp: RegExp): IFuture<string> {
+	public getTemplatesString(regexp: RegExp, replacementNames: IStringDictionary): IFuture<string> {
 		return (() => {
 			let templates = _(this.$fs.readDirectory(this.projectTemplatesDir).wait())
 				.map((file) => {
-					let match = file.match(regexp);
-					return match && match[1];
+					let match = file.match(regexp),
+						templateName = match && match[1],
+						replacementName = replacementNames[templateName.toLowerCase()];
+
+					return replacementName ? replacementName : templateName;
 				})
 				.filter((file: string) => file !== null)
 				.value();

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -297,7 +297,7 @@ export class TemplateServiceStub implements ITemplatesService {
 		return path.join(__dirname, "../resources/ItemTemplates");
 	}
 
-	getTemplatesString(regexp: RegExp): IFuture<string> {
+	getTemplatesString(regexp: RegExp, replacementNames: IStringDictionary): IFuture<string> {
 		return undefined;
 	}
 


### PR DESCRIPTION
In addition replace forgotten occurence of KendoUI.Empty instead of KendoUI.Blank in help.
Implemented with backwards compatibility `--template Blank` still works as expected.

Implements [Project templates should be JavaScript.Blank and TypeScript.Blank](http://teampulse.telerik.com/view#item/268482)

Ping @rosen-vladimirov and @TsvetanMilanov for code review