### PR TITLE
Clean unused code for already deleted {N} versions

### DIFF
--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -450,9 +450,6 @@ interface INativeScriptMigrationConfiguration {
 	appResourcesRequiredPath: string;
 	appResourcesObsoletePath: string;
 
-	valuesStylesXmlPath: string;
-	valuesV21StylesXmlPath: string;
-
 	shouldRollBackAppResources: boolean;
 }
 
@@ -910,9 +907,9 @@ interface INativeScriptMigrationData{
 	 */
 	supportedVersions: IFrameworkVersion[];
 	/**
-	 * From this version onwards tns_modules are included as an npm dependency rather than physical files.
+	 * Versions that are obsolete.
 	 */
-	modulesNpmMinimumVersion: string;
+	obsoleteVersions: IFrameworkVersion[];
 }
 
 /**

--- a/lib/services/nativescript-project-plugins-service.ts
+++ b/lib/services/nativescript-project-plugins-service.ts
@@ -31,9 +31,9 @@ export class NativeScriptProjectPluginsService implements IPluginsService {
 		private $pluginVariablesHelper: IPluginVariablesHelper,
 		private $prompter: IPrompter,
 		private $server: Server.IServer) {
-			let npmVersions: string[] = (<any[]>this.$fs.readJson(this.$nativeScriptResources.nativeScriptMigrationFile).wait().npmVersions).map(npmVersion => npmVersion.version);
+			let versions: string[] = (<any[]>this.$fs.readJson(this.$nativeScriptResources.nativeScriptMigrationFile).wait().versions).map(version => version.version);
 			let frameworkVersion = this.$project.projectData.FrameworkVersion;
-			if(!_.contains(npmVersions, frameworkVersion)) {
+			if(!_.contains(versions, frameworkVersion)) {
 				this.$errors.failWithoutHelp(`Your project targets NativeScript version '${frameworkVersion}' which does not support plugins.`);
 			}
 		}


### PR DESCRIPTION
Since NativeScript version 1.5.2 is obsolete and it cannot be migrated to the old logic for migrating NativeScript projects is not needed any more.
Also the server returns NativeScript.json with additional property - obsoleteVersions and the property npmVersions is renamed to versions.

The improvement is described here http://teampulse.telerik.com/view#item/312022