### PR TITLE
Allow starting of NativeScript apps on Android via Proton

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,7 +1,7 @@
 ///<reference path=".d.ts"/>
 "use strict";
 import * as path from "path";
-import {StaticConfigBase} from "./common/static-config-base";
+import {AppBuilderStaticConfigBase} from "./common/appbuilder/appbuilder-static-config-base";
 import {ConfigBase} from "./common/config-base";
 import * as osenv from "osenv";
 
@@ -77,13 +77,12 @@ export class Configuration extends ConfigBase implements IConfiguration { // Use
 }
 $injector.register("config", Configuration);
 
-export class StaticConfig extends StaticConfigBase implements IStaticConfig {
+export class StaticConfig extends AppBuilderStaticConfigBase implements IStaticConfig {
 	constructor($injector: IInjector) {
 		super($injector);
 		this.RESOURCE_DIR_PATH = path.join(this.RESOURCE_DIR_PATH, "../../resources");
 	}
 
-	private startPackageActivityName: string;
 	private static TOKEN_FILENAME = ".abgithub";
 	public PROJECT_FILE_NAME = ".abproject";
 	public CLIENT_NAME = "AppBuilder";
@@ -92,20 +91,6 @@ export class StaticConfig extends StaticConfigBase implements IStaticConfig {
 	public TRACK_FEATURE_USAGE_SETTING_NAME = "AnalyticsSettings.TrackFeatureUsage";
 	public ERROR_REPORT_SETTING_NAME = "AnalyticsSettings.TrackExceptions";
 	public ANALYTICS_INSTALLATION_ID_SETTING_NAME = "AnalyticsInstallationID";
-
-	public get START_PACKAGE_ACTIVITY_NAME(): string {
-		if(!this.startPackageActivityName) {
-			let project: Project.IProject = $injector.resolve("project");
-			this.startPackageActivityName = project.startPackageActivity;
-		}
-
-		return this.startPackageActivityName;
-	}
-
-	public set START_PACKAGE_ACTIVITY_NAME(value: string) {
-		this.startPackageActivityName = value;
-	}
-
 	public SYS_REQUIREMENTS_LINK = "http://docs.telerik.com/platform/appbuilder/running-appbuilder/running-the-cli/system-requirements-cli";
 	public SOLUTION_SPACE_NAME = "Private_Build_Folder";
 	public QR_SIZE = 300;

--- a/lib/project/cordova-project.ts
+++ b/lib/project/cordova-project.ts
@@ -6,6 +6,7 @@ import * as util from "util";
 import {FrameworkProjectBase} from "./framework-project-base";
 import helpers = require("./../common/helpers");
 import semver = require("semver");
+import  { StartPackageActivityNames } from "../common/mobile/constants";
 
 export class CordovaProject extends FrameworkProjectBase implements Project.IFrameworkProject {
 	private static WP8_DEFAULT_PACKAGE_IDENTITY_NAME_PREFIX = "1234Telerik";
@@ -72,7 +73,7 @@ export class CordovaProject extends FrameworkProjectBase implements Project.IFra
 	}
 
 	public get startPackageActivity(): string {
-		return ".TelerikCallbackActivity";
+		return StartPackageActivityNames.CORDOVA;
 	}
 
 	public get relativeAppResourcesPath(): string {

--- a/lib/project/nativescript-project.ts
+++ b/lib/project/nativescript-project.ts
@@ -6,6 +6,7 @@ import * as util from "util";
 import Future = require("fibers/future");
 import {FrameworkProjectBase} from "./framework-project-base";
 import semver = require("semver");
+import  { StartPackageActivityNames } from "../common/mobile/constants";
 
 export class NativeScriptProject extends FrameworkProjectBase implements Project.IFrameworkProject {
 	constructor(private $config: IConfiguration,
@@ -57,7 +58,7 @@ export class NativeScriptProject extends FrameworkProjectBase implements Project
 	}
 
 	public get startPackageActivity(): string {
-		return "com.tns.NativeScriptActivity";
+		return StartPackageActivityNames.NATIVESCRIPT;
 	}
 
 	public get relativeAppResourcesPath(): string {

--- a/lib/project/project.d.ts
+++ b/lib/project/project.d.ts
@@ -4,7 +4,6 @@ declare module Project {
 		configurations: string[];
 		requiredAndroidApiLevel: number;
 		projectConfigFiles: Project.IConfigurationFile[];
-		startPackageActivity: string;
 
 		isIonicProject(projectDir: string): IFuture<boolean>;
 		createNewProject(projectName: string, framework: string, template?: string): IFuture<void>;


### PR DESCRIPTION
Currently when deploying NativeScript apps on Android via Proton, we are unable to start the application, as we pass incorrect StartPackageActivity.
Fix this by extracting the correct names in constants. When deploy is called from Proton side, we'll set the correct name in the `$project`.
After that the execution of start method will use the value from `$staticConfig`. StaticConfig will return the value of project's property.

`deployOnDevices` method now has additional argument - framework. If it is passed and the provided value is NativeScript, we'll use the NativeScript's StartPackageActivity.
In all other cases we'll use Cordova's StartPackageActivity.