### PR TITLE
Fix QR Code generation for projects with long names

### DIFF
--- a/lib/qr.ts
+++ b/lib/qr.ts
@@ -3,12 +3,25 @@
 let qrcode = require("qrcode-generator");
 
 export class QrCodeGenerator implements IQrCodeGenerator {
-	constructor(private $errors: IErrors,
-		private $staticConfig: IStaticConfig) {}
+	// The order is important.
+	private static ERROR_CORRECTION_LEVEL = ["L", "M", "Q", "H"];
 
-	public generateQrCode(data: string) {
-		for (let i = 1; i <= 40; ++i) {
-			let qr = qrcode(i, "L");
+	// https://en.wikiversity.org/wiki/Reed%E2%80%93Solomon_codes_for_coders/Additional_information
+	private static MAX_BLOCK_VERSION = 40;
+
+	constructor(private $clipboardService: IClipboardService,
+		private $errors: IErrors,
+		private $staticConfig: IStaticConfig) { }
+
+	generateQrCode(data: string) {
+		let errorCorrectionLevel = "L";
+		let errorCorrectionOffset = _.indexOf(QrCodeGenerator.ERROR_CORRECTION_LEVEL, errorCorrectionLevel);
+
+		// 4 is from the qrcode-generator source code.
+		let maxReedSolomonBlockIndex = QrCodeGenerator.MAX_BLOCK_VERSION / 4 - errorCorrectionOffset;
+
+		for (let i = 1; i <= maxReedSolomonBlockIndex; ++i) {
+			let qr = qrcode(i, errorCorrectionLevel);
 			try {
 				qr.addData(data);
 				qr.make();
@@ -24,14 +37,16 @@ export class QrCodeGenerator implements IQrCodeGenerator {
 			return qr;
 		}
 
-		this.$errors.fail("code length overflow.");
+		// Since the max Reed-Solomon block index was calculated before the for loop and no exception was thrown in it here the only error can be because of long project name.
+		this.$clipboardService.copy(data).wait();
+		this.$errors.failWithoutHelp(`Your project name is too long to generate QR Code for its link. The application url ${data.green} ${"is copied to your clipboard and you can use online QR Code generator to generate QR Code for you.".red}.`);
 	}
 
-	generateDataUri(data: string): string {
+	public generateDataUri(data: string): string {
 		let qr = this.generateQrCode(data);
 		let cells = qr.getModuleCount();
 		let size = this.$staticConfig.QR_SIZE;
-		let cellSize = Math.ceil(size / (cells + 2*4 /* margin */));
+		let cellSize = Math.ceil(size / (cells + 2 * 4 /* margin */));
 
 		let imgTag = qr.createImgTag(cellSize);
 		let dataUri = imgTag.split('src="')[1].split('"')[0];


### PR DESCRIPTION
When we try to generate QR Code for project with long name the library we use fails.
The QR Code generation logic was not compatible with the library and the exception that was thrown was not expected.