### PR TITLE
Add EOL in .abignore file in Ionic projects

### DIFF
--- a/lib/ionic-project-transformator.ts
+++ b/lib/ionic-project-transformator.ts
@@ -455,7 +455,7 @@ export class IonicProjectTransformator implements IIonicProjectTransformator {
 		return (() => {
 			let abIgnoreFilePath = path.join(this.$project.projectDir, this.$projectConstants.PROJECT_IGNORE_FILE);
 
-			let ignoreText = `${EOL}# Ionic backup folder${EOL}${IonicProjectTransformator.IONIC_PROJECT_BACKUP_FOLDER_NAME}/`;
+			let ignoreText = `${EOL}# Ionic backup folder${EOL}${IonicProjectTransformator.IONIC_PROJECT_BACKUP_FOLDER_NAME}/${EOL}`;
 
 			this.$fs.appendFile(abIgnoreFilePath, ignoreText).wait();
 		}).future<void>()();


### PR DESCRIPTION
When creating backup of the Ionic project and adding the Ionic_Backup folder to the .abignore file need to add EOL at the and of it.