### PR TITLE
Replace shelljs cp with fs method

### DIFF
--- a/lib/ionic-project-transformator.ts
+++ b/lib/ionic-project-transformator.ts
@@ -97,17 +97,25 @@ export class IonicProjectTransformator implements IIonicProjectTransformator {
 			this.$analyticsService.track("Migrate from Ionic", "true").wait();
 
 			if (createBackup) {
+				console.log(`-------Backup of project started at ${new Date()}`);
 				this.backupCurrentProject().wait();
+				console.log(`-------Backup of project ended at ${new Date()}`);
 				this.addIonicBackupFolderToAbIgnoreFile().wait();
 			}
 
 			this.createReroutingIndexHtml().wait();
 
+			console.log(`-------Cloning resources started at ${new Date()}`);
 			this.cloneResources().wait();
+			console.log(`-------Cloning resources ended at ${new Date()}`);
 
+			console.log(`-------Deleting plugins started at ${new Date()}`);
 			this.deleteEnabledPlugins().wait();
+			console.log(`-------Deleting plugins ended at ${new Date()}`);
 
+			console.log(`-------Deleting Ionic files started at ${new Date()}`);
 			this.deleteAssortedFilesAndDirectories();
+			console.log(`-------Deleting Ionic files ended at ${new Date()}`);
 		}).future<void>()();
 	}
 

--- a/lib/ionic-project-transformator.ts
+++ b/lib/ionic-project-transformator.ts
@@ -97,25 +97,17 @@ export class IonicProjectTransformator implements IIonicProjectTransformator {
 			this.$analyticsService.track("Migrate from Ionic", "true").wait();
 
 			if (createBackup) {
-				console.log(`-------Backup of project started at ${new Date()}`);
 				this.backupCurrentProject().wait();
-				console.log(`-------Backup of project ended at ${new Date()}`);
 				this.addIonicBackupFolderToAbIgnoreFile().wait();
 			}
 
 			this.createReroutingIndexHtml().wait();
 
-			console.log(`-------Cloning resources started at ${new Date()}`);
 			this.cloneResources().wait();
-			console.log(`-------Cloning resources ended at ${new Date()}`);
 
-			console.log(`-------Deleting plugins started at ${new Date()}`);
 			this.deleteEnabledPlugins().wait();
-			console.log(`-------Deleting plugins ended at ${new Date()}`);
 
-			console.log(`-------Deleting Ionic files started at ${new Date()}`);
 			this.deleteAssortedFilesAndDirectories();
-			console.log(`-------Deleting Ionic files ended at ${new Date()}`);
 		}).future<void>()();
 	}
 
@@ -137,9 +129,15 @@ export class IonicProjectTransformator implements IIonicProjectTransformator {
 
 			this.cloneConfigXml(appBuilderResourcesDirectory).wait();
 
+			console.log(`-------Cloning Android resources started at ${new Date()}`);
 			this.cloneResourcesCore(this.ionicResourcesDirectory, appBuilderResourcesDirectory, this.$devicePlatformsConstants.Android.toLowerCase(), this.copyAndroidResources).wait();
+			console.log(`-------Cloning Android resources ended at ${new Date()}`);
+			console.log(`-------Cloning iOS resources started at ${new Date()}`);
 			this.cloneResourcesCore(this.ionicResourcesDirectory, appBuilderResourcesDirectory, this.$devicePlatformsConstants.iOS.toLowerCase(), this.copyResources).wait();
+			console.log(`-------Cloning iOS resources ended at ${new Date()}`);
+			console.log(`-------Cloning WP8 resources started at ${new Date()}`);
 			this.cloneResourcesCore(this.ionicResourcesDirectory, appBuilderResourcesDirectory, this.$devicePlatformsConstants.WP8.toLowerCase(), this.copyWindowsPhoneResources).wait();
+			console.log(`-------Cloning WP8 resources started at ${new Date()}`);
 		}).future<void>()();
 	}
 
@@ -320,7 +318,8 @@ export class IonicProjectTransformator implements IIonicProjectTransformator {
 
 						this.$fs.copyFile(path.join(resourceDirectory, item), resourceDestinationDirectory).wait();
 					} else {
-						shelljs.cp("-R", resourceItemSourceDirectory, resourceDestinationDirectory);
+						this.$fs.copyDirRecursive(resourceItemSourceDirectory, resourceDestinationDirectory).wait();
+						// shelljs.cp("-R", resourceItemSourceDirectory, resourceDestinationDirectory);
 					}
 				});
 			} else {
@@ -335,7 +334,8 @@ export class IonicProjectTransformator implements IIonicProjectTransformator {
 			// Need to add / at the end of resourceDirectory to copy the content of the directory directly to appBuilderPlatformResourcesDirectory not in subfolder.
 			let resourceDirectoryContentPath = `${resourceDirectory}/`;
 
-			shelljs.cp("-rf", resourceDirectoryContentPath, appBuilderPlatformResourcesDirectory);
+			this.$fs.copyDirRecursive(resourceDirectoryContentPath, appBuilderPlatformResourcesDirectory).wait();
+			// shelljs.cp("-r", resourceDirectoryContentPath, appBuilderPlatformResourcesDirectory);
 		}).future<void>()();
 	}
 

--- a/test/ionic-project-transformator.ts
+++ b/test/ionic-project-transformator.ts
@@ -107,18 +107,14 @@ function createIonicProject(testInjector: IInjector, fs: IFileSystem): IFuture<s
 	return ((): string => {
 		if (!hasUnzippedProject) {
 			hasUnzippedProject = true;
-			console.log(`-------Unzipping Ionic project started at ${new Date()}`);
 			fs.unzip(path.join("test", "resources", "ionic-transform-test.zip"), unzippedProjectDirectory, { overwriteExisitingFiles: true }).wait();
-			console.log(`-------Unzipping Ionic project ended at ${new Date()}`);
 		}
 
 		let options = testInjector.resolve("options");
 		let projectDirectory = temp.mkdirSync("ionic-transform-test");
 		options.path = projectDirectory;
 
-		console.log(`-------Copying Ionic project started at ${new Date()}`);
 		shelljs.cp("-Rf", [unzippedProjectDirectory + `${pathSeparator}.*`, unzippedProjectDirectory + `${pathSeparator}*`], projectDirectory);
-		console.log(`-------Copying Ionic project ended at ${new Date()}`);
 
 		return projectDirectory;
 	}).future<string>()();
@@ -290,17 +286,15 @@ describe("Ionic project transformator", () => {
 		it("should create full backup of the project", () => {
 			createBackup = true;
 			let backupDirectory = path.join(projectDirectory, ionicBackupFolderName);
-			console.log(`-------Listing current dir started at ${new Date()}`);
 			let projectDirectoryContent = shelljs.ls("-R", projectDirectory);
-			console.log(`-------Listing current dir ended at ${new Date()}`);
 
 			ionicProjectTransformator.transformToAppBuilderProject(createBackup).wait();
 
-			console.log(`-------Listing backup dir started at ${new Date()}`);
 			let projectBackupDirectoryContent = shelljs.ls("-R", backupDirectory);
-			console.log(`-------Listing backup dir ended at ${new Date()}`);
 
-			assert.deepEqual(projectDirectoryContent, projectBackupDirectoryContent);
+			let differences = _.difference(projectDirectoryContent, projectBackupDirectoryContent);
+
+			assert.deepEqual(differences.length, 0);
 		});
 
 		it("should create rerouting index.html", () => {
@@ -386,7 +380,7 @@ describe("Ionic project transformator", () => {
 				});
 			});
 
-			it(`should clone correctly when more than platform configurations are added to the Ionic config.xml file.`, () => {
+			it(`should clone correctly when more than one platform configurations are added to the Ionic config.xml file.`, () => {
 				let platformConfigXmlItem: IonicConfigXmlFile.IPlatform[] = [];
 				let androidTestContext: IConfigXmlFileTestContext = createConfigXmlTestsContext(androidPlatformName, appResourcesDirectory);
 				let iosTestContext: IConfigXmlFileTestContext = createConfigXmlTestsContext(iosPlatformName, appResourcesDirectory);

--- a/test/ionic-project-transformator.ts
+++ b/test/ionic-project-transformator.ts
@@ -107,13 +107,18 @@ function createIonicProject(testInjector: IInjector, fs: IFileSystem): IFuture<s
 	return ((): string => {
 		if (!hasUnzippedProject) {
 			hasUnzippedProject = true;
+			console.log(`-------Unzipping Ionic project started at ${new Date()}`);
 			fs.unzip(path.join("test", "resources", "ionic-transform-test.zip"), unzippedProjectDirectory, { overwriteExisitingFiles: true }).wait();
+			console.log(`-------Unzipping Ionic project ended at ${new Date()}`);
 		}
 
 		let options = testInjector.resolve("options");
 		let projectDirectory = temp.mkdirSync("ionic-transform-test");
 		options.path = projectDirectory;
+
+		console.log(`-------Copying Ionic project started at ${new Date()}`);
 		shelljs.cp("-Rf", [unzippedProjectDirectory + `${pathSeparator}.*`, unzippedProjectDirectory + `${pathSeparator}*`], projectDirectory);
+		console.log(`-------Copying Ionic project ended at ${new Date()}`);
 
 		return projectDirectory;
 	}).future<string>()();
@@ -285,11 +290,15 @@ describe("Ionic project transformator", () => {
 		it("should create full backup of the project", () => {
 			createBackup = true;
 			let backupDirectory = path.join(projectDirectory, ionicBackupFolderName);
+			console.log(`-------Listing current dir started at ${new Date()}`);
 			let projectDirectoryContent = shelljs.ls("-R", projectDirectory);
+			console.log(`-------Listing current dir ended at ${new Date()}`);
 
 			ionicProjectTransformator.transformToAppBuilderProject(createBackup).wait();
 
+			console.log(`-------Listing backup dir started at ${new Date()}`);
 			let projectBackupDirectoryContent = shelljs.ls("-R", backupDirectory);
+			console.log(`-------Listing backup dir ended at ${new Date()}`);
 
 			assert.deepEqual(projectDirectoryContent, projectBackupDirectoryContent);
 		});

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -111,6 +111,10 @@ export class FileSystemStub implements IFileSystem {
 		return undefined;
 	}
 
+	copyDirRecursive(sourceDirName:string, destinationDirName:string):IFuture<void> {
+		return undefined;
+	}
+
 	openFile(filename: string): void { }
 
 	createReadStream(path:string, options?:{flags?: string; encoding?: string; fd?: string; mode?: number; bufferSize?: number}): any {


### PR DESCRIPTION
For some reason `shelljs.cp` is really slow and that's why we should use the `copyDir` method in our fs.