### PR TITLE
Fix device run command

### DIFF
--- a/lib/project.ts
+++ b/lib/project.ts
@@ -71,7 +71,7 @@ export class Project implements Project.IProject {
 	}
 
 	public get startPackageActivity(): string {
-		return this.frameworkProject.startPackageActivity;
+		return this.frameworkProject && this.frameworkProject.startPackageActivity;
 	}
 
 	public getPluginVariablesInfo(configuration?: string): IFuture<IDictionary<IStringDictionary>> {

--- a/lib/project/cordova-project.ts
+++ b/lib/project/cordova-project.ts
@@ -10,13 +10,7 @@ export class CordovaProject extends FrameworkProjectBase implements Project.IFra
 	private static WP8_DEFAULT_PACKAGE_IDENTITY_NAME_PREFIX = "1234Telerik";
 	private static WP8_DEFAULT_WP8_WINDOWS_PUBLISHER_NAME = "CN=Telerik";
 
-	constructor($errors: IErrors,
-		$fs: IFileSystem,
-		$jsonSchemaValidator: IJsonSchemaValidator,
-		$logger: ILogger,
-		$options: IOptions,
-		$resources: IResourceLoader,
-		private $cordovaResources: ICordovaResourceLoader,
+	constructor(private $cordovaResources: ICordovaResourceLoader,
 		private $config: IConfiguration,
 		private $injector: IInjector,
 		private $jsonSchemaConstants: IJsonSchemaConstants,
@@ -25,7 +19,13 @@ export class CordovaProject extends FrameworkProjectBase implements Project.IFra
 		private $configFilesManager: Project.IConfigFilesManager,
 		private $staticConfig: Config.IStaticConfig,
 		private $templatesService: ITemplatesService,
-		private $cordovaProjectCapabilities: Project.ICapabilities) {
+		private $cordovaProjectCapabilities: Project.ICapabilities,
+		$errors: IErrors,
+		$fs: IFileSystem,
+		$jsonSchemaValidator: IJsonSchemaValidator,
+		$logger: ILogger,
+		$options: IOptions,
+		$resources: IResourceLoader) {
 		super($logger, $fs, $resources, $errors, $jsonSchemaValidator, $options);
 	}
 
@@ -62,7 +62,7 @@ export class CordovaProject extends FrameworkProjectBase implements Project.IFra
 			allConfigFiles["ios-config"]
 		];
 
-		if(!this.$config.ON_PREM) {
+		if (!this.$config.ON_PREM) {
 			availableConfigFiles.push(allConfigFiles["wp8-manifest"]);
 			availableConfigFiles.push(allConfigFiles["wp8-config"]);
 		}
@@ -110,13 +110,13 @@ export class CordovaProject extends FrameworkProjectBase implements Project.IFra
 	}
 
 	public checkSdkVersions(platform: string, projectData: Project.IData): void {
-		if(this.$mobileHelper.isWP8Platform(platform) && projectData.WPSdk && projectData.WPSdk === "8.0" && semver.gte(projectData.FrameworkVersion,"3.7.0")) {
+		if (this.$mobileHelper.isWP8Platform(platform) && projectData.WPSdk && projectData.WPSdk === "8.0" && semver.gte(projectData.FrameworkVersion, "3.7.0")) {
 			this.$logger.warn("Your project targets Apache Cordova %s which lets you use the Windows Phone 8.1 SDK when building your apps. You can change your target Windows Phone SDK by running $ appbuilder prop set WPSdk 8.1", projectData.FrameworkVersion);
 		}
 	}
 
 	private getCorrectWP8PackageIdentityName(appIdentifier: string) {
-		let sanitizedName = appIdentifier ? _.filter(appIdentifier.split(""),(c) => /[a-zA-Z0-9.-]/.test(c)).join("") : "";
+		let sanitizedName = appIdentifier ? _.filter(appIdentifier.split(""), (c) => /[a-zA-Z0-9.-]/.test(c)).join("") : "";
 		return util.format("%s.%s", CordovaProject.WP8_DEFAULT_PACKAGE_IDENTITY_NAME_PREFIX, sanitizedName).substr(0, 50);
 	}
 
@@ -134,7 +134,7 @@ export class CordovaProject extends FrameworkProjectBase implements Project.IFra
 
 		buildProperties.CorePlugins = this.getProperty("CorePlugins", configurationName, projectInformation);
 
-		if(buildProperties.Platform === "WP8") {
+		if (buildProperties.Platform === "WP8") {
 			buildProperties.WP8ProductID = projectData.WP8ProductID || this.generateWP8GUID();
 			buildProperties.WP8PublisherID = projectData.WP8PublisherID;
 			buildProperties.WP8Publisher = projectData.WP8Publisher;
@@ -190,14 +190,14 @@ export class CordovaProject extends FrameworkProjectBase implements Project.IFra
 			}
 		});
 
-		if(!_.has(properties, "WP8PackageIdentityName")) {
+		if (!_.has(properties, "WP8PackageIdentityName")) {
 			let wp8PackageIdentityName = this.getCorrectWP8PackageIdentityName(properties.AppIdentifier);
 			this.$logger.warn("Missing 'WP8PackageIdentityName' property in .abproject. Default value '%s' will be used.", wp8PackageIdentityName);
 			properties.WP8PackageIdentityName = wp8PackageIdentityName;
 			updated = true;
 		}
 
-		if(!_.has(properties, "WP8WindowsPublisherName")) {
+		if (!_.has(properties, "WP8WindowsPublisherName")) {
 			let wp8WindowsPublisherName = CordovaProject.WP8_DEFAULT_WP8_WINDOWS_PUBLISHER_NAME;
 			this.$logger.warn("Missing 'WP8WindowsPublisherName' property in .abproject. Default value '%s' will be used.", wp8WindowsPublisherName);
 			properties.WP8WindowsPublisherName = wp8WindowsPublisherName;

--- a/lib/project/nativescript-project.ts
+++ b/lib/project/nativescript-project.ts
@@ -8,18 +8,18 @@ import { TARGET_FRAMEWORK_IDENTIFIERS } from "../common/mobile/constants";
 
 export class NativeScriptProject extends FrameworkProjectBase implements Project.IFrameworkProject {
 	constructor(private $config: IConfiguration,
-		$errors: IErrors,
-		$fs: IFileSystem,
 		private $jsonSchemaConstants: IJsonSchemaConstants,
-		$jsonSchemaValidator: IJsonSchemaValidator,
-		$logger: ILogger,
 		private $projectConstants: Project.IConstants,
 		private $configFilesManager: Project.IConfigFilesManager,
-		$resources: IResourceLoader,
 		private $staticConfig: Config.IStaticConfig,
 		private $templatesService: ITemplatesService,
 		private $injector: IInjector,
 		private $nativeScriptProjectCapabilities: Project.ICapabilities,
+		$errors: IErrors,
+		$fs: IFileSystem,
+		$jsonSchemaValidator: IJsonSchemaValidator,
+		$logger: ILogger,
+		$resources: IResourceLoader,
 		$options: IOptions) {
 		super($logger, $fs, $resources, $errors, $jsonSchemaValidator, $options);
 	}
@@ -47,7 +47,7 @@ export class NativeScriptProject extends FrameworkProjectBase implements Project
 		return 17; // 4.2 JellyBean
 	}
 
-	public get configFiles():  Project.IConfigurationFile[] {
+	public get configFiles(): Project.IConfigurationFile[] {
 		let allConfigFiles = this.$configFilesManager.availableConfigFiles;
 		return [
 			allConfigFiles["nativescript-ios-info"],
@@ -64,7 +64,7 @@ export class NativeScriptProject extends FrameworkProjectBase implements Project
 	}
 
 	public get projectSpecificFiles(): string[] {
-		return [ this.$projectConstants.PACKAGE_JSON_NAME ];
+		return [this.$projectConstants.PACKAGE_JSON_NAME];
 	}
 
 	public getValidationSchemaId(): string {
@@ -97,7 +97,7 @@ export class NativeScriptProject extends FrameworkProjectBase implements Project
 	}
 
 	public adjustBuildProperties(buildProperties: any, projectInformation?: Project.IProjectInformation): any {
-		if(buildProperties.Platform === "WP8") {
+		if (buildProperties.Platform === "WP8") {
 			this.$errors.fail("You will be able to build NativeScript based applications for WP8 platform in a future release of the Telerik AppBuilder CLI.");
 		}
 
@@ -110,14 +110,14 @@ export class NativeScriptProject extends FrameworkProjectBase implements Project
 			let appResourceFiles = this.$fs.enumerateFilesInDirectorySync(appResourcesDir);
 			// In 0.10.0 original template, App_Resources directory is not included in app directory.
 			let appResourcesHolderDirectory = path.join(projectDir, this.$projectConstants.NATIVESCRIPT_APP_DIR_NAME);
-			if(semver.eq(frameworkVersion, "0.9.0")
+			if (semver.eq(frameworkVersion, "0.9.0")
 				|| (!this.$fs.exists(path.join(appResourcesHolderDirectory, this.$staticConfig.APP_RESOURCES_DIR_NAME)).wait()
-				&& this.$fs.exists(path.join(projectDir, this.$staticConfig.APP_RESOURCES_DIR_NAME)).wait())) {
+					&& this.$fs.exists(path.join(projectDir, this.$staticConfig.APP_RESOURCES_DIR_NAME)).wait())) {
 				appResourcesHolderDirectory = projectDir;
 			}
 			appResourceFiles.forEach((appResourceFile) => {
 				let relativePath = path.relative(appResourcesDir, appResourceFile);
-				let targetFilePath = path.join(appResourcesHolderDirectory,this.$staticConfig.APP_RESOURCES_DIR_NAME, relativePath);
+				let targetFilePath = path.join(appResourcesHolderDirectory, this.$staticConfig.APP_RESOURCES_DIR_NAME, relativePath);
 				this.$logger.trace("Checking app resources: %s must match %s", appResourceFile, targetFilePath);
 				if (!this.$fs.exists(targetFilePath).wait()) {
 					this.printAssetUpdateMessage();
@@ -133,12 +133,12 @@ export class NativeScriptProject extends FrameworkProjectBase implements Project
 			let packageJsonContent = this.$fs.readJson(path.join(projectDir, this.$projectConstants.PACKAGE_JSON_NAME)).wait();
 			let nativescript = packageJsonContent && packageJsonContent.nativescript;
 			let dependencies = packageJsonContent && packageJsonContent.dependencies;
-			if(nativescript && dependencies) {
+			if (nativescript && dependencies) {
 				let pluginsVariables: IStringDictionary = {};
 				_.keys(dependencies).forEach(dependency => {
 					let variablesKey = `${dependency}-variables`;
 					let variables = nativescript[variablesKey];
-					if(variables) {
+					if (variables) {
 						pluginsVariables[dependency] = variables;
 					}
 				});


### PR DESCRIPTION
When executing appbuilder device run appid outside of project the CLI cannot determine which startPackageActivity name to use - for NativeScript or for Cordova application. The fix is to check where the command is executed and if it is not in project we need to run the adb command for both NativeScript and Cordova projects.