### PR TITLE
Move TARGET_FRAMEWORK_IDENTIFIERS to constants

### DIFF
--- a/lib/commands/framework-versions/print-versions.ts
+++ b/lib/commands/framework-versions/print-versions.ts
@@ -1,14 +1,15 @@
+import { TARGET_FRAMEWORK_IDENTIFIERS } from "../../common/mobile/constants";
+
 export class PrintFrameworkVersionsCommand implements ICommand {
 	constructor(private $cordovaMigrationService: IFrameworkMigrationService,
 		private $nativeScriptMigrationService: IFrameworkMigrationService,
 		private $project: Project.IProject,
 		private $logger: ILogger,
-		private $errors: IErrors,
-		private $projectConstants: Project.IConstants) { }
+		private $errors: IErrors) { }
 
 	public execute(args: string[]): IFuture<void> {
 		return (() => {
-			let migrationService = this.$project.projectData.Framework === this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova ? this.$cordovaMigrationService : this.$nativeScriptMigrationService;
+			let migrationService = this.$project.projectData.Framework === TARGET_FRAMEWORK_IDENTIFIERS.Cordova ? this.$cordovaMigrationService : this.$nativeScriptMigrationService;
 			let supportedVersions: IFrameworkVersion[] = migrationService.getSupportedFrameworks().wait();
 			let projectFrameworkVersion = migrationService.getDisplayNameForVersion(this.$project.projectData.FrameworkVersion).wait();
 			if (projectFrameworkVersion) {

--- a/lib/commands/framework-versions/set-version.ts
+++ b/lib/commands/framework-versions/set-version.ts
@@ -1,3 +1,5 @@
+import { TARGET_FRAMEWORK_IDENTIFIERS } from "../../common/mobile/constants";
+
 export class SetFrameworkVersionCommand implements ICommand {
 	constructor(private $injector: IInjector,
 		private $project: Project.IProject) { }
@@ -16,8 +18,7 @@ export class MobileFrameworkCommandParameter implements ICommandParameter {
 	constructor(private $cordovaMigrationService: IFrameworkMigrationService,
 		private $project: Project.IProject,
 		private $errors: IErrors,
-		private $nativeScriptMigrationService: IFrameworkMigrationService,
-		private $projectConstants: Project.IConstants) { }
+		private $nativeScriptMigrationService: IFrameworkMigrationService) { }
 
 	public mandatory = true;
 
@@ -30,7 +31,7 @@ export class MobileFrameworkCommandParameter implements ICommandParameter {
 
 			if(value.match(MobileFrameworkCommandParameter.VERSION_REGEX)) {
 				let supportedVersions: string[];
-				let migrationService = this.$project.projectData.Framework === this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova ? this.$cordovaMigrationService : this.$nativeScriptMigrationService;
+				let migrationService = this.$project.projectData.Framework === TARGET_FRAMEWORK_IDENTIFIERS.Cordova ? this.$cordovaMigrationService : this.$nativeScriptMigrationService;
 				supportedVersions = migrationService.getSupportedVersions().wait();
 
 				if(_.contains(supportedVersions, value)) {

--- a/lib/commands/project/create.ts
+++ b/lib/commands/project/create.ts
@@ -1,5 +1,5 @@
 import * as path from "path";
-
+import { TARGET_FRAMEWORK_IDENTIFIERS } from "../../common/mobile/constants";
 import ProjectCommandBaseLib = require("./project-command-base");
 
 export class CreateCommand extends ProjectCommandBaseLib.ProjectCommandBase {
@@ -8,7 +8,6 @@ export class CreateCommand extends ProjectCommandBaseLib.ProjectCommandBase {
 		private $logger: ILogger,
 		private $nameCommandParameter: ICommandParameter,
 		private $options: IOptions,
-		private $projectConstants: Project.IConstants,
 		private $screenBuilderService: IScreenBuilderService,
 		private $simulatorService: ISimulatorService,
 		private $simulatorPlatformServices: IExtensionPlatformServices,
@@ -25,7 +24,7 @@ export class CreateCommand extends ProjectCommandBaseLib.ProjectCommandBase {
 			let newProjectDir = this.$project.getNewProjectDir();
 			let projectPath = path.resolve(this.$options.path ? newProjectDir : path.join(newProjectDir, projectName));
 
-			this.$project.createNewProject(projectName, this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova, this.$config.DEFAULT_CORDOVA_PROJECT_TEMPLATE).wait();
+			this.$project.createNewProject(projectName, TARGET_FRAMEWORK_IDENTIFIERS.Cordova, this.$config.DEFAULT_CORDOVA_PROJECT_TEMPLATE).wait();
 			_.each(this.$screenBuilderService.screenBuilderSpecificFiles, fileName => this.$fs.deleteFile(path.join(projectPath, fileName)).wait());
 
 			let screenBuilderOptions = this.$screenBuilderService.composeScreenBuilderOptions(this.$options.answers, {

--- a/lib/commands/project/init.ts
+++ b/lib/commands/project/init.ts
@@ -1,4 +1,5 @@
 import * as path from "path";
+import { TARGET_FRAMEWORK_IDENTIFIERS } from "../../common/mobile/constants";
 
 class FileDescriptor {
 	constructor(public path: string, public type: string) { }
@@ -30,12 +31,12 @@ export class InitProjectCommand implements ICommand {
 
 	public execute(args: string[]): IFuture<void> {
 		return (() => {
-			if(this.isProjectType(this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait()) {
+			if(this.isProjectType(TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait()) {
 				this.$logger.info("Attempting to initialize Cordova project.");
-				this.$project.initializeProjectFromExistingFiles(this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait();
-			} else if(this.isProjectType(this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript).wait()) {
+				this.$project.initializeProjectFromExistingFiles(TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait();
+			} else if(this.isProjectType(TARGET_FRAMEWORK_IDENTIFIERS.NativeScript).wait()) {
 				this.$logger.info("Attempting to initialize NativeScript project.");
-				this.$project.initializeProjectFromExistingFiles(this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript).wait();
+				this.$project.initializeProjectFromExistingFiles(TARGET_FRAMEWORK_IDENTIFIERS.NativeScript).wait();
 			} else {
 				this.$errors.fail("Cannot determine project type. Specify project type and try again.");
 			}
@@ -68,7 +69,7 @@ export class InitProjectCommand implements ICommand {
 			}
 
 			// Ionic projects are special, they lack cordova.platform.js files and have package.json. Deal with them here
-			if (projectType === this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova && !result) {
+			if (projectType === TARGET_FRAMEWORK_IDENTIFIERS.Cordova && !result) {
 				result = this.$project.isIonicProject(this.projectDir).wait();
 			}
 
@@ -79,8 +80,8 @@ export class InitProjectCommand implements ICommand {
 	private generateMandatoryAndForbiddenFiles() {
 		this.projectFilesDescriptors = Object.create(null);
 
-		this.generateMandatoryAndForbiddenFilesCore(this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova, this.cordovaFiles, [this.tnsModulesDir]);
-		this.generateMandatoryAndForbiddenFilesCore(this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript, [this.packageJson], this.cordovaFiles.concat([this.indexHtml]));
+		this.generateMandatoryAndForbiddenFilesCore(TARGET_FRAMEWORK_IDENTIFIERS.Cordova, this.cordovaFiles, [this.tnsModulesDir]);
+		this.generateMandatoryAndForbiddenFilesCore(TARGET_FRAMEWORK_IDENTIFIERS.NativeScript, [this.packageJson], this.cordovaFiles.concat([this.indexHtml]));
 	}
 
 	private generateMandatoryAndForbiddenFilesCore(frameworkIdentifer: string, mandatoryFiles: FileDescriptor[], forbiddenFiles: FileDescriptor[]): void {

--- a/lib/commands/prop/prop-print-android-version-code.ts
+++ b/lib/commands/prop/prop-print-android-version-code.ts
@@ -1,18 +1,18 @@
 import {PrintProjectCommand} from "./prop-print";
+import { TARGET_FRAMEWORK_IDENTIFIERS } from "../../common/mobile/constants";
 
 export class PrintAndroidVersionCodeCommand extends PrintProjectCommand implements ICommand {
 	constructor($staticConfig: IStaticConfig,
 		$injector: IInjector,
 		protected $options: IOptions,
-		private $logger: ILogger,
-		private $projectConstants: Project.IConstants) {
+		private $logger: ILogger) {
 		super($staticConfig, $injector, $options);
 	}
 
 	public execute(args:string[]): IFuture<void> {
 		return ((): void => {
 			super.execute(["AndroidVersionCode"]).wait();
-			if (this.$project.projectData.Framework === this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova && !this.$options.validValue) {
+			if (this.$project.projectData.Framework === TARGET_FRAMEWORK_IDENTIFIERS.Cordova && !this.$options.validValue) {
 				this.$logger.printMarkdown("Your final AndroidVersionCode will be `%s2` because Apache Cordova automatically appends a specific number to the version code based on the target Android SDK and architecture. For more information, see https://issues.apache.org/jira/browse/CB-8976.", this.$project.projectData.AndroidVersionCode);
 			}
 

--- a/lib/commands/prop/prop-set-android-version-code.ts
+++ b/lib/commands/prop/prop-set-android-version-code.ts
@@ -1,10 +1,10 @@
 import {SetProjectPropertyCommand} from "./prop-set";
+import { TARGET_FRAMEWORK_IDENTIFIERS } from "../../common/mobile/constants";
 
 export class SetAndroidVersionCodeCommand extends SetProjectPropertyCommand implements ICommand {
 	constructor($staticConfig: IStaticConfig,
 		$injector: IInjector,
-		private $logger: ILogger,
-		private $projectConstants: Project.IConstants) {
+		private $logger: ILogger) {
 		super($staticConfig, $injector);
 	}
 
@@ -15,7 +15,7 @@ export class SetAndroidVersionCodeCommand extends SetProjectPropertyCommand impl
 	public execute(args: string[]): IFuture<void> {
 		return ((): void => {
 			super.execute(["AndroidVersionCode", args[0]]).wait();
-			if (this.$project.projectData.Framework === this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova) {
+			if (this.$project.projectData.Framework === TARGET_FRAMEWORK_IDENTIFIERS.Cordova) {
 				this.$logger.printMarkdown("Your final AndroidVersionCode will be `%s2` because Apache Cordova automatically appends a specific number to the version code based on the target Android SDK and architecture. For more information, see https://issues.apache.org/jira/browse/CB-8976.", args[0]);
 			}
 

--- a/lib/dynamic-help-provider.ts
+++ b/lib/dynamic-help-provider.ts
@@ -1,3 +1,5 @@
+import { TARGET_FRAMEWORK_IDENTIFIERS } from "./common/mobile/constants";
+
 export class DynamicHelpProvider implements IDynamicHelpProvider {
 	constructor(private $project: Project.IProject,
 		private $projectConstants: Project.IConstants) { }
@@ -17,8 +19,8 @@ export class DynamicHelpProvider implements IDynamicHelpProvider {
 		return ((): IDictionary<any> => {
 			let isHtml = options.isHtml;
 			let localVariables:IDictionary<any> = {};
-			localVariables["isCordova"] = isHtml || this.isProjectType([this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova]).wait();
-			localVariables["isNativeScript"] = isHtml || this.isProjectType([this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript]).wait();
+			localVariables["isCordova"] = isHtml || this.isProjectType([TARGET_FRAMEWORK_IDENTIFIERS.Cordova]).wait();
+			localVariables["isNativeScript"] = isHtml || this.isProjectType([TARGET_FRAMEWORK_IDENTIFIERS.NativeScript]).wait();
 
 			return localVariables;
 		}).future<IDictionary<any>>()();

--- a/lib/project.ts
+++ b/lib/project.ts
@@ -4,6 +4,7 @@ import * as util from "util";
 import * as commonHelpers from "./common/helpers";
 import Future = require("fibers/future");
 import * as helpers from "./helpers";
+import { TARGET_FRAMEWORK_IDENTIFIERS } from "./common/mobile/constants";
 
 export class Project implements Project.IProject {
 	private static JSON_PROJECT_FILE_NAME_REGEX = "[.]abproject";
@@ -107,7 +108,7 @@ export class Project implements Project.IProject {
 		if (!this.frameworkProject) {
 			let result: string[] = [];
 
-			_.each(_.values(this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS), (framework: string) => {
+			_.each(_.values(TARGET_FRAMEWORK_IDENTIFIERS), (framework: string) => {
 				let frameworkProject = this.$frameworkProjectResolver.resolve(framework);
 				let configFiles = frameworkProject.configFiles;
 				if (configFiles && configFiles.length > 0) {
@@ -335,7 +336,7 @@ export class Project implements Project.IProject {
 	public ensureCordovaProject() {
 		this.ensureProject();
 
-		if (this.projectData.Framework !== this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova) {
+		if (this.projectData.Framework !== TARGET_FRAMEWORK_IDENTIFIERS.Cordova) {
 			this.$errors.fail("This command is applicable only to Cordova projects.");
 		}
 	}
@@ -449,7 +450,7 @@ export class Project implements Project.IProject {
 			} else {
 				// We'll get here only when command is called outside of project directory and --validValue is specified
 				if (property) {
-					let targetFrameworkIdentifiers = _.values(this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS);
+					let targetFrameworkIdentifiers = _.values(TARGET_FRAMEWORK_IDENTIFIERS);
 					_.each(targetFrameworkIdentifiers, (targetFrameworkIdentifier: string) => {
 						let projectSchema: IDictionary<any> = this.$jsonSchemaValidator.tryResolveValidationSchema(targetFrameworkIdentifier);
 						let currentProp = _.find(_.keys(projectSchema), key => key === property);
@@ -740,7 +741,7 @@ export class Project implements Project.IProject {
 							data["Framework"] = data["projectType"];
 							delete data["projectType"];
 						} else {
-							data["Framework"] = this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova;
+							data["Framework"] = TARGET_FRAMEWORK_IDENTIFIERS.Cordova;
 						}
 
 						shouldSaveProject = true;

--- a/lib/project/cordova-project.ts
+++ b/lib/project/cordova-project.ts
@@ -4,6 +4,7 @@ import {FrameworkProjectBase} from "./framework-project-base";
 import helpers = require("./../common/helpers");
 import semver = require("semver");
 import  { startPackageActivityNames } from "../common/mobile/constants";
+import { TARGET_FRAMEWORK_IDENTIFIERS } from "../common/mobile/constants";
 
 export class CordovaProject extends FrameworkProjectBase implements Project.IFrameworkProject {
 	private static WP8_DEFAULT_PACKAGE_IDENTITY_NAME_PREFIX = "1234Telerik";
@@ -33,7 +34,7 @@ export class CordovaProject extends FrameworkProjectBase implements Project.IFra
 	}
 
 	public get name(): string {
-		return this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova;
+		return TARGET_FRAMEWORK_IDENTIFIERS.Cordova;
 	}
 
 	public get capabilities(): Project.ICapabilities {
@@ -70,7 +71,7 @@ export class CordovaProject extends FrameworkProjectBase implements Project.IFra
 	}
 
 	public get startPackageActivity(): string {
-		return startPackageActivityNames[this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova.toLowerCase()];
+		return startPackageActivityNames[TARGET_FRAMEWORK_IDENTIFIERS.Cordova.toLowerCase()];
 	}
 
 	public get relativeAppResourcesPath(): string {
@@ -153,7 +154,7 @@ export class CordovaProject extends FrameworkProjectBase implements Project.IFra
 			let platforms = this.$mobileHelper.platformNames;
 			_.each(platforms, (platform: string) => this.ensureCordovaJs(platform, projectDir, frameworkVersion).wait());
 
-			let appResourcesDir = this.$resources.getPathToAppResources(this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova);
+			let appResourcesDir = this.$resources.getPathToAppResources(TARGET_FRAMEWORK_IDENTIFIERS.Cordova);
 			let appResourceFiles = this.$fs.enumerateFilesInDirectorySync(appResourcesDir);
 			appResourceFiles.forEach((appResourceFile) => {
 				let relativePath = path.relative(appResourcesDir, appResourceFile);

--- a/lib/project/nativescript-project.ts
+++ b/lib/project/nativescript-project.ts
@@ -4,6 +4,7 @@ import Future = require("fibers/future");
 import {FrameworkProjectBase} from "./framework-project-base";
 import semver = require("semver");
 import  { startPackageActivityNames } from "../common/mobile/constants";
+import { TARGET_FRAMEWORK_IDENTIFIERS } from "../common/mobile/constants";
 
 export class NativeScriptProject extends FrameworkProjectBase implements Project.IFrameworkProject {
 	constructor(private $config: IConfiguration,
@@ -27,7 +28,7 @@ export class NativeScriptProject extends FrameworkProjectBase implements Project
 		return this.$injector.resolve("nativeScriptProjectPluginsService");
 	}
 	public get name(): string {
-		return this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript;
+		return TARGET_FRAMEWORK_IDENTIFIERS.NativeScript;
 	}
 
 	public get capabilities(): Project.ICapabilities {
@@ -55,7 +56,7 @@ export class NativeScriptProject extends FrameworkProjectBase implements Project
 	}
 
 	public get startPackageActivity(): string {
-		return startPackageActivityNames[this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript.toLowerCase()];
+		return startPackageActivityNames[TARGET_FRAMEWORK_IDENTIFIERS.NativeScript.toLowerCase()];
 	}
 
 	public get relativeAppResourcesPath(): string {
@@ -105,7 +106,7 @@ export class NativeScriptProject extends FrameworkProjectBase implements Project
 
 	public ensureAllPlatformAssets(projectDir: string, frameworkVersion: string): IFuture<void> {
 		return (() => {
-			let appResourcesDir = this.$resources.getPathToAppResources(this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript);
+			let appResourcesDir = this.$resources.getPathToAppResources(TARGET_FRAMEWORK_IDENTIFIERS.NativeScript);
 			let appResourceFiles = this.$fs.enumerateFilesInDirectorySync(appResourcesDir);
 			// In 0.10.0 original template, App_Resources directory is not included in app directory.
 			let appResourcesHolderDirectory = path.join(projectDir, this.$projectConstants.NATIVESCRIPT_APP_DIR_NAME);

--- a/lib/project/resolvers/framework-project-resolver-base.ts
+++ b/lib/project/resolvers/framework-project-resolver-base.ts
@@ -1,9 +1,9 @@
 import * as helpers from "../../helpers";
+import { TARGET_FRAMEWORK_IDENTIFIERS } from "../../common/mobile/constants";
 
 export class FrameworkProjectResolverBase implements Project.IFrameworkProjectResolverBase {
 	constructor(private $errors: IErrors,
-		private $injector: IInjector,
-		private $projectConstants: Project.IConstants) { }
+		private $injector: IInjector) { }
 
 	public resolveByName<T>(name: string, framework: string, ctorArguments?: IDictionary<any>): T {
 		let fr = framework.charAt(0).toLowerCase() + framework.slice(1);
@@ -12,7 +12,7 @@ export class FrameworkProjectResolverBase implements Project.IFrameworkProjectRe
 			let frameworkObject = this.$injector.resolve(frameworkName, ctorArguments);
 			return frameworkObject;
 		} catch(err) {
-			this.$errors.fail("Unable to resolve framework %s. Valid frameworks are: %s", frameworkName, helpers.formatListOfNames(_.values(this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS)));
+			this.$errors.fail("Unable to resolve framework %s. Valid frameworks are: %s", frameworkName, helpers.formatListOfNames(_.values(TARGET_FRAMEWORK_IDENTIFIERS)));
 		}
 	}
 }

--- a/lib/project/resolvers/framework-project-resolver.ts
+++ b/lib/project/resolvers/framework-project-resolver.ts
@@ -2,9 +2,8 @@ import * as frameworkProjectResolverBaseLib from "./framework-project-resolver-b
 
 export class FrameworkProjectResolver extends frameworkProjectResolverBaseLib.FrameworkProjectResolverBase implements Project.IFrameworkProjectResolver {
 	constructor($errors: IErrors,
-		$injector: IInjector,
-		$projectConstants: Project.IConstants) {
-		super($errors, $injector, $projectConstants);
+		$injector: IInjector) {
+		super($errors, $injector);
 	}
 
 	public resolve(framework: string): Project.IFrameworkProject {

--- a/lib/project/resolvers/framework-simulator-service-resolver.ts
+++ b/lib/project/resolvers/framework-simulator-service-resolver.ts
@@ -2,9 +2,8 @@ import frameworkProjectResolverBaseLib = require("./framework-project-resolver-b
 
 export class FrameworkSimulatorServiceResolver extends frameworkProjectResolverBaseLib.FrameworkProjectResolverBase implements Project.IFrameworkSimulatorServiceResolver {
 	constructor($errors: IErrors,
-				$injector: IInjector,
-				$projectConstants: Project.IConstants) {
-		super($errors, $injector, $projectConstants);
+				$injector: IInjector) {
+		super($errors, $injector);
 	}
 
 	public resolve(framework: string): IProjectSimulatorService {

--- a/lib/providers/commands-service-provider.ts
+++ b/lib/providers/commands-service-provider.ts
@@ -1,18 +1,18 @@
 import * as initCommandLib from "../commands/project/init-project";
 import * as projectCommandLib from "../commands/project/create-project";
 import * as samplesLib from "../commands/samples";
+import { TARGET_FRAMEWORK_IDENTIFIERS } from "../common/mobile/constants";
 
 class CommandsServiceProvider implements ICommandsServiceProvider {
 	private commands: IDynamicSubCommandInfo[];
 	private mapCommandNameToFramework: IStringDictionary;
 
 	constructor(private $injector: IInjector,
-		private $screenBuilderService: IScreenBuilderService,
-		private $projectConstants: Project.IConstants) {
+		private $screenBuilderService: IScreenBuilderService) {
 
 		this.mapCommandNameToFramework = {
-			hybrid: this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova,
-			native: this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript
+			hybrid: TARGET_FRAMEWORK_IDENTIFIERS.Cordova,
+			native: TARGET_FRAMEWORK_IDENTIFIERS.NativeScript
 		};
 
 		this.commands = [

--- a/lib/services/project-properties-service.ts
+++ b/lib/services/project-properties-service.ts
@@ -1,6 +1,7 @@
 import {EOL} from "os";
 import xmlMapping = require("xml-mapping");
 import * as util from "util";
+import { TARGET_FRAMEWORK_IDENTIFIERS } from "../common/mobile/constants";
 
 export class ProjectPropertiesService implements IProjectPropertiesService {
 	private static PROJECT_VERSION_DEFAULT_VALUE = 1;
@@ -130,7 +131,7 @@ export class ProjectPropertiesService implements IProjectPropertiesService {
 			let result: string[] = [];
 			let schemas: IDictionary<IDictionary<any>> = Object.create(null);
 
-			let targetFrameworkIdentifiers = _.values(this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS);
+			let targetFrameworkIdentifiers = _.values(TARGET_FRAMEWORK_IDENTIFIERS);
 			_.each(targetFrameworkIdentifiers, (targetFrameworkIdentifier: string) => {
 				let projectSchema = this.$frameworkProjectResolver.resolve(targetFrameworkIdentifier).getProjectFileSchema();
 				schemas[targetFrameworkIdentifier] = projectSchema;

--- a/lib/services/samples-service.ts
+++ b/lib/services/samples-service.ts
@@ -2,6 +2,7 @@ import * as path from "path";
 import * as util from "util";
 import {EOL} from "os";
 import temp = require("temp");
+import { TARGET_FRAMEWORK_IDENTIFIERS } from "../common/mobile/constants";
 
 class Sample {
 	constructor(public name: string,
@@ -33,7 +34,6 @@ export class SamplesService implements ISamplesService {
 		private $fs: IFileSystem,
 		private $httpClient: Server.IHttpClient,
 		private $staticConfig: IStaticConfig,
-		private $projectConstants: Project.IConstants,
 		private $options: IOptions) {
 	}
 
@@ -43,7 +43,7 @@ export class SamplesService implements ISamplesService {
 			if(framework) {
 				this.printSamplesInformationForFramework(framework).wait();
 			} else {
-				_.values(this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS).forEach(fx => this.printSamplesInformationForFramework(fx).wait());
+				_.values(TARGET_FRAMEWORK_IDENTIFIERS).forEach(fx => this.printSamplesInformationForFramework(fx).wait());
 			}
 		}).future<void>()();
 	}
@@ -139,9 +139,9 @@ export class SamplesService implements ISamplesService {
 	private getRegExpForFramework(framework?: string): RegExp {
 		framework = framework || "";
 		switch(framework.toLowerCase()) {
-			case this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript.toLowerCase():
+			case TARGET_FRAMEWORK_IDENTIFIERS.NativeScript.toLowerCase():
 				return SamplesService.GITHUB_NS_SAMPLES_REGEX;
-			case this.$projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova.toLowerCase():
+			case TARGET_FRAMEWORK_IDENTIFIERS.Cordova.toLowerCase():
 				return SamplesService.GITHUB_CORDOVA_SAMPLES_REGEX;
 			default:
 				return SamplesService.GITHUB_REGEX;

--- a/test/build-configurations.ts
+++ b/test/build-configurations.ts
@@ -19,6 +19,7 @@ import optionsLib = require("../lib/options");
 import assert = require("assert");
 import Future = require("fibers/future");
 import {ConfigFilesManager} from "../lib/project/config-files-manager";
+import { TARGET_FRAMEWORK_IDENTIFIERS } from "../lib/common/mobile/constants";
 import * as path from "path";
 import temp = require("temp");
 import * as util from "util";
@@ -89,7 +90,7 @@ function createTestInjector() {
 	testInjector.register("frameworkProjectResolver", frameworkProjectResolverLib.FrameworkProjectResolver);
 	testInjector.register("cordovaProject", cordovaProjectLib.CordovaProject);
 	testInjector.register("serverExtensionsService", {});
-	testInjector.register("projectConstants", require("../lib/common/appbuilder/project-constants").ProjectConstants);
+	testInjector.register("projectConstants", projectConstantsLib.ProjectConstants);
 	testInjector.register("projectFilesManager", stubs.ProjectFilesManager);
 	testInjector.register("jsonSchemaValidator", {
 		validate: (data: Project.IData) => { /* mock */ },
@@ -165,7 +166,6 @@ function getProjectFileName(configuration: string) {
 
 function assertCorePluginsCount(configuration?: string) {
 	let testInjector = createTestInjector();
-	let projectConstants: Project.IConstants = new projectConstantsLib.ProjectConstants();
 	let options = testInjector.resolve("options");
 	let project = testInjector.resolve("project");
 	let fs = testInjector.resolve("fs");
@@ -185,7 +185,7 @@ function assertCorePluginsCount(configuration?: string) {
 		options.release = true;
 	}
 
-	project.createNewProject(projectName, projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait();
+	project.createNewProject(projectName, TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait();
 
 	let availableMarketplacePlugins = [
 		{

--- a/test/project.ts
+++ b/test/project.ts
@@ -35,6 +35,7 @@ import { NativeScriptProjectCapabilities } from "../lib/common/appbuilder/projec
 import { CordovaProjectCapabilities } from "../lib/common/appbuilder/project/cordova-project-capabilities";
 temp.track();
 let projectConstants = new projectConstantsLib.ProjectConstants();
+import { TARGET_FRAMEWORK_IDENTIFIERS } from "../lib/common/mobile/constants";
 
 class PrompterStub implements IPrompter {
 	public confirmResult: boolean = false;
@@ -178,7 +179,7 @@ describe("project integration tests", () => {
 			options.template = "Blank";
 			options.appid = "com.telerik.Test";
 
-			project.createNewProject(projectName, projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait();
+			project.createNewProject(projectName, TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait();
 
 			let abProject = fs.readFileSync(path.join(tempFolder, ".abproject"));
 			let correctABProject = fs.readFileSync(path.join(__dirname, "/resources/blank-Cordova.abproject"));
@@ -210,7 +211,7 @@ describe("project integration tests", () => {
 			options.template = "Blank";
 			options.appid = "com.telerik.Test";
 
-			project.createNewProject(projectName, projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript).wait();
+			project.createNewProject(projectName, TARGET_FRAMEWORK_IDENTIFIERS.NativeScript).wait();
 			let abProject = fs.readFileSync(path.join(tempFolder, ".abproject"));
 			let correctABProject = fs.readFileSync(path.join(__dirname, "/resources/blank-NativeScript.abproject"));
 			let testProperties = JSON.parse(abProject.toString());
@@ -241,7 +242,7 @@ describe("project integration tests", () => {
 			options.appid = "com.telerik.Test";
 			let projectName = "Test";
 			project = testInjector.resolve("project");
-			project.createNewProject(projectName, projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait();
+			project.createNewProject(projectName, TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait();
 			options.debug = options.release = false;
 			project.updateProjectPropertyAndSave("set", "FrameworkVersion", ["3.7.0"]).wait();
 		});
@@ -333,7 +334,7 @@ describe("project integration tests", () => {
 
 			it("Blank template has all mandatory files", () => {
 				options.template = "Blank";
-				project.createNewProject(projectName, projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript).wait();
+				project.createNewProject(projectName, TARGET_FRAMEWORK_IDENTIFIERS.NativeScript).wait();
 				let projectDir = project.getProjectDir().wait();
 				let packageJson = path.join(projectDir, projectConstants.PACKAGE_JSON_NAME);
 				assert.isTrue(fs.existsSync(packageJson), "NativeScript Blank template does not contain mandatory 'package.json' file. This file is required in init command. You should check if this is problem with the template or change init command to use another file.");
@@ -341,7 +342,7 @@ describe("project integration tests", () => {
 
 			it("TypeScript.Blank template has mandatory files", () => {
 				options.template = "TypeScript.Blank";
-				project.createNewProject(projectName, projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript).wait();
+				project.createNewProject(projectName, TARGET_FRAMEWORK_IDENTIFIERS.NativeScript).wait();
 				let projectDir = project.getProjectDir().wait();
 				let packageJson = path.join(projectDir, projectConstants.PACKAGE_JSON_NAME);
 				assert.isTrue(fs.existsSync(packageJson), "NativeScript TypeScript.Blank template does not contain mandatory 'package.json' file. This file is required in init command. You should check if this is problem with the template or change init command to use another file.");
@@ -349,27 +350,27 @@ describe("project integration tests", () => {
 
 			it("existing TypeScript.Blank project has project files after init",() => {
 				options.template = "TypeScript.Blank";
-				project.createNewProject(projectName, projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript).wait();
+				project.createNewProject(projectName, TARGET_FRAMEWORK_IDENTIFIERS.NativeScript).wait();
 				let projectDir = project.getProjectDir().wait();
 				removeProjectFiles(projectDir);
 				options.path = projectDir;
-				project.initializeProjectFromExistingFiles(projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript).wait();
+				project.initializeProjectFromExistingFiles(TARGET_FRAMEWORK_IDENTIFIERS.NativeScript).wait();
 				assertProjectFilesExistAfterInit(projectDir);
 			});
 
 			it("existing project has project files after init",() => {
 				options.template = "Blank";
-				project.createNewProject(projectName, projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript).wait();
+				project.createNewProject(projectName, TARGET_FRAMEWORK_IDENTIFIERS.NativeScript).wait();
 				let projectDir = project.getProjectDir().wait();
 				removeProjectFiles(projectDir);
 				options.path = projectDir;
-				project.initializeProjectFromExistingFiles(projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript).wait();
+				project.initializeProjectFromExistingFiles(TARGET_FRAMEWORK_IDENTIFIERS.NativeScript).wait();
 				assertProjectFilesExistAfterInit(projectDir);
 			});
 
 			it("empty directory has project files after init",() => {
 				options.path = tempFolder;
-				project.initializeProjectFromExistingFiles(projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript).wait();
+				project.initializeProjectFromExistingFiles(TARGET_FRAMEWORK_IDENTIFIERS.NativeScript).wait();
 				assertProjectFilesExistAfterInit(tempFolder);
 			});
 		});
@@ -397,23 +398,23 @@ describe("project integration tests", () => {
 
 			it("existing project has configuration specific files and .abignore files after init",() => {
 				options.template = "Blank";
-				project.createNewProject(projectName, projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait();
+				project.createNewProject(projectName, TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait();
 				let projectDir = project.getProjectDir().wait();
 				removeProjectFiles(projectDir);
 				options.path = projectDir;
-				project.initializeProjectFromExistingFiles(projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait();
+				project.initializeProjectFromExistingFiles(TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait();
 				assertProjectFilesExistAfterInit(projectDir);
 			});
 
 			it("empty directory has project files after init",() => {
 				options.path = tempFolder;
-				project.initializeProjectFromExistingFiles(projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait();
+				project.initializeProjectFromExistingFiles(TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait();
 				assertProjectFilesExistAfterInit(tempFolder);
 			});
 
 			it("Blank template has all mandatory files", () => {
 				options.template = "Blank";
-				project.createNewProject(projectName, projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait();
+				project.createNewProject(projectName, TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait();
 				let projectDir = project.getProjectDir().wait();
 
 				_.forEach(mobileHelper.platformNames, platform => {
@@ -424,7 +425,7 @@ describe("project integration tests", () => {
 
 			it("TypeScript.Blank template has mandatory files", () => {
 				options.template = "TypeScript.Blank";
-				project.createNewProject(projectName, projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait();
+				project.createNewProject(projectName, TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait();
 				let projectDir = project.getProjectDir().wait();
 
 				_.forEach(mobileHelper.platformNames, platform => {
@@ -435,7 +436,7 @@ describe("project integration tests", () => {
 
 			it("KendoUI.Drawer template has mandatory files", () => {
 				options.template = "KendoUI.Drawer";
-				project.createNewProject(projectName, projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait();
+				project.createNewProject(projectName, TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait();
 				let projectDir = project.getProjectDir().wait();
 
 				_.forEach(mobileHelper.platformNames, platform => {
@@ -446,7 +447,7 @@ describe("project integration tests", () => {
 
 			it("When KendoUI.Blank is specified use KendoUI.Empty", () => {
 				options.template = "KendoUI.Blank";
-				project.createNewProject(projectName, projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait();
+				project.createNewProject(projectName, TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait();
 				let projectDir = project.getProjectDir().wait();
 
 				_.forEach(mobileHelper.platformNames, platform => {
@@ -457,7 +458,7 @@ describe("project integration tests", () => {
 
 			it("KendoUI.Empty template has mandatory files", () => {
 				options.template = "KendoUI.Empty";
-				project.createNewProject(projectName, projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait();
+				project.createNewProject(projectName, TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait();
 				let projectDir = project.getProjectDir().wait();
 
 				_.forEach(mobileHelper.platformNames, platform => {
@@ -468,7 +469,7 @@ describe("project integration tests", () => {
 
 			it("KendoUI.TabStrip template has mandatory files", () => {
 				options.template = "KendoUI.TabStrip";
-				project.createNewProject(projectName, projectConstants.TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait();
+				project.createNewProject(projectName, TARGET_FRAMEWORK_IDENTIFIERS.Cordova).wait();
 				let projectDir = project.getProjectDir().wait();
 
 				_.forEach(mobileHelper.platformNames, platform => {


### PR DESCRIPTION
Move TARGET_FRAMEWORK_IDENTIFIERS from $projectConstants (available in AppBuilder CLI only) to constants.
This way we can use it in common lib and all CLIs directly.