### PR TITLE
Rename packageId to appIdentifier

### DIFF
--- a/lib/services/debug/darwin-debugger-service.ts
+++ b/lib/services/debug/darwin-debugger-service.ts
@@ -37,7 +37,7 @@ export class DarwinDebuggerService implements IDebuggerService {
 			let applicationsAvailableForDebugging = this.$androidProcessService.getDebuggableApps(deviceIdentifier).wait();
 			let applicationNotStartedErrorMessage = `Application with identifier ${applicationId} is not started on device ${deviceIdentifier}. Please open the application on the device to debug it.`;
 
-			if (!_.find(applicationsAvailableForDebugging, app => app.packageId === applicationId)) {
+			if (!_.find(applicationsAvailableForDebugging, app => app.appIdentifier === applicationId)) {
 				this.$errors.failWithoutHelp(applicationNotStartedErrorMessage);
 			}
 


### PR DESCRIPTION
Rename packageId to appIdentifier in IAndroidApplicationInformation.