### PR TITLE
Download nativeScript-migration-data.json file

### DIFF
--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -472,6 +472,13 @@ interface IFrameworkMigrationService {
 	downloadMigrationData(): IFuture<void>;
 
 	/**
+	 * Downloads the configuration file which contains information about migrating project.
+	 * @param  {string} the directory in which to save the file.
+	 * @return {IFuture<void>}
+	 */
+	downloadMigrationConfigFile(targetPath?: string): IFuture<void>;
+
+	/**
 	 * Gives a list of all supported versions. Each version is a string in the following format <Major>.<Minor>.<Patch>
 	 * @return {IFuture<string[]>} List of all supported versions.
 	 */
@@ -489,6 +496,7 @@ interface IFrameworkMigrationService {
 	 * @return {IFuture<string>} User-friendly name of the specified version.
 	 */
 	getDisplayNameForVersion(version: string): IFuture<string>;
+
 	/**
 	 * Hook which is dynamically called when a project's framework version is changing
 	 * @param  {string} newVersion The version to upgrade/downgrade to

--- a/lib/project.ts
+++ b/lib/project.ts
@@ -18,11 +18,7 @@ export class Project extends ProjectBase implements Project.IProject {
 
 	private _projectSchema: any;
 	private cachedProjectDir: string = "";
-
 	private frameworkProject: Project.IFrameworkProject;
-	public get projectDir(): string {
-		return this.getProjectDir().wait();
-	}
 
 	constructor(private $config: IConfiguration,
 		private $frameworkProjectResolver: Project.IFrameworkProjectResolver,
@@ -51,6 +47,15 @@ export class Project extends ProjectBase implements Project.IProject {
 				"The AppBuilder CLI lets you target only Apache Cordova 3.0.0 or later. " +
 				"To develop your projects with Apache Cordova 2.x, run the AppBuilder Windows client or the in-browser client.");
 		}
+
+		if (this.projectData && this.projectData.Framework) {
+			this.frameworkProject = this.$frameworkProjectResolver.resolve(this.projectData.Framework);
+			this.frameworkProject.updateMigrationConfigFile().wait();
+		}
+	}
+
+	public get projectDir(): string {
+		return this.getProjectDir().wait();
 	}
 
 	public get capabilities(): Project.ICapabilities {

--- a/lib/project/cordova-project.ts
+++ b/lib/project/cordova-project.ts
@@ -1,9 +1,10 @@
 import * as path from "path";
 import * as util from "util";
 import {FrameworkProjectBase} from "./framework-project-base";
+import {TARGET_FRAMEWORK_IDENTIFIERS} from "../common/constants";
 import helpers = require("./../common/helpers");
 import semver = require("semver");
-import { TARGET_FRAMEWORK_IDENTIFIERS } from "../common/constants";
+import Future = require("fibers/future");
 
 export class CordovaProject extends FrameworkProjectBase implements Project.IFrameworkProject {
 	private static WP8_DEFAULT_PACKAGE_IDENTITY_NAME_PREFIX = "1234Telerik";
@@ -200,6 +201,10 @@ export class CordovaProject extends FrameworkProjectBase implements Project.IFra
 		}
 
 		return updated;
+	}
+
+	public updateMigrationConfigFile(): IFuture<void> {
+		return Future.fromResult();
 	}
 
 	private generateWP8GUID(): string {

--- a/lib/project/framework-project-base.ts
+++ b/lib/project/framework-project-base.ts
@@ -1,4 +1,5 @@
-export class FrameworkProjectBase implements Project.IFrameworkProjectBase {
+export abstract class FrameworkProjectBase implements Project.IFrameworkProjectBase {
+	protected static MAX_MIGRATION_FILE_EDIT_TIME_DIFFERENCE = 60 * 60 * 1000 * 2;
 	private assetUpdateMessagePrinted = false;
 
 	constructor(protected $logger: ILogger,
@@ -12,7 +13,7 @@ export class FrameworkProjectBase implements Project.IFrameworkProjectBase {
 		properties.DisplayName = projectName;
 		properties.Description = projectName;
 		let appid = this.$options.appid;
-		if(!this.$options.appid) {
+		if (!this.$options.appid) {
 			appid = this.generateDefaultAppId(projectName);
 			this.$logger.warn("--appid was not specified. Defaulting to " + appid);
 		}
@@ -32,7 +33,7 @@ export class FrameworkProjectBase implements Project.IFrameworkProjectBase {
 				let files = this.$fs.readDirectory(dir).wait();
 				_.each(files, (file) => {
 					let matches = file.match(fileMask);
-					if(matches) {
+					if (matches) {
 						result.push(matches[1].toLowerCase());
 					}
 				});
@@ -52,7 +53,7 @@ export class FrameworkProjectBase implements Project.IFrameworkProjectBase {
 	public getProperty(propertyName: string, configuration: string, projectInformation: Project.IProjectInformation): any {
 		let propertyValue: any = null;
 		let configData = projectInformation.configurationSpecificData[configuration];
-		if(configData && configData[propertyName]) {
+		if (configData && configData[propertyName]) {
 			propertyValue = configData[propertyName];
 		} else {
 			propertyValue = projectInformation.projectData[propertyName];
@@ -83,10 +84,12 @@ export class FrameworkProjectBase implements Project.IFrameworkProjectBase {
 		return updated;
 	}
 
+	public abstract updateMigrationConfigFile(): IFuture<void>;
+
 	private generateDefaultAppId(appName: string): string {
 		let sanitizedName = _.filter(appName.split(""), c => /[a-zA-Z0-9]/.test(c)).join("");
-		if(sanitizedName) {
-			if(/^\d.*$/.test(sanitizedName)) {
+		if (sanitizedName) {
+			if (/^\d.*$/.test(sanitizedName)) {
 				sanitizedName = "the" + sanitizedName;
 			}
 			return "com.telerik." + sanitizedName;

--- a/lib/project/project.d.ts
+++ b/lib/project/project.d.ts
@@ -131,6 +131,10 @@ declare module Project {
 		 * }
 		 */
 		getPluginVariablesInfo(projectInformation: Project.IProjectInformation, projectDir?: string, configuration?: string): IFuture<IDictionary<IStringDictionary>>;
+		/**
+		 * Updates the json file which contains the migration information. If the user is not connectet to the internet the file will not be updated and the CLI will use the one which is downloaded when the CLI is installed or updated.
+		 */
+		updateMigrationConfigFile(): IFuture<void>;
 	}
 
 	interface IFrameworkProjectBase {

--- a/lib/resource-downloader.ts
+++ b/lib/resource-downloader.ts
@@ -4,7 +4,6 @@ class ResourceDownloader implements IResourceDownloader {
 	private imageDefinitionsResourcesPath: string;
 
 	constructor(private $config: IConfiguration,
-		private $cordovaMigrationService: IFrameworkMigrationService,
 		private $cordovaResources: ICordovaResourceLoader,
 		private $fs: IFileSystem,
 		private $httpClient: Server.IHttpClient,
@@ -13,10 +12,14 @@ class ResourceDownloader implements IResourceDownloader {
 		private $projectConstants: Project.IConstants,
 		private $resources: IResourceLoader,
 		private $server: Server.IServer,
+		private $injector: IInjector,
 		private $staticConfig: Config.IStaticConfig) {
+		this.imageDefinitionsResourcesPath = `http://${this.$config.AB_SERVER}/appbuilder/Resources/${this.$projectConstants.IMAGE_DEFINITIONS_FILE_NAME}`;
+	}
 
-			this.imageDefinitionsResourcesPath = `http://${this.$config.AB_SERVER}/appbuilder/Resources/${this.$projectConstants.IMAGE_DEFINITIONS_FILE_NAME}`;
-		}
+	private get $cordovaMigrationService(): IFrameworkMigrationService {
+		return this.$injector.resolve("cordovaMigrationService");
+	}
 
 	public downloadCordovaJsFiles(): IFuture<void> {
 		return (() => {
@@ -39,7 +42,7 @@ class ResourceDownloader implements IResourceDownloader {
 			let file = this.$fs.createWriteStream(targetPath);
 			let fileEnd = this.$fs.futureFromEvent(file, "finish");
 			this.$logger.trace(`Downloading resource from server. Remote path is: '${remotePath}'. Target path is: '${targetPath}'.`);
-			this.$httpClient.httpRequest({ url:remotePath, pipeTo: file}).wait();
+			this.$httpClient.httpRequest({ url: remotePath, pipeTo: file }).wait();
 			fileEnd.wait();
 		}).future<void>()();
 	}

--- a/test/project-properties-service.ts
+++ b/test/project-properties-service.ts
@@ -72,6 +72,9 @@ class SampleProject implements Project.IFrameworkProject {
 	getPluginVariablesInfo(projectInformation: Project.IProjectInformation, projectDir?: string, configuration?: string): IFuture<IDictionary<IStringDictionary>> {
 		return Future.fromResult(null);
 	}
+	updateMigrationConfigFile(): IFuture<void> {
+		return Future.fromResult(null);
+	}
 }
 
 describe("projectPropertiesService", () => {

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -382,6 +382,10 @@ class FrameworkProjectStub implements Project.IFrameworkProject {
 	public getPluginVariablesInfo(projectInformation: Project.IProjectInformation, projectDir?: string, configuration?: string): IFuture<IDictionary<IStringDictionary>> {
 		return Future.fromResult(null);
 	}
+
+	public updateMigrationConfigFile(): IFuture<void> {
+		return Future.fromResult(null);
+	}
 }
 
 export class ProjectFilesManager implements IProjectFilesManager {


### PR DESCRIPTION
When we integrate experimental version of NativeScript we need to upload new package of the CLI in npm with the updated nativeScript-migration-data.json file so the users can use the new version.

It will be better to download the nativeScript-migration-data.json file when NativeScript related command is executed.