### PR TITLE
Remove logic about storing configuration-specific keys

### DIFF
--- a/lib/project.ts
+++ b/lib/project.ts
@@ -407,6 +407,7 @@ export class Project extends ProjectBase implements Project.IProject {
 					});
 				} else {
 					this.$projectPropertiesService.updateProjectProperty(this.projectData, undefined, mode, normalizedPropertyName, propertyValues).wait();
+					_.each(this.configurationSpecificData, data => this.$projectPropertiesService.updateProjectProperty(data, undefined, mode, normalizedPropertyName, propertyValues).wait());
 				}
 			}
 
@@ -657,7 +658,8 @@ export class Project extends ProjectBase implements Project.IProject {
 				let configFilePath = path.join(projectDir, util.format(".%s%s", configuration, this.$projectConstants.PROJECT_FILE));
 
 				if (this.$fs.exists(configFilePath).wait() && this.configurationSpecificData[configuration]) {
-					this.$fs.writeJson(configFilePath, _.pick(this.configurationSpecificData[configuration], this.configurationSpecificKeys[configuration])).wait();
+					let configurationSpecificKeys = _.reduce(this.configurationSpecificData[configuration], (result, value, key) => _.isEqual(value, this.projectData[key]) ? result : result.concat(key), []);
+					this.$fs.writeJson(configFilePath, _.pick(this.configurationSpecificData[configuration], configurationSpecificKeys)).wait();
 				}
 			});
 		}).future<void>()();


### PR DESCRIPTION
Instead of caching the old keys, do a deep diff between configuration-specific data and current project data. Save only configuration-specific data to configuration files.

In addition, if no configuration is specified, set property in base configuration file (.abproject) and delete keys in the other configuration files (.debug.abproject, .release.abproject).
This is accomplished by setting the property of all configuration-specific data objects in addition to the project data object to the same value.

Ping @rosen-vladimirov and @TsvetanMilanov 

Merge after https://github.com/telerik/mobile-cli-lib/pull/742 (although this PR doesn't depend on it)