### PR TITLE
Add analytics for Sublime

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -167,6 +167,7 @@ $injector.require("clientSpecificUserSettingsService", "./services/user-settings
 $injector.require("sharedUserSettingsFileService", "./services/user-settings-service");
 $injector.require("sharedUserSettingsService", "./services/user-settings-service");
 $injector.require("analyticsSettingsService", "./services/analytics-settings-service");
+$injector.require("analyticsService", "./services/analytics-service");
 
 $injector.require("emulatorSettingsService", "./services/emulator-settings-service");
 $injector.require("express", "./express");

--- a/lib/services/analytics-service.ts
+++ b/lib/services/analytics-service.ts
@@ -1,0 +1,29 @@
+import {AnalyticsServiceBase} from "../common/services/analytics-service-base";
+
+export class AnalyticsService extends AnalyticsServiceBase implements IAnalyticsService {
+	private static SUBLIME_ANALYTICS_CLIENT_NAME = "Sublime";
+	private static SUBLIME_ANALYTICS_PROJECT_KEY = "0e2863c76b76409fa7bc140a2b36a066";
+
+	constructor(protected $logger: ILogger,
+		protected $options: IOptions,
+		$staticConfig: Config.IStaticConfig,
+		$errors: IErrors,
+		$prompter: IPrompter,
+		$userSettingsService: UserSettings.IUserSettingsService,
+		$analyticsSettingsService: IAnalyticsSettingsService,
+		$progressIndicator: IProgressIndicator) {
+		super($logger, $options, $staticConfig, $errors, $prompter, $userSettingsService, $analyticsSettingsService, $progressIndicator);
+	}
+
+	public trackFeature(featureName: string): IFuture<void> {
+		return (() => {
+			if (this.$options.analyticsClient === AnalyticsService.SUBLIME_ANALYTICS_CLIENT_NAME) {
+				super.restartEqatecMonitor(AnalyticsService.SUBLIME_ANALYTICS_PROJECT_KEY).wait();
+			}
+
+			super.trackFeature(featureName).wait();
+		}).future<void>()();
+	}
+}
+
+$injector.register("analyticsService", AnalyticsService);

--- a/test/resources/blank-NativeScript.abproject
+++ b/test/resources/blank-NativeScript.abproject
@@ -12,7 +12,7 @@
         "2"
     ]
     ,"iOSBackgroundMode": []
-    ,"FrameworkVersion": "2.0.0"
+    ,"FrameworkVersion": "2.1.0"
     ,"AndroidPermissions": [
         "android.permission.INTERNET"
      ]


### PR DESCRIPTION
We need to redirect the analytics data sent from Sublime to separate analytics project so we can keep track of how many users are using Telerik AppBuilder for Sublime Text.