### PR TITLE
Fix plugin fetch from plugins directory

### DIFF
--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -1277,3 +1277,20 @@ interface ILocalPluginData {
 	 */
 	suppressMessage?: boolean;
 }
+
+declare module NpmPlugins {
+	/**
+	 * Describes options for fetching local plugin.
+	 */
+	interface IFetchLocalPluginOptions {
+		/**
+		 * Use the original plugin directory instead of the one in Temp.
+		 */
+		useOriginalPluginDirectory: boolean;
+
+		/**
+		 * The original directory of the local plugin.
+		 */
+		originalPluginDirectory?: string;
+	}
+}

--- a/lib/services/plugins/cordova-project-plugins-service.ts
+++ b/lib/services/plugins/cordova-project-plugins-service.ts
@@ -321,11 +321,11 @@ export class CordovaProjectPluginsService extends NpmPluginsServiceBase implemen
 		}).future<IBasicPluginInformation>()();
 	}
 
-	protected fetchPluginBasicInformationCore(pathToInstalledPlugin: string, pluginData?: ILocalPluginData): IFuture<IBasicPluginInformation> {
+	protected fetchPluginBasicInformationCore(pathToInstalledPlugin: string, pluginData?: ILocalPluginData, options?: NpmPlugins.IFetchLocalPluginOptions): IFuture<IBasicPluginInformation> {
 		// We do not need to add the plugin to .abproject file because it will be sent with the plugins directory.
 		pluginData.addPluginToConfigFile = false;
 
-		return super.installLocalPlugin(pathToInstalledPlugin, pluginData);
+		return super.installLocalPlugin(pathToInstalledPlugin, pluginData, options);
 	}
 
 	private loadPluginsData(): IFuture<void> {

--- a/lib/services/plugins/nativescript-project-plugins-service.ts
+++ b/lib/services/plugins/nativescript-project-plugins-service.ts
@@ -220,7 +220,7 @@ export class NativeScriptProjectPluginsService extends NpmPluginsServiceBase imp
 		}).future<IBasicPluginInformation>()();
 	}
 
-	protected fetchPluginBasicInformationCore(pathToInstalledPlugin: string, pluginData?: ILocalPluginData): IFuture<IBasicPluginInformation> {
+	protected fetchPluginBasicInformationCore(pathToInstalledPlugin: string, pluginData?: ILocalPluginData, options?: NpmPlugins.IFetchLocalPluginOptions): IFuture<IBasicPluginInformation> {
 		if (pluginData && pluginData.isTgz || this.$fs.exists(pluginData.actualName).wait()) {
 			pluginData.configFileContents = this.$fs.readJson(path.join(pathToInstalledPlugin, this.$projectConstants.PACKAGE_JSON_NAME)).wait();
 		}
@@ -229,7 +229,7 @@ export class NativeScriptProjectPluginsService extends NpmPluginsServiceBase imp
 		pluginData.addPluginToConfigFile = true;
 
 		// Pass the actual plugin name because we do not need to add the extracted plugin if it is tgz file.
-		return super.installLocalPlugin(pluginData && pluginData.isTgz ? pluginData.actualName : pathToInstalledPlugin, pluginData);
+		return super.installLocalPlugin(pluginData && pluginData.isTgz ? pluginData.actualName : pathToInstalledPlugin, pluginData, options);
 	}
 
 	protected shouldCopyToPluginsDirectory(pathToPlugin: string): IFuture<boolean> {


### PR DESCRIPTION
When the user tries to fetch plugin from the plugins directory in the project we do not need to copy again the already existing plugin.