### PR TITLE
Update osenv dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "mute-stream": "0.0.4",
     "node-uuid": "1.4.1",
     "open": "0.0.4",
-    "osenv": "0.1.0",
+    "osenv": "0.1.3",
     "plist": "1.1.0",
     "plistlib": "0.2.1",
     "progress-stream": "0.5.0",


### PR DESCRIPTION
Update osenv dependency in order to resolve issue on Mac OS X and Linux when HOME environment variable is not set.