### PR TITLE
Search http://registry.npmjs.org for plugins

### DIFF
--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -1293,4 +1293,14 @@ declare module NpmPlugins {
 		 */
 		originalPluginDirectory?: string;
 	}
+
+	/**
+	 * Describes the format of the result returned from http://registry.npmjs.org/[plugin-name].
+	 */
+	interface INpmRegistryResult {
+		_id: string;
+		name: string;
+		description: string;
+		versions: IDictionary<IBasicPluginInformation>;
+	}
 }

--- a/lib/services/plugins/nativescript-project-plugins-service.ts
+++ b/lib/services/plugins/nativescript-project-plugins-service.ts
@@ -23,7 +23,6 @@ export class NativeScriptProjectPluginsService extends NpmPluginsServiceBase imp
 	constructor(private $nativeScriptResources: INativeScriptResources,
 		private $pluginVariablesHelper: IPluginVariablesHelper,
 		private $server: Server.IServer,
-		private $httpClient: Server.IHttpClient,
 		$errors: IErrors,
 		$logger: ILogger,
 		$prompter: IPrompter,
@@ -31,26 +30,16 @@ export class NativeScriptProjectPluginsService extends NpmPluginsServiceBase imp
 		$project: Project.IProject,
 		$projectConstants: Project.IConstants,
 		$childProcess: IChildProcess,
+		$httpClient: Server.IHttpClient,
 		$hostInfo: IHostInfo,
 		$progressIndicator: IProgressIndicator) {
-		super($errors, $logger, $prompter, $fs, $project, $projectConstants, $childProcess, $hostInfo, $progressIndicator);
+		super($errors, $logger, $prompter, $fs, $project, $projectConstants, $childProcess, $httpClient, $hostInfo, $progressIndicator);
 
 		let versions: string[] = (<any[]>this.$fs.readJson(this.$nativeScriptResources.nativeScriptMigrationFile).wait().supportedVersions).map(version => version.version);
 		let frameworkVersion = this.$project.projectData.FrameworkVersion;
 		if (!_.includes(versions, frameworkVersion)) {
 			this.$errors.failWithoutHelp(`Your project targets NativeScript version '${frameworkVersion}' which does not support plugins.`);
 		}
-	}
-
-	public findPlugins(keywords: string[]): IFuture<IBasicPluginInformation[]> {
-		let nativeScriptKeyword = TARGET_FRAMEWORK_IDENTIFIERS.NativeScript.toLowerCase();
-		let hasNativeScriptKeyword = _.some(keywords, (keyword: string) => keyword.toLowerCase().indexOf(nativeScriptKeyword) >= 0);
-
-		if (!hasNativeScriptKeyword) {
-			keywords.unshift(nativeScriptKeyword);
-		}
-
-		return super.findPlugins(keywords);
 	}
 
 	public getAvailablePlugins(pluginsCount?: number): IPlugin[] {
@@ -195,6 +184,17 @@ export class NativeScriptProjectPluginsService extends NpmPluginsServiceBase imp
 
 	protected getPluginsDirName(): string {
 		return NativeScriptProjectPluginsService.NODE_MODULES_DIR_NAME;
+	}
+
+	protected composeSearchQuery(keywords: string[]): string[] {
+		let nativeScriptKeyword = TARGET_FRAMEWORK_IDENTIFIERS.NativeScript.toLowerCase();
+		let hasNativeScriptKeyword = _.some(keywords, (keyword: string) => keyword.toLowerCase().indexOf(nativeScriptKeyword) >= 0);
+
+		if (!hasNativeScriptKeyword) {
+			keywords.unshift(nativeScriptKeyword);
+		}
+
+		return keywords;
 	}
 
 	protected installLocalPluginCore(pathToPlugin: string, pluginData: ILocalPluginData): IFuture<IBasicPluginInformation> {

--- a/lib/services/plugins/npm-plugins-service-base.ts
+++ b/lib/services/plugins/npm-plugins-service-base.ts
@@ -10,6 +10,8 @@ import temp = require("temp");
 temp.track();
 
 export abstract class NpmPluginsServiceBase implements IPluginsService {
+	private static NPM_REGISTRY_ADDRESS = "http://registry.npmjs.org";
+
 	constructor(protected $errors: IErrors,
 		protected $logger: ILogger,
 		protected $prompter: IPrompter,
@@ -17,6 +19,7 @@ export abstract class NpmPluginsServiceBase implements IPluginsService {
 		protected $project: Project.IProject,
 		protected $projectConstants: Project.IConstants,
 		protected $childProcess: IChildProcess,
+		protected $httpClient: Server.IHttpClient,
 		private $hostInfo: IHostInfo,
 		private $progressIndicator: IProgressIndicator) { }
 
@@ -24,19 +27,26 @@ export abstract class NpmPluginsServiceBase implements IPluginsService {
 		return ((): IBasicPluginInformation[] => {
 			let pluginsFound: IBasicPluginInformation[] = [];
 
-			let searchParams = ["search"].concat(keywords);
+			let query = this.composeSearchQuery(keywords);
+
+			let searchParams = ["search"].concat(query);
 
 			let npmCommand = this.$hostInfo.isWindows ? "npm.cmd" : "npm";
 
 			let npmFuture = this.$childProcess.spawnFromEvent(npmCommand, searchParams, "close");
 
 			this.$logger.printInfoMessageOnSameLine("Searching for plugins in npm, please wait.");
+
 			this.$progressIndicator.showProgressIndicator(npmFuture, 2000).wait();
 
 			let npmSearchResult = npmFuture.get();
 
 			if (npmSearchResult.stderr) {
-				this.$errors.failWithoutHelp(npmSearchResult.stderr);
+				// npm will write "npm WARN Building the local index for the first time, please be patient" to the stderr and if it is the only message on the stderr we should ignore it.
+				let splitError = npmSearchResult.stderr.split("\n");
+				if (splitError.length > 2 || splitError[0].indexOf("Building the local index for the first time") === -1) {
+					this.$errors.failWithoutHelp(npmSearchResult.stderr);
+				}
 			}
 
 			// Need to split the result only by \n because the npm result contains only \n and on Windows it will not split correctly when using EOL.
@@ -97,7 +107,10 @@ export abstract class NpmPluginsServiceBase implements IPluginsService {
 
 			let plugin = _.find(this.getAvailablePlugins(), (pl: IPlugin) => pl.data.Identifier.toLowerCase() === pluginIdentifier || pl.data.Name.toLowerCase() === pluginIdentifier);
 			let pluginUrl = plugin && plugin.data && plugin.data.Url ? plugin.data.Url : null;
-			let plugins = this.findPlugins([pluginIdentifier]).wait();
+
+			let npmRegistryResult = this.searchNpmRegistry(pluginIdentifier).wait();
+			let plugins = npmRegistryResult ? [npmRegistryResult] : this.findPlugins([pluginIdentifier]).wait();
+
 			let pluginKeys = _.map(plugins, (pluginInfo: IBasicPluginInformation) => pluginInfo.name);
 			let pluginsCount = pluginKeys.length;
 
@@ -302,6 +315,8 @@ export abstract class NpmPluginsServiceBase implements IPluginsService {
 
 	protected abstract getPluginsDirName(): string;
 
+	protected abstract composeSearchQuery(keywords: string[]): string[];
+
 	private fetchPluginCore(pluginIdentifier: string, options: NpmPlugins.IFetchLocalPluginOptions = { useOriginalPluginDirectory: false }): IFuture<void> {
 		return (() => {
 			let pluginBasicInfo: IBasicPluginInformation;
@@ -330,5 +345,38 @@ export abstract class NpmPluginsServiceBase implements IPluginsService {
 
 	private isUrlToRepository(pluginId: string): boolean {
 		return validUrl.isUri(pluginId);
+	}
+
+	private searchNpmRegistry(pluginIdentifier: string): IFuture<IBasicPluginInformation> {
+		return ((): IBasicPluginInformation => {
+			let npmRegistryRequestFuture = this.$httpClient.httpRequest(`${NpmPluginsServiceBase.NPM_REGISTRY_ADDRESS}/${pluginIdentifier}`);
+
+			this.$logger.printInfoMessageOnSameLine(`Searching for '${pluginIdentifier}' in ${NpmPluginsServiceBase.NPM_REGISTRY_ADDRESS}, please wait.`);
+			try {
+				this.$progressIndicator.showProgressIndicator(npmRegistryRequestFuture, 2000).wait();
+			} catch (err) {
+				if (err.response.statusCode === 404) {
+					return null;
+				} else {
+					throw err;
+				}
+			}
+
+			let response = npmRegistryRequestFuture.get();
+			let responseBody = response && response.body;
+
+			if (!responseBody) {
+				return null;
+			}
+
+			let pluginInfo: NpmPlugins.INpmRegistryResult = JSON.parse(responseBody);
+
+			let latestVersion = _(pluginInfo.versions)
+				.keys()
+				.sort()
+				.last();
+
+			return pluginInfo.versions[latestVersion];
+		}).future<IBasicPluginInformation>()();
 	}
 }

--- a/test/plugins-service.ts
+++ b/test/plugins-service.ts
@@ -30,6 +30,9 @@ function createTestInjector(cordovaPlugins: any[], installedMarketplacePlugins: 
 	testInjector.register("fs", stubs.FileSystemStub);
 	testInjector.register("config", {});
 	testInjector.register("prompter", {});
+	testInjector.register("httpClient", {
+		httpRequest: (): IFuture<Server.IResponse> => Future.fromResult(null)
+	});
 	testInjector.register("progressIndicator", {
 		showProgressIndicator: () => Future.fromResult()
 	});
@@ -238,6 +241,7 @@ function createTestInjectorForProjectWithBothConfigurations(installedMarketplace
 	testInjector.register("logger", stubs.LoggerStub);
 	testInjector.register("fs", stubs.FileSystemStub);
 	testInjector.register("childProcess", {});
+	testInjector.register("httpClient", {});
 	testInjector.register("progressIndicator", {
 		showProgressIndicator: () => Future.fromResult()
 	});
@@ -288,6 +292,7 @@ function createTestInjectorForAvailableMarketplacePlugins(availableMarketplacePl
 	testInjector.register("logger", stubs.LoggerStub);
 	testInjector.register("fs", stubs.FileSystemStub);
 	testInjector.register("childProcess", {});
+	testInjector.register("httpClient", {});
 	testInjector.register("progressIndicator", {
 		showProgressIndicator: () => Future.fromResult()
 	});
@@ -336,7 +341,6 @@ function createTestInjectorForLocalPluginsFetch(): IInjector {
 
 	testInjector.register("nativeScriptResources", NativeScriptResources);
 	testInjector.register("pluginVariablesHelper", PluginVariablesHelper);
-	testInjector.register("httpClient", {});
 
 	return testInjector;
 }


### PR DESCRIPTION
When existing plugin name is passed to the fetch command it takes very long time to fetch the plugin. Slow fetch is expected only when keywords are passed to the fetch command. We can send request to http://registry.npmjs.org/[plugin-name] and see if there is registered plugin before using the slow npm find command.