### PR TITLE
Fix failing plugin fetch tests

### DIFF
--- a/lib/services/plugins/nativescript-project-plugins-service.ts
+++ b/lib/services/plugins/nativescript-project-plugins-service.ts
@@ -16,7 +16,6 @@ export class NativeScriptProjectPluginsService extends NpmPluginsServiceBase imp
 	private static HEADERS = ["NPM Packages", "NPM NativeScript Plugins", "Marketplace Plugins"];
 	private static DEFAULT_NUMBER_OF_NPM_PACKAGES = 10;
 	private static NPM_REGISTRY_URL = "https://registry.npmjs.org";
-	private static NODE_MODULES_DIR_NAME = "node_modules";
 
 	private marketplacePlugins: IPlugin[];
 
@@ -183,7 +182,7 @@ export class NativeScriptProjectPluginsService extends NpmPluginsServiceBase imp
 	}
 
 	protected getPluginsDirName(): string {
-		return NativeScriptProjectPluginsService.NODE_MODULES_DIR_NAME;
+		return NpmPluginsServiceBase.NODE_MODULES_DIR_NAME;
 	}
 
 	protected composeSearchQuery(keywords: string[]): string[] {

--- a/lib/services/plugins/npm-plugins-service-base.ts
+++ b/lib/services/plugins/npm-plugins-service-base.ts
@@ -10,6 +10,8 @@ import temp = require("temp");
 temp.track();
 
 export abstract class NpmPluginsServiceBase implements IPluginsService {
+	protected static NODE_MODULES_DIR_NAME = "node_modules";
+
 	private static NPM_REGISTRY_ADDRESS = "http://registry.npmjs.org";
 
 	constructor(protected $errors: IErrors,
@@ -238,7 +240,7 @@ export abstract class NpmPluginsServiceBase implements IPluginsService {
 				this.$fs.writeJson(path.join(tempInstallDir, this.$projectConstants.PACKAGE_JSON_NAME), packageJsonData).wait();
 
 				let npmInstallOutput: string = this.$childProcess.exec(`npm install ${identifier} --production --ignore-scripts`, { cwd: tempInstallDir }).wait();
-				let pathToPackage = path.join(tempInstallDir, this.getPluginsDirName());
+				let pathToPackage = path.join(tempInstallDir, NpmPluginsServiceBase.NODE_MODULES_DIR_NAME);
 
 				if (this.$fs.exists(pathToPackage).wait()) {
 					// Most probably the package is installed inside node_modules dir in temp folder.
@@ -253,7 +255,7 @@ export abstract class NpmPluginsServiceBase implements IPluginsService {
 				//                           └── plugin-var-plugin@1.0.0  extraneous
 				let npm2OutputMatch = npmInstallOutput.match(/.*?tempPackage@1\.0\.0.*?\r?\n.*?\s+?(.*?)@.*?\s+?/m);
 				if (npm2OutputMatch) {
-					return path.join(tempInstallDir, this.getPluginsDirName(), npm2OutputMatch[1]);
+					return path.join(tempInstallDir, NpmPluginsServiceBase.NODE_MODULES_DIR_NAME, npm2OutputMatch[1]);
 				}
 
 				// output is something like: nativescript-google-sdk@0.1.18 node_modules\nativescript-google-sdk\n


### PR DESCRIPTION
Wehn we install the plugin with npm to Temp directory we need to check if the plugin is installed in node_modules in the Temp folder both for NativeScript and for Cordova projects.