### PR TITLE
Remove string-to-json dependency

### DIFF
--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -210,3 +210,37 @@ export function fill(value: string, times: number): string[]{
 
 	return repeatedValues;
 }
+
+function getDottedStringObjectRecursive(arr: string[], val: any): any {
+	if (arr.length <= 0) {
+		return val;
+	}
+
+	let first = _.head(arr),
+		rest = _.tail(arr),
+		result: any = {};
+
+	if (_.isUndefined(result[first]) ) {
+		result[first] = {};
+	}
+
+	result[first] = getDottedStringObjectRecursive(rest, val);
+	return result;
+}
+
+export function convertDottedStringToObject(data: any): any {
+	let output: any = {};
+
+	if (_.isObject(data) && !_.isArray(data)) {
+		_(data).keys().each(key => {
+			if (data.hasOwnProperty(key)) {
+				let dotSplit = key.split("."),
+					value = data[key];
+
+				_.extend(output, getDottedStringObjectRecursive(dotSplit, value));
+			}
+		});
+	}
+
+	return output;
+}

--- a/lib/services/user-settings-service.ts
+++ b/lib/services/user-settings-service.ts
@@ -155,7 +155,7 @@ export  class SharedUserSettingsService extends UserSettingsServiceBase implemen
 				delete data[property];
 			});
 
-			let convertedData = require("string-to-json").convert(data);
+			let convertedData = helpers.convertDottedStringToObject(data);
 			helpers.mergeRecursive(this.userSettingsData[SharedUserSettingsService.SETTINGS_ROOT_TAG], convertedData);
 
 			let xml = xmlMapping.toxml(this.userSettingsData);

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "rimraf": "2.2.6",
     "semver": "4.3.4",
     "shelljs": "0.5.3",
-    "string-to-json": "0.1.0",
     "tabtab": "https://github.com/Icenium/node-tabtab/tarball/master",
     "temp": "0.8.1",
     "typescript": "1.8.10",


### PR DESCRIPTION
Using this dependency leads to the error `breaker is not defined` when working with iOS devices and installing dependencies with npm 3.
As the logic is somewhat tirvial remove said dependency and implement the code.

Ping @rosen-vladimirov @TsvetanMilanov 