### PR TITLE
Fix adding CorePlugins to specific configuration

### DIFF
--- a/lib/project/project.d.ts
+++ b/lib/project/project.d.ts
@@ -1,6 +1,6 @@
 declare module Project {
 	interface IProject extends IProjectBase {
-		configurationSpecificData: IDictionary<IDictionary<any>>;
+		configurationSpecificData: IDictionary<IData>;
 		configurations: string[];
 		requiredAndroidApiLevel: number;
 		projectConfigFiles: Project.IConfigurationFile[];
@@ -19,7 +19,8 @@ declare module Project {
 		getProperty(propertyName: string, configuration: string): any;
 		getProjectTargets(): IFuture<string[]>;
 		getConfigFileContent(template: string): IFuture<any>;
-		updateProjectPropertyAndSave(mode: string, propertyName: string, propertyValues: string[]): IFuture<void>;
+		updateProjectProperty(mode: string, propertyName: string, propertyValues: string[], configurations?: string[]): IFuture<void>;
+		updateProjectPropertyAndSave(mode: string, propertyName: string, propertyValues: string[], configurations?: string[]): IFuture<void>;
 		printProjectProperty(property: string, configuration?: string): IFuture<void>;
 		setProperty(propertyName: string, value: any, configuration: string): void;
 		validateProjectProperty(property: string, args: string[], mode: string): IFuture<boolean>;

--- a/lib/services/project-properties-service.ts
+++ b/lib/services/project-properties-service.ts
@@ -69,7 +69,7 @@ export class ProjectPropertiesService implements IProjectPropertiesService {
 				this.updateProjectProperty(projectData, configurationSpecificData[configuration], mode, this.$projectConstants.CORE_PLUGINS_PROPERTY_NAME, newValue).wait();
 			});
 
-			// check if CorePlugins in both configurations are the same
+			// check if CorePlugins in all configurations are the same
 			this.tryMovingCorePluginsToProjectData(projectData, configurationSpecificData);
 		}).future<void>()();
 	}


### PR DESCRIPTION
- Fix `$ appbuilder prop set CorePlugins <values> --debug` not setting values to specific configuration.
- Fix `$ appbuilder plugin add console --release` not moving all CorePlugins to all available configurations.
- Fix possible adding of multiple plugins with same name in a single configuration (missing `uniq` in the code).

When change in CorePlugins is applied, save all possible .abproject files as all of them might be affected.
Extract the `updateProjectProperty` functionality from `updateProjectPropertyAndSave` method to a separate public method in order to keep the current logging for `plugin add` command.

Fixes http://teampulse.telerik.com/view#item/317915