### PR TITLE
Update to latest common lib API for mapAbstractToTcpPort

### DIFF
--- a/lib/commands/debug.ts
+++ b/lib/commands/debug.ts
@@ -100,7 +100,7 @@ export class DebugAndroidCommand extends DebugCommand {
 			super.runDebugger().wait();
 
 			if (!this.$hostInfo.isWindows) {
-				this.$darwinDebuggerService.debugAndroidApplication(this.$project.projectData.AppIdentifier).wait();
+				this.$darwinDebuggerService.debugAndroidApplication(this.$project.projectData.AppIdentifier, this.$project.projectData.Framework).wait();
 			}
 		}).future<void>()();
 	}

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -318,7 +318,7 @@ interface IExtensionPlatformServices extends IRunValidator {
 }
 
 interface IDebuggerService {
-	debugAndroidApplication(applicationId: string): IFuture<void>;
+	debugAndroidApplication(applicationId: string, framework: string): IFuture<void>;
 	debugIosApplication(applicationId: string): void;
 }
 

--- a/lib/services/debug/darwin-debugger-service.ts
+++ b/lib/services/debug/darwin-debugger-service.ts
@@ -17,7 +17,7 @@ export class DarwinDebuggerService implements IDebuggerService {
 		this.$opener.open(`${pathToDebuggingGuideHtml}`, "Safari");
 	}
 
-	public debugAndroidApplication(applicationId: string): IFuture<void> {
+	public debugAndroidApplication(applicationId: string, framework: string): IFuture<void> {
 		return (() => {
 			let deviceIdentifier: string;
 			this.$devicesService.detectCurrentlyAttachedDevices().wait();
@@ -44,7 +44,7 @@ export class DarwinDebuggerService implements IDebuggerService {
 			let tcpPort: string;
 
 			try {
-				tcpPort = this.$androidProcessService.mapAbstractToTcpPort(deviceIdentifier, applicationId).wait();
+				tcpPort = this.$androidProcessService.mapAbstractToTcpPort(deviceIdentifier, applicationId, framework).wait();
 			} catch (err) {
 				this.$errors.failWithoutHelp("Your device has no open ports. Please close programs that are using device's ports to listen on them and try again.");
 			}


### PR DESCRIPTION
Pass framework as required by new API in common lib when mapping abstract to TCP port.