### PR TITLE
Fix publish of the CLI

### DIFF
--- a/lib/services/cordova-migration-service.ts
+++ b/lib/services/cordova-migration-service.ts
@@ -163,7 +163,7 @@ export class CordovaMigrationService implements ICordovaMigrationService {
 	public downloadMigrationConfigFile(targetPath?: string): IFuture<void> {
 		return (() => {
 			let cordovaJsonPath = `${this.$serverConfiguration.resourcesPath.wait()}/cordova/cordova.json`;
-			return this.$resourceDownloader.downloadResourceFromServer(cordovaJsonPath, targetPath || this.cordovaJsonFilePath);
+			return this.$resourceDownloader.downloadResourceFromServer(cordovaJsonPath, targetPath || this.cordovaJsonFilePath).wait();
 		}).future<void>()();
 	}
 

--- a/publish.cmd
+++ b/publish.cmd
@@ -12,7 +12,7 @@ git fetch
 git tag -a v%2 -m "Telerik AppBuilder %2" remotes/origin/release
 git push origin v%2
 
-npm publish "%1" --ignore-scripts
+npm publish "%1"
 @goto :EOF
 
 :error


### PR DESCRIPTION
Fix publishing of the CLI as currently the published package does not have it's scripts section. The reason is that we pass `--ignore-scripts` to `npm publish` command. This removes all scripts from the published package.
After removing `--ignore-scripts` it turned out the package cannot be published. The problem is that when `npm publish <tgz>` is used, the package is added to local npm cache. After that it's package.json is extracted from the cached .tgz file and modified with additional metadata. At this point npm calls the prepublish script, but it fails to find our prepublish.js as it's not extracted in the cache (only the package.json is extracted).
So in order to fix this, remove the `prepublish` script in the `grunt pack` step.

I've not removed the prepublish script from the package.json, so if anyone uses `npm pack` locally or `npm publish` directly, the correct resources will be downloaded.
> NOTE: Calling `grunt pack` locally will modify your package.json. DO NOT commit these changes.