### PR TITLE
Cherry pick fixes and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ The AppBuilder CLI lets you build, test, deploy, and publish cross-platform hybr
 Installation
 ===
 
-Latest version: AppBuilder 3.4
-<br/>Release date: July 27, 2016
+Latest version: AppBuilder 3.4.1
+<br/>Release date: Aug 09, 2016
 
-> For a complete list of the improvements and updates available in this release, see <a href="http://docs.telerik.com/platform/appbuilder/release-notes/v3-4" target="_blank">AppBuilder 3.4 Release Notes</a>.
+> AppBuilder 3.4.1 is an update release. For a complete list of the improvements and updates available in this release, see <a href="http://docs.telerik.com/platform/appbuilder/release-notes/v3-4-1" target="_blank">AppBuilder 3.4.1 Release Notes</a>.<br/>For a complete list of the improvements and updates available in the earlier major release, see <a href="http://docs.telerik.com/platform/appbuilder/release-notes/v3-4" target="_blank">AppBuilder 3.4 Release Notes</a>.
 
 ### System Requirements
 
@@ -371,10 +371,10 @@ If addressing the configuration issues does not resolve your problem, you can [r
 Features
 ===
 
-Latest version: AppBuilder 3.4
-<br/>Release date: July 27, 2016
+Latest version: AppBuilder 3.4.1
+<br/>Release date: Aug 09, 2016
 
-> For a complete list of the improvements and updates available in this release, see <a href="http://docs.telerik.com/platform/appbuilder/release-notes/v3-3" target="_blank">AppBuilder 3.4 Release Notes</a>.
+> AppBuilder 3.4.1 is an update release. For a complete list of the improvements and updates available in this release, see <a href="http://docs.telerik.com/platform/appbuilder/release-notes/v3-4-1" target="_blank">AppBuilder 3.4.1 Release Notes</a>.<br/>For a complete list of the improvements and updates available in the earlier major release, see <a href="http://docs.telerik.com/platform/appbuilder/release-notes/v3-4" target="_blank">AppBuilder 3.4 Release Notes</a>.
 
 #### What you can do with this version of the AppBuilder CLI
 

--- a/lib/services/cordova-migration-service.ts
+++ b/lib/services/cordova-migration-service.ts
@@ -163,7 +163,7 @@ export class CordovaMigrationService implements ICordovaMigrationService {
 	public downloadMigrationConfigFile(targetPath?: string): IFuture<void> {
 		return (() => {
 			let cordovaJsonPath = `${this.$serverConfiguration.resourcesPath.wait()}/cordova/cordova.json`;
-			return this.$resourceDownloader.downloadResourceFromServer(cordovaJsonPath, targetPath || this.cordovaJsonFilePath);
+			return this.$resourceDownloader.downloadResourceFromServer(cordovaJsonPath, targetPath || this.cordovaJsonFilePath).wait();
 		}).future<void>()();
 	}
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "appbuilder",
   "preferGlobal": true,
-  "version": "3.4.0",
+  "version": "3.4.1",
   "author": "Telerik <support@telerik.com>",
   "description": "command line interface to Telerik AppBuilder",
   "bin": {

--- a/publish.cmd
+++ b/publish.cmd
@@ -12,7 +12,7 @@ git fetch
 git tag -a v%2 -m "Telerik AppBuilder %2" remotes/origin/release
 git push origin v%2
 
-npm publish "%1" --ignore-scripts
+npm publish "%1"
 @goto :EOF
 
 :error


### PR DESCRIPTION
Cherry pick fixes:
**Fix publish of the CLI**
Fix publishing of the CLI as currently the published package does not have it's scripts section. The reason is that we pass `--ignore-scripts` to `npm publish` command. This removes all scripts from the published package.
After removing `--ignore-scripts` it turned out the package cannot be published. The problem is that when `npm publish <tgz>` is used, the package is added to local npm cache. After that it's package.json is extracted from the cached .tgz file and modified with additional metadata. At this point npm calls the prepublish script, but it fails to find our prepublish.js as it's not extracted in the cache (only the package.json is extracted).
So in order to fix this, remove the `prepublish` script in the `grunt pack` step.

I've not removed the prepublish script from the package.json, so if anyone uses `npm pack` locally or `npm publish` directly, the correct resources will be downloaded.
> NOTE: Calling `grunt pack` locally will modify your package.json. DO NOT commit these changes.

**Add missing .wait when downloading cordova.json**
Add missing .wait when downloading cordova.json

Bump version to 3.4.1