### PR TITLE
Add support for installing npm modules and @types

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -13,7 +13,7 @@ $injector.requireCommand("dev-config-apply", "./commands/dev/config-apply");
 $injector.requireCommand("dev-config-reset", "./commands/dev/config-reset");
 $injector.require("cordovaResources", "./cordova-resource-loader");
 $injector.require("resourceDownloader", "./resource-downloader");
-$injector.require("platformMigrator", "./services/platform-migration");
+$injector.require("projectMigrationService", "./services/project-migration-service");
 $injector.require("clipboardService", "./services/clipboard-service");
 $injector.require("templatesService", "./templates-service");
 $injector.require("serverExtensionsService", "./services/server-extensions");

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -224,8 +224,9 @@ declare module Project {
 		buildForTAM?: boolean;
 	}
 
-	interface IPlatformMigrator {
+	interface IProjectMigrationService {
 		ensureAllPlatformAssets(): IFuture<void>;
+		migrateTypeScriptProject(): IFuture<void>;
 	}
 }
 
@@ -975,6 +976,7 @@ interface IOptions extends ICommonOptions {
 	skipUi: boolean;
 	splash: string;
 	template: string;
+	types: boolean;
 	validValue: boolean;
 	verified: boolean;
 }

--- a/lib/hooks/typescript-compilation.ts
+++ b/lib/hooks/typescript-compilation.ts
@@ -1,6 +1,8 @@
 require("./../bootstrap");
 import * as path from "path";
 import fiberBootstrap = require("./../common/fiber-bootstrap");
+import { TARGET_FRAMEWORK_IDENTIFIERS } from "../common/constants";
+
 fiberBootstrap.run(() => {
 	$injector.require("typeScriptCompilationService", "./common/services/typescript-compilation-service");
 	let project: Project.IProject = $injector.resolve("project");
@@ -13,6 +15,14 @@ fiberBootstrap.run(() => {
 		let typeScriptCompilationService: ITypeScriptCompilationService = $injector.resolve("typeScriptCompilationService");
 		let $fs: IFileSystem = $injector.resolve("fs");
 		let pathToTsConfig = path.join(project.getProjectDir().wait(), "tsconfig.json");
+
+		if (project.projectData.Framework.toLowerCase() === TARGET_FRAMEWORK_IDENTIFIERS.NativeScript.toLowerCase()) {
+			let $projectMigrationService: Project.IProjectMigrationService = $injector.resolve("projectMigrationService");
+			$projectMigrationService.migrateTypeScriptProject().wait();
+			let $npmService: INpmService = $injector.resolve("npmService");
+			$npmService.install(project.projectDir).wait();
+		}
+
 		if ($fs.exists(pathToTsConfig).wait()) {
 			let json = $fs.readJson(pathToTsConfig).wait();
 			typeScriptCompilationService.compileWithDefaultOptions({ noEmitOnError: !!(json && json.compilerOptions && json.compilerOptions.noEmitOnError) }).wait();

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -34,6 +34,7 @@ export class Options extends OptionsBase {
 				skipUi: { type: OptionType.Boolean },
 				splash: { type: OptionType.String},
 				template: { type: OptionType.String, alias: "t" },
+				types: { type: OptionType.Boolean, default: true},
 				validValue: { type: OptionType.Boolean },
 				verified: { type: OptionType.Boolean }
 			},

--- a/lib/services/build.ts
+++ b/lib/services/build.ts
@@ -25,7 +25,7 @@ export class BuildService implements Project.IBuildService {
 		private $loginManager: ILoginManager,
 		private $opener: IOpener,
 		private $qr: IQrCodeGenerator,
-		private $platformMigrator: Project.IPlatformMigrator,
+		private $projectMigrationService: Project.IProjectMigrationService,
 		private $jsonSchemaValidator: IJsonSchemaValidator,
 		private $mobileHelper: Mobile.IMobileHelper,
 		private $progressIndicator: IProgressIndicator,
@@ -345,7 +345,8 @@ export class BuildService implements Project.IBuildService {
 			this.$logger.info("Building project for platform '%s', project configuration '%s', build configuration '%s'",
 				settings.platform, settings.projectConfiguration, settings.buildConfiguration);
 
-			this.$platformMigrator.ensureAllPlatformAssets().wait();
+			this.$projectMigrationService.ensureAllPlatformAssets().wait();
+			this.$projectMigrationService.migrateTypeScriptProject().wait();
 			this.$project.importProject().wait();
 
 			let buildResult = this.requestCloudBuild(settings).wait();

--- a/lib/services/platform-migration.ts
+++ b/lib/services/platform-migration.ts
@@ -1,8 +1,0 @@
-export class PlatformMigrationService implements Project.IPlatformMigrator {
-	constructor(private $project: Project.IProject) { }
-
-	public ensureAllPlatformAssets(): IFuture<void> {
-		return this.$project.ensureAllPlatformAssets();
-	}
-}
-$injector.register("platformMigrator", PlatformMigrationService);

--- a/lib/services/plugins/nativescript-project-plugins-service.ts
+++ b/lib/services/plugins/nativescript-project-plugins-service.ts
@@ -140,16 +140,13 @@ export class NativeScriptProjectPluginsService extends NpmPluginsServiceBase imp
 					this.$fs.deleteDirectory(fullPluginPath).wait();
 				}
 
-				delete packageJsonContent.dependencies[pluginBasicInfo.name];
 				if (packageJsonContent.nativescript) {
 					delete packageJsonContent.nativescript[`${pluginBasicInfo.name}-variables`];
 				}
 
 				this.$fs.writeJson(pathToPackageJson, packageJsonContent).wait();
 
-				if (this.$project.isTypeScriptProject().wait()) {
-					this.$npmService.uninstall(this.$project.projectDir, pluginBasicInfo.name).wait();
-				}
+				this.$npmService.uninstall(this.$project.projectDir, pluginBasicInfo.name).wait();
 
 				this.$logger.printMarkdown(util.format("Successfully removed plugin `%s`.", pluginBasicInfo.name));
 			} else {

--- a/lib/services/project-migration-service.ts
+++ b/lib/services/project-migration-service.ts
@@ -1,0 +1,39 @@
+import * as path from "path";
+import * as constants from "../common/constants";
+
+export class ProjectMigrationService implements Project.IProjectMigrationService {
+	private shouldAskForTypeScriptMigration = true;
+
+	constructor(private $fs: IFileSystem,
+		private $npmService: INpmService,
+		private $prompter: IPrompter,
+		private $project: Project.IProject) { }
+
+	public ensureAllPlatformAssets(): IFuture<void> {
+		return this.$project.ensureAllPlatformAssets();
+	}
+
+	public migrateTypeScriptProject(): IFuture<void> {
+		return (() => {
+			if (this.shouldAskForTypeScriptMigration) {
+				if (this.$project.isTypeScriptProject().wait() && this.$project.projectData &&
+					this.$project.projectData.Framework.toLowerCase() === constants.TARGET_FRAMEWORK_IDENTIFIERS.NativeScript.toLowerCase()) {
+
+					let projectDir = this.$project.projectDir,
+						pathToTypingsTnsCoreModules = path.join(projectDir, "typings", constants.TNS_CORE_MODULES);
+
+					if (this.$fs.exists(pathToTypingsTnsCoreModules).wait()) {
+						if (this.$prompter.confirm("Your project is using old version of AppBuilder TypeScript support. Do you want to migrate it? ", () => true).wait()) {
+							this.$fs.deleteDirectory(pathToTypingsTnsCoreModules).wait();
+							this.$npmService.install(projectDir).wait();
+						}
+					}
+				}
+
+				// Ask once per process.
+				this.shouldAskForTypeScriptMigration = false;
+			}
+		}).future<void>()();
+	}
+}
+$injector.register("projectMigrationService", ProjectMigrationService);

--- a/lib/services/simulator-service.ts
+++ b/lib/services/simulator-service.ts
@@ -6,7 +6,7 @@ export class SimulatorService implements ISimulatorService {
 	constructor(private $errors: IErrors,
 		private $logger: ILogger,
 		private $loginManager: ILoginManager,
-		private $platformMigrator: Project.IPlatformMigrator,
+		private $projectMigrationService: Project.IProjectMigrationService,
 		private $processInfo: IProcessInfo,
 		private $project: Project.IProject,
 		private $projectSimulatorService: IProjectSimulatorService,
@@ -23,7 +23,8 @@ export class SimulatorService implements ISimulatorService {
 		this.simulatorPath = this.$serverExtensionsService.getExtensionPath(simulatorPackageName);
 		this.$serverExtensionsService.prepareExtension(simulatorPackageName, this.ensureSimulatorIsNotRunning.bind(this)).wait();
 
-		this.$platformMigrator.ensureAllPlatformAssets().wait();
+		this.$projectMigrationService.ensureAllPlatformAssets().wait();
+		this.$projectMigrationService.migrateTypeScriptProject().wait();
 		return this.runSimulator(simulatorPackageName);
 	}
 

--- a/test/plugins-service.ts
+++ b/test/plugins-service.ts
@@ -364,6 +364,10 @@ function createTestInjectorForLocalPluginsFetch(): IInjector {
 
 	testInjector.register("nativeScriptResources", NativeScriptResources);
 	testInjector.register("pluginVariablesHelper", PluginVariablesHelper);
+	testInjector.register("npmService", {});
+	testInjector.register("projectMigrationService", {
+		migrateTypeScriptProject: () => Future.fromResult()
+	});
 
 	return testInjector;
 }

--- a/test/simulator-service.ts
+++ b/test/simulator-service.ts
@@ -20,9 +20,9 @@ function createTestInjector(isFeatureTrackingEnabled: boolean, isExceptionsTrack
 	testInjector.register("loginManager", {
 		ensureLoggedIn: () => { return Future.fromResult(); }
 	});
-	testInjector.register("platformMigrator", {
+	testInjector.register("projectMigrationService", {
 		ensureAllPlatformAssets: () => { return Future.fromResult(); },
-		isRunning: (name: string) => { return Future.fromResult(); }
+		migrateTypeScriptProject: () => Future.fromResult()
 	});
 	testInjector.register("processInfo", {
 		isRunning: (executableName: string) => { return Future.fromResult(!!isRunning); }


### PR DESCRIPTION
Add support for installing npm dependencies. Provide two methods for public API:
 - install - installs everything from package.json. In case a specific dependency must be installed, it's described as second argument with its name, version and should `@types` be installed.
 - uninstall - uninstalls the specified dependency from both node_modules and package.json. The call will also remove `@types/<dependency>` entry from devDependencies.

On each build related command in NativeScript TypeScript project, CLI will call `npm install` in order to verify all required dependencies are installed.
On plugin add - try adding `@types/<dependency>` in case it exists and `--no-types` is not passed on the terminal.
On plugin remove - remove both the dependency and `@types/<dependency>` entries.
http://teampulse.telerik.com/view#item/317268

Remove typings/tns-core-modules after user's confirmation as it just conflicts with our new code: http://teampulse.telerik.com/view#item/317583

Do not create typings/tns-core-modules when migrating between {N} versions, Simplify migration logic http://teampulse.telerik.com/view#item/319382
Renamed platformMigrator to projectMigrationService.

Introduce public API in common lib for installing dependencies from Proton: http://teampulse.telerik.com/view#item/318796

Fix:
 - CLI is unable to install scoped dependencies (`@angular/core` for example) as:
   - we assume everything after `@` is the version
   - we encode the name, so `@angular/core` becomes `%40angular%2Fcore`, but registry.npmjs.org does not understand this, only `/` must be encoded.

Still to do (in separate PRs)
* Add android17.d.ts and ios.d.ts to the project and reference them in .abreferences.d.ts
* Add unit tests