### PR TITLE
Start App with identifier returned from the server

### DIFF
--- a/lib/commands/debug.ts
+++ b/lib/commands/debug.ts
@@ -3,6 +3,7 @@ import Future = require("fibers/future");
 
 export class DebugCommand implements ICommand {
 	private debuggerPath: string;
+	protected platform: string;
 
 	constructor(protected $logger: ILogger,
 		protected $errors: IErrors,
@@ -49,7 +50,7 @@ export class DebugCommand implements ICommand {
 
 				let debuggerParams = [
 					"--user-settings", this.$sharedUserSettingsFileService.userSettingsFilePath,
-					"--app-ids", this.$project.projectData.AppIdentifier // We can specify more than one appid. They should be separated with ;.
+					"--app-ids", this.$project.getAppIdentifierForPlatform(this.platform).wait() // We can specify more than one appid. They should be separated with ;.
 				];
 
 				this.$winDebuggerService.runApplication(this.debuggerPath, debuggerParams);
@@ -69,7 +70,8 @@ export class DebugCommand implements ICommand {
 }
 
 export class DebugAndroidCommand extends DebugCommand {
-	constructor($logger: ILogger,
+	constructor(private $projectConstants: Project.IConstants,
+		$logger: ILogger,
 		$errors: IErrors,
 		$hostCapabilities: IHostCapabilities,
 		$loginManager: ILoginManager,
@@ -93,6 +95,8 @@ export class DebugAndroidCommand extends DebugCommand {
 			$winDebuggerService,
 			$hostInfo,
 			$darwinDebuggerService);
+
+		this.platform = this.$projectConstants.ANDROID_PLATFORM_NAME;
 	}
 
 	protected runDebugger(): IFuture<void> {
@@ -100,7 +104,7 @@ export class DebugAndroidCommand extends DebugCommand {
 			super.runDebugger().wait();
 
 			if (!this.$hostInfo.isWindows) {
-				this.$darwinDebuggerService.debugAndroidApplication(this.$project.projectData.AppIdentifier, this.$project.projectData.Framework).wait();
+				this.$darwinDebuggerService.debugAndroidApplication(this.$project.getAppIdentifierForPlatform(this.platform).wait(), this.$project.projectData.Framework).wait();
 			}
 		}).future<void>()();
 	}

--- a/lib/commands/emulate.ts
+++ b/lib/commands/emulate.ts
@@ -7,6 +7,7 @@ export class EmulateAndroidCommand extends EnsureProjectCommand {
 		private $androidEmulatorServices: Mobile.IEmulatorPlatformServices,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		private $options: IOptions,
+		private $projectConstants: Project.IConstants,
 		$project: Project.IProject,
 		$errors: IErrors) {
 		super($project, $errors);
@@ -27,7 +28,8 @@ export class EmulateAndroidCommand extends EnsureProjectCommand {
 				downloadedFilePath: packageFilePath
 			}).wait();
 			this.$options.justlaunch = true;
-			this.$androidEmulatorServices.runApplicationOnEmulator(packageFilePath, <Mobile.IEmulatorOptions>{ appId: this.$project.projectData.AppIdentifier }).wait();
+			let emulateOptions: Mobile.IEmulatorOptions = { appId: this.$project.getAppIdentifierForPlatform(this.$projectConstants.ANDROID_PLATFORM_NAME).wait() };
+			this.$androidEmulatorServices.runApplicationOnEmulator(packageFilePath, emulateOptions).wait();
 		}).future<void>()();
 	}
 

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -1316,7 +1316,17 @@ interface IDateProvider {
 	getCurrentDate(): Date;
 }
 
+/**
+ * Describes information about application package.
+ */
 interface IApplicationInformation {
+	/**
+	 * The name of the package file.
+	 */
 	packageName: string;
+
+	/**
+	 * The identifier of the application.
+	 */
 	appIdentifier: string;
 }

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -40,6 +40,9 @@ declare module Server {
 		format: string;
 		url: string;
 		fileName: string;
+		key?: string;
+		value?: string;
+		architecture?: string;
 	}
 
 	interface IBuildResult {
@@ -204,7 +207,7 @@ declare module Project {
 		getDownloadUrl(urlKind: string, liveSyncToken: string, packageDef: Server.IPackageDef): IFuture<string>;
 		executeBuild(platform: string, opts?: { buildForiOSSimulator?: boolean }): IFuture<void>;
 		build(settings: IBuildSettings): IFuture<Server.IPackageDef[]>;
-		buildForDeploy(platform: string, downloadedFilePath: string, buildForiOSSimulator?: boolean, device?: Mobile.IDevice): IFuture<string>;
+		buildForDeploy(platform: string, downloadedFilePath: string, buildForiOSSimulator?: boolean, device?: Mobile.IDevice): IFuture<IApplicationInformation>;
 		buildForiOSSimulator(downloadedFilePath: string, device?: Mobile.IDevice): IFuture<string>;
 	}
 
@@ -1311,4 +1314,9 @@ declare module NpmPlugins {
 
 interface IDateProvider {
 	getCurrentDate(): Date;
+}
+
+interface IApplicationInformation {
+	packageName: string;
+	appIdentifier: string;
 }

--- a/lib/providers/livesync-provider.ts
+++ b/lib/providers/livesync-provider.ts
@@ -1,17 +1,18 @@
 import { AppBuilderLiveSyncProviderBase } from "../common/appbuilder/providers/appbuilder-livesync-provider-base";
+import Future = require("fibers/future");
 
 export class LiveSyncProvider extends AppBuilderLiveSyncProviderBase {
-	constructor($androidLiveSyncServiceLocator: {factory: Function},
-		$iosLiveSyncServiceLocator: {factory: Function},
+	constructor($androidLiveSyncServiceLocator: { factory: Function },
+		$iosLiveSyncServiceLocator: { factory: Function },
 		private $buildService: Project.IBuildService,
 		private $devicesService: Mobile.IDevicesService,
 		private $options: IOptions) {
-			super($androidLiveSyncServiceLocator, $iosLiveSyncServiceLocator);
-		}
+		super($androidLiveSyncServiceLocator, $iosLiveSyncServiceLocator);
+	}
 
 	public buildForDevice(device: Mobile.IDevice): IFuture<string> {
 		return this.$devicesService.isiOSSimulator(device) ? this.$buildService.buildForiOSSimulator(this.$options.saveTo, device)
-			: this.$buildService.buildForDeploy(this.$devicesService.platform, this.$options.saveTo, false, device);
+			: Future.fromResult(this.$buildService.buildForDeploy(this.$devicesService.platform, this.$options.saveTo, false, device).wait().packageName);
 	}
 }
 $injector.register("liveSyncProvider", LiveSyncProvider);

--- a/lib/services/build.ts
+++ b/lib/services/build.ts
@@ -102,7 +102,10 @@ export class BuildService implements Project.IBuildService {
 					disposition: buildResult.Disposition,
 					format: buildResult.Format,
 					url: buildResult.FullPath,
-					fileName: fullFileName
+					fileName: fullFileName,
+					key: buildResult.Key,
+					value: buildResult.Value,
+					architecture: buildResult.Architecture
 				};
 			});
 
@@ -432,8 +435,8 @@ export class BuildService implements Project.IBuildService {
 		}).future<Server.IPackageDef[]>()();
 	}
 
-	public buildForDeploy(platform: string, downloadedFilePath: string, buildForiOSSimulator?: boolean, device?: Mobile.IDevice): IFuture<string> {
-		return (() => {
+	public buildForDeploy(platform: string, downloadedFilePath: string, buildForiOSSimulator?: boolean, device?: Mobile.IDevice): IFuture<IApplicationInformation> {
+		return ((): IApplicationInformation => {
 			platform = this.$mobileHelper.validatePlatformName(platform);
 			this.$project.ensureProject();
 			let buildResult = this.build({
@@ -444,14 +447,19 @@ export class BuildService implements Project.IBuildService {
 				device: device
 			}).wait();
 
-			let result = _.filter(buildResult, (def: Server.IPackageDef) => !def.disposition || def.disposition === "BuildResult")[0].localFile;
-			return result;
-		}).future<string>()();
+			let packageName = _.filter(buildResult, (def: Server.IPackageDef) => !def.disposition || def.disposition === "BuildResult")[0].localFile;
+			let metadata = _.filter(buildResult, (def: Server.IPackageDef) => !def.disposition || (def.disposition === "BuildResultMetadata" && def.key === "AppIdentifier"))[0];
+			let appIdentifier = metadata ? metadata.value : this.$project.projectData.AppIdentifier;
+			return {
+				packageName,
+				appIdentifier
+			};
+		}).future<IApplicationInformation>()();
 	}
 
 	public buildForiOSSimulator(downloadedFilePath: string, device?: Mobile.IDevice): IFuture<string> {
 		return (() => {
-			let packageFile = this.buildForDeploy(this.$devicePlatformsConstants.iOS, downloadedFilePath, true, device).wait();
+			let packageFile = this.buildForDeploy(this.$devicePlatformsConstants.iOS, downloadedFilePath, true, device).wait().packageName;
 			let tempDir = this.$project.getTempDir("emulatorFiles").wait();
 			this.$fs.unzip(packageFile, tempDir).wait();
 			let appFilePath = path.join(tempDir, this.$fs.readDirectory(tempDir).wait().filter(minimatch.filter("*.app"))[0]);

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -40,7 +40,7 @@ export class LiveSyncService implements ILiveSyncService {
 
 			let livesyncData: ILiveSyncData = {
 				platform: platform,
-				appIdentifier: this.$project.projectData.AppIdentifier,
+				appIdentifier: this.$project.getAppIdentifierForPlatform(platform).wait(),
 				projectFilesPath: projectDir,
 				syncWorkingDirectory: projectDir,
 				excludedProjectDirsAndFiles: this.excludedProjectDirsAndFiles,


### PR DESCRIPTION
Since the app identifier can be changed in AndroidManifest.xml and config.xml the server needs to return the identifier which is used to build the application. That's why we need to use the app identifier from the server instead of the one from the .abproject.