### PR TITLE
Get the correct app id

### DIFF
--- a/lib/commands/emulate.ts
+++ b/lib/commands/emulate.ts
@@ -7,6 +7,7 @@ export class EmulateAndroidCommand extends EnsureProjectCommand {
 		private $androidEmulatorServices: Mobile.IEmulatorPlatformServices,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		private $options: IOptions,
+		private $projectConstants: Project.IConstants,
 		$project: Project.IProject,
 		$errors: IErrors) {
 		super($project, $errors);
@@ -27,7 +28,8 @@ export class EmulateAndroidCommand extends EnsureProjectCommand {
 				downloadedFilePath: packageFilePath
 			}).wait();
 			this.$options.justlaunch = true;
-			this.$androidEmulatorServices.runApplicationOnEmulator(packageFilePath, <Mobile.IEmulatorOptions>{ appId: this.$project.projectData.AppIdentifier }).wait();
+			let emulateOptions: Mobile.IEmulatorOptions = { appId: this.$project.getAppIdentifierForPlatform(this.$projectConstants.ANDROID_PLATFORM_NAME).wait() };
+			this.$androidEmulatorServices.runApplicationOnEmulator(packageFilePath, emulateOptions).wait();
 		}).future<void>()();
 	}
 

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -1312,7 +1312,17 @@ interface IDateProvider {
 	getCurrentDate(): Date;
 }
 
+/**
+ * Describes information about application package.
+ */
 interface IApplicationInformation {
+	/**
+	 * The name of the package file.
+	 */
 	packageName: string;
+
+	/**
+	 * The identifier of the application.
+	 */
 	appIdentifier: string;
 }

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -38,6 +38,9 @@ declare module Server {
 		localFile?: string;
 		disposition: string;
 		format: string;
+		key?: string;
+		value?: string;
+		architecture?: string;
 	}
 
 	interface IBuildResult {
@@ -202,7 +205,7 @@ declare module Project {
 		getLiveSyncUrl(urlKind: string, filesystemPath: string, liveSyncToken: string): IFuture<string>;
 		executeBuild(platform: string, opts?: { buildForiOSSimulator?: boolean }): IFuture<void>;
 		build(settings: IBuildSettings): IFuture<Server.IPackageDef[]>;
-		buildForDeploy(platform: string, downloadedFilePath: string, buildForiOSSimulator?: boolean, device?: Mobile.IDevice): IFuture<string>;
+		buildForDeploy(platform: string, downloadedFilePath: string, buildForiOSSimulator?: boolean, device?: Mobile.IDevice): IFuture<IApplicationInformation>;
 		buildForiOSSimulator(downloadedFilePath: string, device?: Mobile.IDevice): IFuture<string>;
 	}
 
@@ -1303,4 +1306,13 @@ declare module NpmPlugins {
 		description: string;
 		versions: IDictionary<IBasicPluginInformation>;
 	}
+}
+
+interface IDateProvider {
+	getCurrentDate(): Date;
+}
+
+interface IApplicationInformation {
+	packageName: string;
+	appIdentifier: string;
 }

--- a/lib/providers/livesync-provider.ts
+++ b/lib/providers/livesync-provider.ts
@@ -1,17 +1,18 @@
 import { AppBuilderLiveSyncProviderBase } from "../common/appbuilder/providers/appbuilder-livesync-provider-base";
+import Future = require("fibers/future");
 
 export class LiveSyncProvider extends AppBuilderLiveSyncProviderBase {
-	constructor($androidLiveSyncServiceLocator: {factory: Function},
-		$iosLiveSyncServiceLocator: {factory: Function},
+	constructor($androidLiveSyncServiceLocator: { factory: Function },
+		$iosLiveSyncServiceLocator: { factory: Function },
 		private $buildService: Project.IBuildService,
 		private $devicesService: Mobile.IDevicesService,
 		private $options: IOptions) {
-			super($androidLiveSyncServiceLocator, $iosLiveSyncServiceLocator);
-		}
+		super($androidLiveSyncServiceLocator, $iosLiveSyncServiceLocator);
+	}
 
 	public buildForDevice(device: Mobile.IDevice): IFuture<string> {
 		return this.$devicesService.isiOSSimulator(device) ? this.$buildService.buildForiOSSimulator(this.$options.saveTo, device)
-			: this.$buildService.buildForDeploy(this.$devicesService.platform, this.$options.saveTo, false, device);
+			: Future.fromResult(this.$buildService.buildForDeploy(this.$devicesService.platform, this.$options.saveTo, false, device).wait().packageName);
 	}
 }
 $injector.register("liveSyncProvider", LiveSyncProvider);

--- a/lib/services/build.ts
+++ b/lib/services/build.ts
@@ -320,6 +320,7 @@ export class BuildService implements Project.IBuildService {
 
 			this.$jsonSchemaValidator.validate(this.$project.projectData);
 			this.$jsonSchemaValidator.validateWithBuildSchema(this.$project.projectData, settings.platform);
+			this.$project.validateAppIdentifier(settings.platform).wait();
 
 			settings.projectConfiguration = settings.projectConfiguration || this.$project.getProjectConfiguration();
 			settings.buildConfiguration = settings.buildConfiguration || this.$project.getBuildConfiguration();
@@ -387,9 +388,12 @@ export class BuildService implements Project.IBuildService {
 					let targetFileName: string;
 					if (pkg.disposition === this.$projectConstants.ADDITIONAL_FILE_DISPOSITION) {
 						targetFileName = path.join(this.$project.getProjectDir().wait(), this.$projectConstants.ADDITIONAL_FILES_DIRECTORY, path.basename(pkg.solutionPath));
-					} else {
+					} else if (pkg.disposition === this.$projectConstants.BUILD_RESULT_DISPOSITION) {
 						targetFileName = settings.downloadedFilePath
 							|| path.join(this.$project.getProjectDir().wait(), path.basename(pkg.solutionPath));
+					} else {
+						// We will get here if the disposition is BuildResultMetadata which is not file for download.
+						return;
 					}
 
 					this.$logger.info("Downloading file '%s/%s' into '%s'", pkg.solution, pkg.solutionPath, targetFileName);
@@ -417,7 +421,7 @@ export class BuildService implements Project.IBuildService {
 			}).wait();
 
 			let packageName = _.filter(buildResult, (def: Server.IPackageDef) => !def.disposition || def.disposition === "BuildResult")[0].localFile;
-			let metadata = _.filter(buildResult, (def: Server.IPackageDef) => !def.disposition || (def.disposition === "BuildResultMetadata" && def.key === "AppIdentifier"))[0];
+			let metadata = _.filter(buildResult, (def: Server.IPackageDef) => def.disposition === "BuildResultMetadata" && def.key === "AppIdentifier")[0];
 			let appIdentifier = metadata ? metadata.value : this.$project.projectData.AppIdentifier;
 			return {
 				packageName,
@@ -494,7 +498,7 @@ export class BuildService implements Project.IBuildService {
 
 			this.$project.importProject().wait();
 
-			let appIdentifier = this.$deviceAppDataFactory.create<ILiveSyncDeviceAppData>(this.$project.projectData.AppIdentifier, platform, null);
+			let appIdentifier = this.$deviceAppDataFactory.create<ILiveSyncDeviceAppData>(this.$project.getAppIdentifierForPlatform(platform).wait(), platform, null);
 			let liveSyncToken = this.$server.cordova.getLiveSyncToken(this.$project.projectData.ProjectName, this.$project.projectData.ProjectName).wait();
 
 			let hostPart = util.format("%s://%s/appbuilder", this.$config.AB_SERVER_PROTO, this.$config.AB_SERVER);

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -40,7 +40,7 @@ export class LiveSyncService implements ILiveSyncService {
 
 			let livesyncData: ILiveSyncData = {
 				platform: platform,
-				appIdentifier: this.$project.projectData.AppIdentifier,
+				appIdentifier: this.$project.getAppIdentifierForPlatform(platform).wait(),
 				projectFilesPath: projectDir,
 				syncWorkingDirectory: projectDir,
 				excludedProjectDirsAndFiles: this.excludedProjectDirsAndFiles,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "appbuilder",
   "preferGlobal": true,
-  "version": "3.4.2",
+  "version": "3.4.3",
   "author": "Telerik <support@telerik.com>",
   "description": "command line interface to Telerik AppBuilder",
   "bin": {


### PR DESCRIPTION
Cherry-pick the following commits from master:

#### Start App with identifier returned from the server
Since the app identifier can be changed in AndroidManifest.xml and config.xml the server needs to return the identifier which is used to build the application. That's why we need to use the app identifier from the server instead of the one from the .abproject.

#### Get the correct app id
We need to get the correct app id which will be used to build the application on our server when we execute operations for Android.