### PR TITLE
Fix add and fetch scoped dependencies

### DIFF
--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -1272,6 +1272,14 @@ declare module NpmPlugins {
 		description: string;
 		versions: IDictionary<IBasicPluginInformation>;
 	}
+
+	/**
+	 * Describes data which is required to copy local plugin.
+	 */
+	interface ICopyLocalPluginData {
+		sourceDirectory: string;
+		destinationDirectory: string;
+	}
 }
 
 interface IDateProvider {

--- a/lib/services/plugins/nativescript-project-plugins-service.ts
+++ b/lib/services/plugins/nativescript-project-plugins-service.ts
@@ -204,6 +204,18 @@ export class NativeScriptProjectPluginsService extends PluginsServiceBase implem
 		return Future.fromResult(plugins);
 	}
 
+	protected getCopyLocalPluginData(pathToPlugin: string): NpmPlugins.ICopyLocalPluginData {
+		// We need this check because for NS projects we do not extract the tgz.
+		if (this.hasTgzExtension(pathToPlugin)) {
+			return {
+				sourceDirectory: pathToPlugin,
+				destinationDirectory: path.join(this.$project.getProjectDir().wait(), "plugins")
+			};
+		} else {
+			return super.getCopyLocalPluginData(pathToPlugin);
+		}
+	}
+
 	protected getPluginsDirName(): string {
 		return NODE_MODULES_DIR_NAME;
 	}

--- a/test/plugins-service.ts
+++ b/test/plugins-service.ts
@@ -21,6 +21,7 @@ import * as temp from "temp";
 import * as shelljs from "shelljs";
 import Future = require("fibers/future");
 temp.track();
+let pluginXmlFileName = "plugin.xml";
 
 function createTestInjector(cordovaPlugins: any[], installedMarketplacePlugins: any[], availableMarketplacePlugins: any[]): IInjector {
 	let testInjector = new Yok();
@@ -266,7 +267,9 @@ function createTestInjectorForProjectWithBothConfigurations(installedMarketplace
 	testInjector.register("fs", stubs.FileSystemStub);
 	testInjector.register("childProcess", {});
 	testInjector.register("httpClient", {});
-	testInjector.register("npmService", {});
+	testInjector.register("npmService", {
+		isScopedDependency: () => false
+	});
 	testInjector.register("npmPluginsService", NpmPluginsService);
 	testInjector.register("progressIndicator", {
 		showProgressIndicator: () => Future.fromResult()
@@ -321,7 +324,9 @@ function createTestInjectorForAvailableMarketplacePlugins(availableMarketplacePl
 	testInjector.register("fs", stubs.FileSystemStub);
 	testInjector.register("childProcess", {});
 	testInjector.register("httpClient", {});
-	testInjector.register("npmService", {});
+	testInjector.register("npmService", {
+		isScopedDependency: () => false
+	});
 	testInjector.register("npmPluginsService", NpmPluginsService);
 	testInjector.register("progressIndicator", {
 		showProgressIndicator: () => Future.fromResult()
@@ -373,7 +378,9 @@ function createTestInjectorForLocalPluginsFetch(): IInjector {
 
 	testInjector.register("nativeScriptResources", NativeScriptResources);
 	testInjector.register("pluginVariablesHelper", PluginVariablesHelper);
-	testInjector.register("npmService", {});
+	testInjector.register("npmService", {
+		isScopedDependency: () => false
+	});
 	testInjector.register("projectMigrationService", {
 		migrateTypeScriptProject: () => Future.fromResult()
 	});
@@ -518,9 +525,8 @@ describe("plugins-service", () => {
 
 		let service: IPluginsService = testInjector.resolve(CordovaProjectPluginsService);
 		let fs: IFileSystem = testInjector.resolve("fs");
-		fs.exists = (path: string) => Future.fromResult(false);
-		fs.readText = (path: string) => Future.fromResult(`<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" version="1.1.3-dev"> <name>${pluginName}</name> <description>Cordova Battery Plugin</description></plugin>`);
-
+		fs.exists = (dir: string) => Future.fromResult(dir.indexOf(pluginXmlFileName) >= 0);
+		fs.readText = (dir: string) => Future.fromResult(`<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" version="1.1.3-dev"> <name>${pluginName}</name> <description>Cordova Battery Plugin</description></plugin>`);
 		let fetchedPluginName = fetchWithMockedShellJsCp(service, "org.apache.cordova.battery-status").wait();
 		assert.deepEqual(fetchedPluginName, pluginName);
 	});
@@ -668,7 +674,7 @@ describe("plugins-service", () => {
 
 		let service: IPluginsService = testInjector.resolve(CordovaProjectPluginsService);
 		let fs: IFileSystem = testInjector.resolve("fs");
-		fs.exists = (path: string) => Future.fromResult(false);
+		fs.exists = (dir: string) => Future.fromResult(dir.indexOf(pluginXmlFileName) >= 0);
 		fs.readText = (path: string) => Future.fromResult(`<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" version="1.1.3-dev"> <name>${pluginName}</name> <description>Telerik Dropbox</description></plugin>`);
 
 		let fetchedPluginName = fetchWithMockedShellJsCp(service, "com.telerik.dropbox").wait();

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -139,7 +139,7 @@ export class FileSystemStub implements IFileSystem {
 	}
 
 	ensureDirectoryExists(directoryPath: string): IFuture<void> {
-		return undefined;
+		return Future.fromResult();
 	}
 
 	rename(oldPath: string, newPath: string): IFuture<void> {


### PR DESCRIPTION
When we fetch scoped dependencies we need to get the correct directory in which the dependency is installed because it will be in `node_modules/@<scope>/<dependency>` instead of `node_modules/<dependency>`.