### PR TITLE
Support noEmitOnError parameter and execute hooks in process

### DIFF
--- a/lib/hooks/before-build.js
+++ b/lib/hooks/before-build.js
@@ -1,1 +1,1 @@
-require("./typescript-compilation.js");
+module.exports = require("./typescript-compilation.js");

--- a/lib/hooks/before-deploy.js
+++ b/lib/hooks/before-deploy.js
@@ -1,1 +1,1 @@
-require("./typescript-compilation.js");
+module.exports = require("./typescript-compilation.js");

--- a/lib/hooks/before-livesync.js
+++ b/lib/hooks/before-livesync.js
@@ -1,1 +1,1 @@
-require("./typescript-compilation.js");
+module.exports = require("./typescript-compilation.js");

--- a/lib/hooks/typescript-compilation.ts
+++ b/lib/hooks/typescript-compilation.ts
@@ -1,9 +1,7 @@
-require("./../bootstrap");
 import * as path from "path";
-import fiberBootstrap = require("./../common/fiber-bootstrap");
 import { TARGET_FRAMEWORK_IDENTIFIERS } from "../common/constants";
 
-fiberBootstrap.run(() => {
+module.exports = () => {
 	let $project: Project.IProject = $injector.resolve("project");
 	if (!$project.projectData) {
 		return;
@@ -37,4 +35,4 @@ fiberBootstrap.run(() => {
 			$typeScriptService.transpile($project.projectDir, typeScriptFilesData.typeScriptFiles, typeScriptFilesData.definitionFiles, transpileOptions).wait();
 		}
 	}
-});
+};

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "colors": "0.6.2",
     "cookie": "0.1.0",
     "copy-paste": "1.2.0",
+    "esprima": "2.7.3",
     "express": "4.8.5",
     "ffi": "https://github.com/icenium/node-ffi/tarball/v2.0.0.2",
     "fibers": "https://github.com/Icenium/node-fibers/tarball/v1.0.13.0",


### PR DESCRIPTION
Previously there were some cases when TypeScript was unable to generate .js files. After adding the `noEmitOnError` parameter to tsconfig, TypeScript will not generate .js files ONLY when it is set to true.
Currently our TypeScriptService does not handle this case as it thinks that the .js files are not generated in some cases. Respect the parameter and always show the output of the compiler to the user.

Also make sure all of our hooks are executed in the current process, so the error messages from them will be correctly shown to the user. This requires adding `esprima` as dependency as its used in mobile-cli-lib code.