### PR TITLE
Print the device log for specific duration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,4 +6,6 @@
 		"**/*.js": { "when": "$(basename).ts"},
 		"**/*.js.map": true
 	}
+,
+"typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -213,3 +213,5 @@ $injector.requireCommand("resource|create", "./commands/resource");
 $injector.require("nativeScriptResources", "./nativescript-resources");
 $injector.require("sysInfo", "./sys-info");
 $injector.require("messages", "./messages");
+
+$injector.require("deviceLogService", "./services/device-log-service");

--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -213,5 +213,3 @@ $injector.requireCommand("resource|create", "./commands/resource");
 $injector.require("nativeScriptResources", "./nativescript-resources");
 $injector.require("sysInfo", "./sys-info");
 $injector.require("messages", "./messages");
-
-$injector.require("deviceLogService", "./services/device-log-service");


### PR DESCRIPTION
Since the device log command does not end unless the process is killed by the user we need to provide a way to execute it for specific duration.
This way it can be used in tests without blocking them.

Common reference https://github.com/telerik/mobile-cli-lib/pull/792
