### PR TITLE
Respect configurations on appmanager/appstore upload

### DIFF
--- a/lib/project.ts
+++ b/lib/project.ts
@@ -398,8 +398,13 @@ export class Project extends ProjectBase implements Project.IProject {
 		return _.keys(this.configurationSpecificData);
 	}
 
-	public getProjectConfiguration(): string {
-		return this.getConfigurationsSpecifiedByUser()[0] || _.first(this.getAllConfigurationsNames().sort()) || Configurations.Debug;
+	public getProjectConfiguration(defaultConfiguration?: string): string {
+		let result = this.getConfigurationsSpecifiedByUser()[0];
+		if (!result && defaultConfiguration) {
+			result = _.some(this.getAllConfigurationsNames(), conf => conf.toLowerCase() === defaultConfiguration.toLowerCase()) ? defaultConfiguration : null;
+		}
+
+		return result || _.first(this.getAllConfigurationsNames().sort()) || Configurations.Debug;
 	}
 
 	public updateProjectProperty(mode: string, propertyName: string, propertyValues: string[], configurations?: string[]): IFuture<void> {

--- a/lib/project/project.d.ts
+++ b/lib/project/project.d.ts
@@ -34,10 +34,11 @@ declare module Project {
 		ensureAllPlatformAssets(): IFuture<void>;
 		getConfigurationsSpecifiedByUser(): string[];
 		/**
-		 * Returns a project configuration. Defaults to the lexicographically first project configuration. If no configurations present returns `debug`.
+		 * Returns a project configuration, passed by the user as a flag. Defaults to defaultConfiguration, the lexicographically first project configuration or `debug` in that order.
+		 * @param {string} defaultConfiguration Configuration to which to default to if present amongs user configurations.
 		 * @return {string} the project configuration.
 		 */
-		getProjectConfiguration(): string;
+		getProjectConfiguration(defaultConfiguration?: string): string;
 		/**
 		 * Returns the names of all configurations in the current project.
 		 * @return {string[]} the names of all configurations in the project.

--- a/lib/services/appmanager-service.ts
+++ b/lib/services/appmanager-service.ts
@@ -31,11 +31,11 @@ class AppManagerService implements IAppManagerService {
 			this.$logger.info("Accessing Telerik AppManager.");
 			this.$server.tam.verifyStoreCreated().wait();
 
-			this.$logger.info("Building release package.");
+			this.$logger.info("Building package.");
 			let buildResult = this.$buildService.build({
 				platform: mobilePlatform,
 				buildConfiguration: constants.Configurations.Release,
-				projectConfiguration: constants.Configurations.Release,
+				projectConfiguration: this.$project.getProjectConfiguration(constants.Configurations.Release),
 				provisionTypes: [constants.ProvisionType.Development, constants.ProvisionType.Enterprise, constants.ProvisionType.AdHoc],
 				showWp8SigningMessage: false,
 				buildForTAM: true,

--- a/lib/services/appstore-service.ts
+++ b/lib/services/appstore-service.ts
@@ -17,10 +17,10 @@ export class AppStoreService implements IAppStoreService {
 				this.$errors.fail("App '%s' does not exist or is not ready for upload.", application);
 			}
 
-			this.$logger.info("Building release package.");
+			this.$logger.info("Building package.");
 			let buildResult = this.$buildService.build({
 				platform: "iOS",
-				projectConfiguration: constants.Configurations.Release,
+				projectConfiguration: this.$project.getProjectConfiguration(constants.Configurations.Release),
 				buildConfiguration: constants.Configurations.Release,
 				provisionTypes: [constants.ProvisionType.AppStore]
 			}).wait();


### PR DESCRIPTION
Expose a way to default to a desired configuration (if present among the user configurations) throught the `$project` dependency.
Set project configuration as:
* What the user has defined as `--config`
* `release` (if present among the user's configurations)
* The lexicographically first configuration the user has
* `Debug`

In that order.

Mind that this is a project configuration as opposed to build configuration and even in the unlikely case that we end up building in `Debug`, the build configuration will always be `release` thus preventing any unwanted behavior.

Fixes [appmanager and appstore upload do not respect --config ](http://teampulse.telerik.com/view#item/318698)

Ping @rosen-vladimirov @TsvetanMilanov 