### PR TITLE
Install all npm dependencies in NS TS projects

### DIFF
--- a/lib/project.ts
+++ b/lib/project.ts
@@ -340,6 +340,8 @@ export class Project extends ProjectBase implements Project.IProject {
 		if (!this.projectData) {
 			this.$errors.fail("No project found at or above '%s' and neither was a --path specified.", process.cwd());
 		}
+
+		this.frameworkProject.ensureProject(this.projectDir).wait();
 	}
 
 	public ensureCordovaProject() {
@@ -777,6 +779,8 @@ export class Project extends ProjectBase implements Project.IProject {
 					this.$fs.deleteDirectory(projectDir).wait();
 					throw ex;
 				}
+
+				this.frameworkProject.ensureProject(this.projectDir).wait();
 			} else {
 				let templates = this.frameworkProject.projectTemplatesString().wait();
 				this.$errors.failWithoutHelp(`The specified template ${this.$options.template} does not exist. You can use any of the following templates:${EOL}${templates}`);

--- a/lib/project/cordova-project.ts
+++ b/lib/project/cordova-project.ts
@@ -167,6 +167,10 @@ export class CordovaProject extends FrameworkProjectBase implements Project.IFra
 		}).future<void>()();
 	}
 
+	public ensureProject(projectDir: string): IFuture<void> {
+		return Future.fromResult();
+	}
+
 	private ensureCordovaJs(platform: string, projectDir: string, frameworkVersion: string): IFuture<void> {
 		return (() => {
 			let cordovaJsFilePath = path.join(projectDir, `cordova.${platform.toLowerCase()}.js`),

--- a/lib/project/framework-project-base.ts
+++ b/lib/project/framework-project-base.ts
@@ -84,6 +84,8 @@ export abstract class FrameworkProjectBase implements Project.IFrameworkProjectB
 		return updated;
 	}
 
+	public abstract ensureProject(projectDir: string): IFuture<void>;
+
 	public abstract updateMigrationConfigFile(): IFuture<void>;
 
 	private generateDefaultAppId(appName: string): string {

--- a/lib/project/project.d.ts
+++ b/lib/project/project.d.ts
@@ -76,7 +76,7 @@ declare module Project {
 		getPluginVariablesInfo(configuration?: string): IFuture<IDictionary<IStringDictionary>>;
 	}
 
-	interface IFrameworkProject {
+	interface IFrameworkProject extends IFrameworkProjectBase {
 		name: string;
 		capabilities: ICapabilities;
 		defaultProjectTemplate: string;
@@ -152,6 +152,12 @@ declare module Project {
 		 * @return {boolean}			whether or not the initial properties have been updated
 		 */
 		completeProjectProperties(properties: any): boolean;
+
+		/**
+		 * Ensures the project has all required files.
+		 * @param {string} projectDir The directory of the project.
+		 */
+		ensureProject(projectDir: string): IFuture<void>;
 	}
 
 	interface IFrameworkProjectResolverBase {

--- a/lib/services/build.ts
+++ b/lib/services/build.ts
@@ -413,9 +413,6 @@ export class BuildService implements Project.IBuildService {
 					} else if (pkg.disposition === this.$projectConstants.BUILD_RESULT_DISPOSITION) {
 						targetFileName = settings.downloadedFilePath
 							|| path.join(this.$project.getProjectDir().wait(), pkg.fileName);
-					} else if (pkg.disposition === this.$projectConstants.BUILD_RESULT_DISPOSITION) {
-						// We will get here if the disposition is BuildResultMetadata which is not file for download.
-						return;
 					} else {
 						// We will get here if the disposition is BuildResultMetadata which is not file for download.
 						return;

--- a/test/nativescript-project.ts
+++ b/test/nativescript-project.ts
@@ -54,6 +54,8 @@ function createTestInjector(): IInjector {
 	testInjector.register("hostInfo", HostInfo);
 	testInjector.register("dateProvider", DateProvider);
 	testInjector.register("injector", testInjector);
+	testInjector.register("typeScriptService", {});
+	testInjector.register("npmService", {});
 
 	return testInjector;
 }

--- a/test/project-properties-service.ts
+++ b/test/project-properties-service.ts
@@ -57,7 +57,7 @@ class SampleProject implements Project.IFrameworkProject {
 	projectTemplatesString(): IFuture<string> {
 		return null;
 	}
-	alterPropertiesForNewProject(properties: any, projectName: string): void {/* mock */}
+	alterPropertiesForNewProject(properties: any, projectName: string): void {/* mock */ }
 	checkSdkVersions(platform: string, projectData: Project.IData): void {/* mock */ }
 	completeProjectProperties(properties: any): boolean {
 		return this.completeProjectePropertiesResult;
@@ -74,6 +74,20 @@ class SampleProject implements Project.IFrameworkProject {
 	}
 	updateMigrationConfigFile(): IFuture<void> {
 		return Future.fromResult(null);
+	}
+	ensureProject(projectDir: string): IFuture<void> {
+		return Future.fromResult(null);
+	}
+	alterPropertiesForNewProjectBase(properties: any, projectName: string): void { /* No implementation required. */ }
+	getProjectFileSchemaByName(name: string): IDictionary<any> {
+		return null;
+	}
+	getProjectTargetsBase(projectDir: string, fileMask: RegExp): IFuture<string[]> {
+		return Future.fromResult([]);
+	}
+	printAssetUpdateMessage(): void { /* No implementation required. */ }
+	getProperty(propertyName: string, configuration: string, projectInformation: Project.IProjectInformation): any {
+		return null;
 	}
 }
 

--- a/test/project.ts
+++ b/test/project.ts
@@ -158,6 +158,10 @@ function createTestInjector(): IInjector {
 	testInjector.register("projectFilesProvider", ProjectFilesProvider);
 	testInjector.register("configFilesManager", ConfigFilesManager);
 	testInjector.register("dateProvider", DateProvider);
+	testInjector.register("typeScriptService", {
+		isTypeScriptProject: (projectDir: string): IFuture<boolean> => Future.fromResult(false)
+	});
+	testInjector.register("npmService", {});
 
 	return testInjector;
 }

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -390,6 +390,26 @@ class FrameworkProjectStub implements Project.IFrameworkProject {
 	public updateMigrationConfigFile(): IFuture<void> {
 		return Future.fromResult(null);
 	}
+
+	public ensureProject(projectDir: string): IFuture<void> {
+		return Future.fromResult(null);
+	}
+
+	public alterPropertiesForNewProjectBase(properties: any, projectName: string): void { /* No implementation required. */ }
+
+	public getProjectFileSchemaByName(name: string): IDictionary<any> {
+		return null;
+	}
+
+	public getProjectTargetsBase(projectDir: string, fileMask: RegExp): IFuture<string[]> {
+		return Future.fromResult([]);
+	}
+
+	public printAssetUpdateMessage(): void { /* No implementation required. */ }
+
+	public getProperty(propertyName: string, configuration: string, projectInformation: Project.IProjectInformation): any {
+		return null;
+	}
 }
 
 export class ProjectFilesManager implements IProjectFilesManager {


### PR DESCRIPTION
When we create NS TS project we need to install all npm dependencies because if we don't have the tns-core-modules installed we will not add theirs .d.ts in .abreferences file untill the project is built.
Also we need to install the dependencies on every project related command because we must be sure that we are working with correct content of node_modules.