### PR TITLE
Use monkey to start Android applications

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,6 +1,6 @@
 import * as path from "path";
-import {AppBuilderStaticConfigBase} from "./common/appbuilder/appbuilder-static-config-base";
 import {ConfigBase} from "./common/config-base";
+import { StaticConfigBase } from "./common/static-config-base";
 import * as osenv from "osenv";
 
 export class Configuration extends ConfigBase implements IConfiguration { // User specific config
@@ -75,7 +75,7 @@ export class Configuration extends ConfigBase implements IConfiguration { // Use
 }
 $injector.register("config", Configuration);
 
-export class StaticConfig extends AppBuilderStaticConfigBase implements IStaticConfig {
+export class StaticConfig extends StaticConfigBase implements IStaticConfig {
 	constructor($injector: IInjector) {
 		super($injector);
 		this.RESOURCE_DIR_PATH = path.join(this.RESOURCE_DIR_PATH, "../../resources");

--- a/test/project-properties-service.ts
+++ b/test/project-properties-service.ts
@@ -32,7 +32,6 @@ class SampleProject implements Project.IFrameworkProject {
 	liveSyncUrl: string;
 	requiredAndroidApiLevel: number;
 	configFiles: Project.IConfigurationFile[];
-	startPackageActivity: string;
 
 	get relativeAppResourcesPath(): string {
 		return 'App_Resources';

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -347,8 +347,6 @@ class FrameworkProjectStub implements Project.IFrameworkProject {
 
 	public get configFiles(): Project.IConfigurationFile[] { return undefined; }
 
-	public get startPackageActivity(): string { return ""; }
-
 	public get relativeAppResourcesPath(): string { return ''; }
 
 	public get projectSpecificFiles(): string[] {
@@ -438,7 +436,6 @@ export class StaticConfig implements IStaticConfig {
 	public TRACK_FEATURE_USAGE_SETTING_NAME = "AnalyticsSettings.TrackFeatureUsage";
 	public ERROR_REPORT_SETTING_NAME = "AnaliticsSettings.TrackExceptions";
 	public ANALYTICS_INSTALLATION_ID_SETTING_NAME = "AnalyticsInstallationID";
-	public START_PACKAGE_ACTIVITY_NAME = ".TelerikCallbackActivity";
 	public SYS_REQUIREMENTS_LINK = "";
 	public SOLUTION_SPACE_NAME = "Private_Build_Folder";
 	public APP_RESOURCES_DIR_NAME = "App_Resources";


### PR DESCRIPTION
Use the monkey tool to start Android applications on device. This way we do not have to care about the startPackageActivity name and we can start the application in case a custom activity is used.
Remove unused code and variables.