### PR TITLE
Fix adding missing cordova.<platform>.js file to project

### DIFF
--- a/lib/project/cordova-project.ts
+++ b/lib/project/cordova-project.ts
@@ -175,10 +175,11 @@ export class CordovaProject extends FrameworkProjectBase implements Project.IFra
 		return (() => {
 			let cordovaJsFilePath = path.join(projectDir, `cordova.${platform.toLowerCase()}.js`),
 				cordovaJsSourceFilePath = this.$cordovaResources.buildCordovaJsFilePath(frameworkVersion, platform),
-				cordovaJsFileContents = this.$fs.readText(cordovaJsFilePath).wait().replace(CordovaProject.WHITESPACE_REGEX, ""),
-				cordovaJsSourceFileContents = this.$fs.readText(cordovaJsSourceFilePath).wait().replace(CordovaProject.WHITESPACE_REGEX, "");
+				cordovaJsSourceFileContents = this.$fs.readText(cordovaJsSourceFilePath).wait().replace(CordovaProject.WHITESPACE_REGEX, ""),
+				shouldCopyCordovaJsFile = !this.$fs.exists(cordovaJsFilePath).wait() ||
+					this.$fs.readText(cordovaJsFilePath).wait().replace(CordovaProject.WHITESPACE_REGEX, "") !== cordovaJsSourceFileContents;
 
-			if (!this.$fs.exists(cordovaJsFilePath).wait() || cordovaJsFileContents !== cordovaJsSourceFileContents) {
+			if (shouldCopyCordovaJsFile) {
 				this.printAssetUpdateMessage();
 				this.$fs.copyFile(cordovaJsSourceFilePath, cordovaJsFilePath).wait();
 			}


### PR DESCRIPTION
Before build CLI tries to ensure all `cordova.<platform>.js` files are part of the project.
When any of them is missing, CLI should extract it from the resources and add it to the project. Instead of adding it, CLI fails with error:
`Error: ENOENT: no such file or directory, open '<project dir>\cordova.<platform>.js'`
The reason is incorrect code in CLI that tries to verify if the content of the file in the project (no matter that it does not exist) is the same as the one in the resources of CLI.
Fixes http://teampulse.telerik.com/view#item/321100