### PR TITLE
Fix iOS QR code generation

### DIFF
--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -204,7 +204,7 @@ declare module Project {
 	}
 
 	interface IBuildService {
-		getDownloadUrl(urlKind: string, liveSyncToken: string, packageDef: Server.IPackageDef): IFuture<string>;
+		getDownloadUrl(urlKind: string, liveSyncToken: string, packageDef: Server.IPackageDef, projectConfiguration: string): IFuture<string>;
 		executeBuild(platform: string, opts?: { buildForiOSSimulator?: boolean }): IFuture<void>;
 		build(settings: IBuildSettings): IFuture<Server.IPackageDef[]>;
 		buildForDeploy(platform: string, downloadedFilePath: string, buildForiOSSimulator?: boolean, device?: Mobile.IDevice): IFuture<IApplicationInformation>;


### PR DESCRIPTION
When we generate QR codes for iOS we need to pass the correct download path when we call the server endpoint for livesync url generation and also we need to pass the project configuration because the endpoint needs it.

Fixes http://teampulse.telerik.com/view#item/321268