### PR TITLE
Delete node_modules of fetched plugin

### DIFF
--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -61,7 +61,7 @@ export class FileSystemStub implements IFileSystem {
 	}
 
 	deleteDirectory(directory: string): IFuture<any> {
-		return undefined;
+		return Future.fromResult();
 	}
 
 	getFileSize(path: string): IFuture<number> {


### PR DESCRIPTION
When we fetch plugin we are using npm install <plugin-name> and npm also installs the dependencies of the plugin. Since we do not need them we should delete them.