### PR TITLE
Fix adding of NativeScript plugin

### DIFF
--- a/lib/services/plugins/nativescript-project-plugins-service.ts
+++ b/lib/services/plugins/nativescript-project-plugins-service.ts
@@ -568,7 +568,7 @@ export class NativeScriptProjectPluginsService extends PluginsServiceBase implem
 
 				if (jsonInfo.nativescript && jsonInfo.nativescript.platforms) {
 					let matchingVersion = semver.maxSatisfying(_.values<string>(jsonInfo.nativescript.platforms), `>=${this.$project.projectData.FrameworkVersion}`);
-					if (matchingVersion) {
+					if (!matchingVersion) {
 						this.$errors.failWithoutHelp(`Plugin ${name} requires newer version of NativeScript, your project targets ${this.$project.projectData.FrameworkVersion}.`);
 					}
 				}


### PR DESCRIPTION
NativeScript plugins have nativescript key in package.json based on which we decide if the plugin can be used with our current NativeScript version. Currently our check is incorrect, so any plugin which has nativescript key in it's package.json and the version matches with our NativeScript version cannot be added.