### PR TITLE
Do not add fetched plugin to core plugins

### DIFF
--- a/test/plugins-service.ts
+++ b/test/plugins-service.ts
@@ -41,7 +41,9 @@ function createTestInjector(cordovaPlugins: any[], installedMarketplacePlugins: 
 	testInjector.register("fs", stubs.FileSystemStub);
 	testInjector.register("config", {});
 	testInjector.register("typeScriptService", {});
-	testInjector.register("prompter", {});
+	testInjector.register("prompter", {
+		get: () => Future.fromResult("test-value")
+	});
 	testInjector.register("npmService", NpmService);
 	testInjector.register("npmPluginsService", NpmPluginsService);
 	testInjector.register("httpClient", {


### PR DESCRIPTION
When we fetch plugin in Cordova project we must not add it to the core plugins because when we build the project the build will fail for duplicate symbols/classes.

Fixes http://teampulse.telerik.com/view#item/321807