### PR TITLE
Respect npm settings - proxy and registry 

### DIFF
--- a/test/service-util.ts
+++ b/test/service-util.ts
@@ -9,6 +9,9 @@ let testInjector = new yok.Yok();
 testInjector.register("logger", stubs.LoggerStub);
 testInjector.register("serverConfiguration", {});
 testInjector.register("errors", stubs.ErrorsStub);
+testInjector.register("npmService", {
+	getPackageJsonFromNpmRegistry: (packageName: string) => Future.fromResult( { version: "3.0.0" } )
+});
 
 class MockUserDataStore implements IUserDataStore {
 	hasCookie(): IFuture<boolean> {
@@ -86,6 +89,7 @@ describe("ServiceProxy", () => {
 		testInjector.register("fs", stubs.FileSystemStub);
 		testInjector.resolve("config").SOLUTION_SPACE_NAME = "MockedSolutionSpaceName";
 	});
+
 	it("calls api without arguments and expected return", () => {
 		let proxy = makeProxy();
 


### PR DESCRIPTION
Use npm proxy for connections to registry.npmjs.org. This way in case the user has set a proxy, we'll use it.
Also respect user's settings for npm registry.

http://teampulse.telerik.com/view#item/322319