### PR TITLE
Use WKWebView Engine for Cordova >=5.0.0

### DIFF
--- a/lib/commands/web-view/set-web-view.ts
+++ b/lib/commands/web-view/set-web-view.ts
@@ -9,7 +9,7 @@ export class SetWebViewCommand implements ICommand {
 
 	public execute(args: string[]): IFuture<void> {
 		return (() => {
-			this.$webViewService.enableWebView(args[0], args[1]).wait();
+			this.$webViewService.enableWebView(args[0], args[1], this.$project.projectData.FrameworkVersion).wait();
 			this.$logger.out(`Operation completed successfully. Your project now uses the ${args[1]} web view for ${args[0]}.`);
 		}).future<void>()();
 	}
@@ -18,7 +18,7 @@ export class SetWebViewCommand implements ICommand {
 		return (() => {
 			this.$project.ensureCordovaProject();
 
-			if(!args[0] || !args[1]) {
+			if (!args[0] || !args[1]) {
 				this.$errors.fail(`You must specify target platform and web view name.`);
 			}
 
@@ -27,21 +27,21 @@ export class SetWebViewCommand implements ICommand {
 			// Validate platform
 			let platform = args[0].toLowerCase();
 			let platforms = _.keys(supportedWebViews);
-			if(!_.includes(platforms, platform)) {
+			if (!_.includes(platforms, platform)) {
 				this.$errors.failWithoutHelp(`Invalid platform. You can set the web view for the following platforms: ${platforms.join(", ")}`);
 			}
 
 			// Validate webView
 			let webViewName = args[1].toLowerCase();
 			let webViewNames = this.$webViewService.getWebViewNames(platform);
-			if(!_.includes(webViewNames, webViewName)) {
+			if (!_.includes(webViewNames, webViewName)) {
 				this.$errors.failWithoutHelp(`Invalid web view. The valid ${platform} web views are: ${webViewNames.join(", ")}`);
 			}
 
 			// Validate project version
 			let currentProjectVersion = this.$project.projectData.FrameworkVersion;
-			let webView = this.$webViewService.getWebView(platform, webViewName);
-			if(semver.lt(currentProjectVersion, webView.minSupportedVersion)) {
+			let webView = this.$webViewService.getWebView(platform, webViewName, this.$project.projectData.FrameworkVersion);
+			if (semver.lt(currentProjectVersion, webView.minSupportedVersion)) {
 				this.$errors.failWithoutHelp(`You cannot set the ${webViewName} web view for projects that target Apache Cordova ${currentProjectVersion}. Your project must target Apache Cordova ${webView.minSupportedVersion} or later. Run \`$ appbuilder mobileframework\` set to change your target framework version.`);
 			}
 

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -999,10 +999,10 @@ interface IFrameworkVersion {
  */
 interface IWebViewService {
 	supportedWebViews: IDictionary<IWebView[]>;
-	getWebView(platform: string, webViewName: string): IWebView;
+	getWebView(platform: string, webViewName: string, frameworkVersion: string): IWebView;
 	getWebViews(platform: string): IWebView[];
 	getWebViewNames(platform: string): string[];
-	enableWebView(platform: string, webViewName: string): IFuture<void>;
+	enableWebView(platform: string, webViewName: string, frameworkVersion: string): IFuture<void>;
 	getCurrentWebViewName(platform: string): string;
 }
 
@@ -1014,6 +1014,7 @@ interface IWebView {
 	minSupportedVersion: string;
 	pluginIdentifier?: string;
 	default?: boolean;
+	frameworkVersionCondition?: string;
 }
 
 /**

--- a/lib/services/cordova-migration-service.ts
+++ b/lib/services/cordova-migration-service.ts
@@ -226,6 +226,9 @@ export class CordovaMigrationService implements ICordovaMigrationService {
 			this.$logger.info("Migrating to Cordova version %s", versionDisplayName);
 			let oldVersion = this.$project.projectData.FrameworkVersion;
 			let availablePlugins = this.$pluginsService.getAvailablePlugins();
+
+			this.migrateWebView(oldVersion, newVersion).wait();
+
 			this.invalidMarketplacePlugins = _(this.$project.configurations)
 				.map(configuration => <string[]>this.$project.getProperty("CorePlugins", configuration))
 				.union()
@@ -351,6 +354,24 @@ export class CordovaMigrationService implements ICordovaMigrationService {
 
 			return plugin;
 		});
+	}
+
+	private migrateWebView(oldFrameworkVersion: string, newFrameworkVersion: string): IFuture<void> {
+		return (() => {
+			// For Cordova versions below 5.0.0 with WKWebView we need to set the WKWebView to com.telerik.plugins.wkwebview.
+			// For Cordova version 5.0.0 and above with WKWebView we need to set the WKWebView to cordova-plugin-wkwebview-engine.
+			let currentWebViewName = this.$webViewService.getCurrentWebViewName(this.$projectConstants.IOS_PLATFORM_NAME);
+			let currentWebView = this.$webViewService.getWebView(this.$projectConstants.IOS_PLATFORM_NAME, currentWebViewName, oldFrameworkVersion);
+			let newWebView = this.$webViewService.getWebView(this.$projectConstants.IOS_PLATFORM_NAME, currentWebViewName, newFrameworkVersion);
+
+			if (newWebView.pluginIdentifier !== currentWebView.pluginIdentifier) {
+				if (currentWebView.pluginIdentifier) {
+					this.$pluginsService.removePlugin(currentWebView.pluginIdentifier).wait();
+				}
+
+				this.$webViewService.enableWebView(this.$projectConstants.IOS_PLATFORM_NAME, currentWebViewName, newFrameworkVersion).wait();
+			}
+		}).future<void>()();
 	}
 }
 $injector.register("cordovaMigrationService", CordovaMigrationService);

--- a/lib/services/web-view-service.ts
+++ b/lib/services/web-view-service.ts
@@ -1,8 +1,10 @@
+import * as semver from "semver";
+
 export class WebViewService implements IWebViewService {
+	private static CORDOVA_VERSION_FIVE = "5.0.0";
 
 	constructor(private $errors: IErrors,
 		private $pluginsService: IPluginsService,
-		private $project: Project.IProject,
 		private $projectConstants: Project.IConstants,
 		private $options: IOptions) { }
 
@@ -10,22 +12,31 @@ export class WebViewService implements IWebViewService {
 		return {
 			'ios': [
 				{ name: "Default", minSupportedVersion: "3.0.0", default: true },
-				{ name: "WKWebView", minSupportedVersion: "3.7.0", pluginIdentifier: "com.telerik.plugins.wkwebview" }],
+				{ name: "WKWebView", minSupportedVersion: "3.7.0", pluginIdentifier: "com.telerik.plugins.wkwebview", frameworkVersionCondition: `<${WebViewService.CORDOVA_VERSION_FIVE}` },
+				{ name: "WKWebView", minSupportedVersion: WebViewService.CORDOVA_VERSION_FIVE, pluginIdentifier: "cordova-plugin-wkwebview-engine", frameworkVersionCondition: `>=${WebViewService.CORDOVA_VERSION_FIVE}` }],
 			'android': [
 				{ name: "Default", minSupportedVersion: "3.0.0", default: true },
 				{ name: "Crosswalk", minSupportedVersion: "4.0.0", pluginIdentifier: "cordova-plugin-crosswalk-webview" }]
 		};
 	}
 
-	public getWebView(platform: string, webViewName: string): IWebView {
+	public getWebView(platform: string, webViewName: string, frameworkVersion: string): IWebView {
 		let webViews = this.getWebViews(platform);
 		let webViewNameLowerCase = webViewName.toLowerCase();
-		let webView = _.find(webViews, _webView => _webView.name.toLowerCase() === webViewNameLowerCase);
+		let webView = _.find(webViews, _webView => {
+			let hasTheSameName = _webView.name.toLowerCase() === webViewNameLowerCase;
+			let hasTheRequiredFrameworkVersion = true;
+			if (_webView.frameworkVersionCondition) {
+				hasTheRequiredFrameworkVersion = semver.satisfies(frameworkVersion, _webView.frameworkVersionCondition);
+			}
+
+			return hasTheSameName && hasTheRequiredFrameworkVersion;
+		});
 		return webView;
 	}
 
 	public getWebViews(platform: string): IWebView[] {
-		 return this.supportedWebViews[platform.toLowerCase()];
+		return this.supportedWebViews[platform.toLowerCase()];
 	}
 
 	public getWebViewNames(platform: string): string[] {
@@ -43,9 +54,9 @@ export class WebViewService implements IWebViewService {
 		return _.find(webViews, _webView => _webView.default).name;
 	}
 
-	public enableWebView(platform: string, webViewName: string): IFuture<void> {
-		let webView = this.getWebView(platform, webViewName);
-		if(webView.default) {
+	public enableWebView(platform: string, webViewName: string, frameworkVersion: string): IFuture<void> {
+		let webView = this.getWebView(platform, webViewName, frameworkVersion);
+		if (webView.default) {
 			return this.enableDefaultWebView(platform);
 		}
 
@@ -54,7 +65,7 @@ export class WebViewService implements IWebViewService {
 
 	private enableWebViewCore(webView: IWebView): IFuture<void> {
 		return (() => {
-			if(!this.$pluginsService.isPluginInstalled(webView.pluginIdentifier)) {
+			if (!this.$pluginsService.isPluginInstalled(webView.pluginIdentifier)) {
 				this.$options.default = true;
 				this.$pluginsService.addPlugin(webView.pluginIdentifier).wait();
 			}
@@ -64,8 +75,8 @@ export class WebViewService implements IWebViewService {
 	private enableDefaultWebView(platform: string): IFuture<void> {
 		return (() => {
 			_(this.getWebViews(platform))
-			.filter(webView => !webView.default && this.$pluginsService.isPluginInstalled(webView.pluginIdentifier))
-			.each(webView => this.$pluginsService.removePlugin(webView.pluginIdentifier).wait());
+				.filter(webView => !webView.default && this.$pluginsService.isPluginInstalled(webView.pluginIdentifier))
+				.each(webView => this.$pluginsService.removePlugin(webView.pluginIdentifier).wait());
 		}).future<void>()();
 	}
 }

--- a/test/project.ts
+++ b/test/project.ts
@@ -148,7 +148,10 @@ function createTestInjector(): IInjector {
 	testInjector.register("options", optionsLib.Options);
 	testInjector.register("hostInfo", hostInfoLib.HostInfo);
 	testInjector.register("webViewService", {
-		minSupportedVersion: "4.0.0"
+		minSupportedVersion: "4.0.0",
+		getCurrentWebViewName: () => "Default",
+		getWebView: () => ({ name: "Default" }),
+		enableWebView: () => Future.fromResult()
 	});
 	testInjector.register("serverConfiguration", {});
 


### PR DESCRIPTION
Since there is an issue with our WKWebView for Cordova projects with version >=5.0.0 we need to use the WKWebView Engine from Cordova for those projects. When we set the webview we need to check the framework version and choose the correct WKWebView. Also when we migrate the project we should change the WKWebView.

Fixes: http://teampulse.telerik.com/view#item/321628