### PR TITLE
Prevent outstanding futures when npm hangs

### DIFF
--- a/lib/service-util.ts
+++ b/lib/service-util.ts
@@ -103,23 +103,13 @@ export class ServiceProxyBase implements Server.IServiceProxy {
 
 	private getInformationFromRegistry(): IFuture<string> {
 		return (() => {
-			const registryRequestTimeout = 6000;
+			let packageJson = this.$npmService.getPackageJsonFromNpmRegistry(this.$staticConfig.CLIENT_NAME.toLowerCase()).wait();
 
-			let httpRequestFuture = this.$npmService.getPackageJsonFromNpmRegistry(this.$staticConfig.CLIENT_NAME.toLowerCase());
+			if (!packageJson) {
+				throw new Error("Unable to get information from registry.");
+			}
 
-			let timer = setTimeout(() => {
-				if (!httpRequestFuture.isResolved()) {
-					httpRequestFuture.throw(`Unable to get response from npm for ${registryRequestTimeout}.`);
-				}
-			}, registryRequestTimeout);
-
-			// This will not block the event loop
-			// So after 5 seconds in case we do not have result, error will be thrown.
-			let version = httpRequestFuture.wait().version;
-
-			clearTimeout(timer);
-
-			return version;
+			return packageJson.version;
 		}).future<string>()();
 	}
 }


### PR DESCRIPTION
When we make a call to registry.npmjs.org in order to get the latest version of AppBuilder CLI, we set a timeout of 6000ms.
If the call hangs, we throw error of the newly created FiberFuture and expect to catch it after that.
This works fine, however the FiberFuture is not removed from the cache with futures. Before exiting our process we have a check for "futures left behind". The FiberFuture is still in the cache of "not resolved" ones and we show error:
```
Error: There are outstanding futures. Construction call stacks:
....
```

This is a problem with the FiberFuture construction that cannot be resolved easily. However it's not reproducible in case we use a pure Future. So move the timeout option directly to the httpRequest call where we use Future, not FiberFuture.

The fix includes the following change in `mobile-cli-lib`:

Add timeout option to http request which defines the time that we'll wait for response.
In case there's no response, the call will throw error.
Set timeout of 6000 for calls to registry.npmjs.org.

http://teampulse.telerik.com/view#item/322418
