### PR TITLE
Make <Application Name> in appstore upload command optional 

### DIFF
--- a/docs/man_pages/publishing/appstore-upload.md
+++ b/docs/man_pages/publishing/appstore-upload.md
@@ -3,7 +3,7 @@ appstore upload
 
 Usage | Synopsis
 ------|-------
-General | `$ appbuilder appstore upload <Application Name> [<AppleID>] [<Password>] --certificate <Certificate ID> --provision <Provision ID>`
+General | `$ appbuilder appstore upload [<Application>] [<AppleID>] [<Password>] --certificate <Certificate ID> --provision <Provision ID>`
 
 Builds the project and uploads the application to iTunes Connect.
 
@@ -12,8 +12,8 @@ Builds the project and uploads the application to iTunes Connect.
 * `--certificate` - Sets the **production** certificate that you want to use for code signing your iOS app.
 * `--provision` - Sets the **distribution** provisioning profile that you want to use for code signing your iOS app.
 
-### Attributes 
-* `<Application Name>` is the name for the application record that you want to upload for publishing as listed by `$ appbuilder appstore list`
+### Attributes
+* `<Application>` is the Name or the Bundle Identifier for the application record that you want to upload for publishing as listed by `$ appbuilder appstore list`
 * `<AppleID>` and `<Password>` are your credentials for logging into iTunes Connect.
 * `<Certificate ID>` is the index or name of the certificate as listed by `$ appbuilder certificate`
 * `<Provision ID>` is the index or name of the provisioning profile as listed by `$ appbuilder provision`

--- a/lib/commands/build.ts
+++ b/lib/commands/build.ts
@@ -1,6 +1,6 @@
-import { EnsureProjectCommand } from "./ensure-project-command";
+import { EnsureProjectCommandWithoutArgs } from "./ensure-project-command-without-args";
 
-export class BuildAndroidCommand extends EnsureProjectCommand {
+export class BuildAndroidCommand extends EnsureProjectCommandWithoutArgs {
 	constructor(private $buildService: Project.IBuildService,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		$project: Project.IProject,
@@ -15,7 +15,7 @@ export class BuildAndroidCommand extends EnsureProjectCommand {
 }
 $injector.registerCommand("build|android", BuildAndroidCommand);
 
-export class BuildIosCommand extends EnsureProjectCommand {
+export class BuildIosCommand extends EnsureProjectCommandWithoutArgs {
 	constructor(private $buildService: Project.IBuildService,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		private $options: IOptions,
@@ -30,7 +30,7 @@ export class BuildIosCommand extends EnsureProjectCommand {
 }
 $injector.registerCommand("build|ios", BuildIosCommand);
 
-export class BuildWP8Command extends EnsureProjectCommand {
+export class BuildWP8Command extends EnsureProjectCommandWithoutArgs {
 	constructor(private $buildService: Project.IBuildService,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		$project: Project.IProject,

--- a/lib/commands/deploy.ts
+++ b/lib/commands/deploy.ts
@@ -1,5 +1,5 @@
 import * as helpers from "../common/helpers";
-import { EnsureProjectCommand } from "./ensure-project-command";
+import { EnsureProjectCommandWithoutArgs } from "./ensure-project-command-without-args";
 
 export class DeployHelper implements IDeployHelper {
 	constructor(protected $devicesService: Mobile.IDevicesService,
@@ -97,7 +97,7 @@ export class DeployHelper implements IDeployHelper {
 }
 $injector.register("deployHelper", DeployHelper);
 
-export class DeployCommand extends EnsureProjectCommand {
+export class DeployCommand extends EnsureProjectCommandWithoutArgs {
 	constructor(private $deployHelper: IDeployHelper,
 		$project: Project.IProject,
 		$errors: IErrors) {
@@ -112,7 +112,7 @@ export class DeployCommand extends EnsureProjectCommand {
 }
 $injector.registerCommand("deploy|*devices", DeployCommand);
 
-export class DeployAndroidCommand extends EnsureProjectCommand {
+export class DeployAndroidCommand extends EnsureProjectCommandWithoutArgs {
 	constructor(private $deployHelper: IDeployHelper,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		$project: Project.IProject,
@@ -128,7 +128,7 @@ export class DeployAndroidCommand extends EnsureProjectCommand {
 }
 $injector.registerCommand("deploy|android", DeployAndroidCommand);
 
-export class DeployIosCommand extends EnsureProjectCommand {
+export class DeployIosCommand extends EnsureProjectCommandWithoutArgs {
 	constructor(private $deployHelper: IDeployHelper,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		$project: Project.IProject,
@@ -144,7 +144,7 @@ export class DeployIosCommand extends EnsureProjectCommand {
 }
 $injector.registerCommand("deploy|ios", DeployIosCommand);
 
-export class DeployWP8Command extends EnsureProjectCommand {
+export class DeployWP8Command extends EnsureProjectCommandWithoutArgs {
 	constructor(private $deployHelper: IDeployHelper,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		private $config: Config.IConfig,

--- a/lib/commands/emulate.ts
+++ b/lib/commands/emulate.ts
@@ -1,8 +1,8 @@
 import * as path from "path";
-import { EnsureProjectCommand } from "./ensure-project-command";
+import { EnsureProjectCommandWithoutArgs } from "./ensure-project-command-without-args";
 import {Configurations} from "../common/constants";
 
-export class EmulateAndroidCommand extends EnsureProjectCommand {
+export class EmulateAndroidCommand extends EnsureProjectCommandWithoutArgs {
 	constructor(private $buildService: Project.IBuildService,
 		private $androidEmulatorServices: Mobile.IEmulatorPlatformServices,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
@@ -43,7 +43,7 @@ export class EmulateAndroidCommand extends EnsureProjectCommand {
 }
 $injector.registerCommand("emulate|android", EmulateAndroidCommand);
 
-export class EmulateIosCommand extends EnsureProjectCommand {
+export class EmulateIosCommand extends EnsureProjectCommandWithoutArgs {
 	constructor(private $fs: IFileSystem,
 		private $buildService: Project.IBuildService,
 		private $iOSEmulatorServices: Mobile.IEmulatorPlatformServices,
@@ -76,7 +76,7 @@ export class EmulateIosCommand extends EnsureProjectCommand {
 }
 $injector.registerCommand("emulate|ios", EmulateIosCommand);
 
-export class EmulateWp8Command extends EnsureProjectCommand {
+export class EmulateWp8Command extends EnsureProjectCommandWithoutArgs {
 	constructor(private $buildService: Project.IBuildService,
 		private $wp8EmulatorServices: Mobile.IEmulatorPlatformServices,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,

--- a/lib/commands/ensure-project-command-without-args.ts
+++ b/lib/commands/ensure-project-command-without-args.ts
@@ -1,0 +1,13 @@
+import {EnsureProjectCommand} from "./ensure-project-command";
+
+export class EnsureProjectCommandWithoutArgs extends EnsureProjectCommand {
+	public canExecute(args: string[]): IFuture<boolean> {
+		return (() => {
+			if (args.length) {
+				this.$errors.fail("This command doesn't accept parameters.");
+			}
+
+			return super.canExecute(args);
+		}).future<boolean>()();
+	}
+}

--- a/lib/commands/ensure-project-command.ts
+++ b/lib/commands/ensure-project-command.ts
@@ -5,20 +5,15 @@ export class EnsureProjectCommand implements ICommand {
 	constructor(protected $project: Project.IProject,
 		protected $errors: IErrors) { }
 
-	allowedParameters: ICommandParameter[] = [];
+	public allowedParameters: ICommandParameter[] = [];
 
-	execute(args: string[]): IFuture<void> {
-		assert.fail("","", "You should never get here. Please contact Telerik support and send the output of your command, executed with `--log trace`.");
+	public execute(args: string[]): IFuture<void> {
+		assert.fail("", "", "You should never get here. Please contact Telerik support and send the output of your command, executed with `--log trace`.");
 		return Future.fromResult();
 	}
 
-	canExecute(args: string[]): IFuture<boolean> {
+	public canExecute(args: string[]): IFuture<boolean> {
 		return (() => {
-			if(args.length) {
-  				this.$errors.fail("This command doesn't accept parameters.");
-				return false;
-  			}
-
 			this.$project.ensureProject();
 			return true;
 		}).future<boolean>()();

--- a/lib/commands/live-sync.ts
+++ b/lib/commands/live-sync.ts
@@ -1,7 +1,7 @@
-import { EnsureProjectCommand } from "./ensure-project-command";
+import { EnsureProjectCommandWithoutArgs } from "./ensure-project-command-without-args";
 import Future = require("fibers/future");
 
-class LiveSyncCommandBase extends EnsureProjectCommand {
+class LiveSyncCommandBase extends EnsureProjectCommandWithoutArgs {
 	constructor(protected $liveSyncService: ILiveSyncService,
 		private $options: IOptions,
 		$project: Project.IProject,

--- a/lib/commands/livesync-cloud.ts
+++ b/lib/commands/livesync-cloud.ts
@@ -1,6 +1,6 @@
-import { EnsureProjectCommand } from "./ensure-project-command";
+import { EnsureProjectCommandWithoutArgs } from "./ensure-project-command-without-args";
 
-export class ImportProjectCommand extends EnsureProjectCommand {
+export class ImportProjectCommand extends EnsureProjectCommandWithoutArgs {
 	constructor($project: Project.IProject,
 		$errors: IErrors) {
 		super($project, $errors);

--- a/lib/services/appstore-service.ts
+++ b/lib/services/appstore-service.ts
@@ -2,19 +2,18 @@ import * as constants from "../common/constants";
 
 export class AppStoreService implements IAppStoreService {
 	constructor(public $logger: ILogger,
-				public $errors: IErrors,
-				public $server: Server.IServer,
-				private $project: Project.IProject,
-				private $buildService: Project.IBuildService
-			) {}
+		public $errors: IErrors,
+		public $server: Server.IServer,
+		private $project: Project.IProject,
+		private $buildService: Project.IBuildService) { }
 
 	public upload(userName: string, password: string, application: string): IFuture<void> {
 		return (() => {
 			this.$logger.info("Checking that iTunes Connect application is ready for upload.");
 			let apps = this.$server.itmstransporter.getApplicationsReadyForUpload(userName, password).wait();
-			let theApp = _.find(apps, (app: Server.Application) => app.Application === application);
-			if(!theApp) {
-				this.$errors.fail("App '%s' does not exist or is not ready for upload.", application);
+			let theApp = _.find(apps, (app: Server.Application) => app.Application === application || app.ReservedBundleIdentifier === application);
+			if (!theApp) {
+				this.$errors.fail("App '%s' is not ready for upload.", application);
 			}
 
 			this.$logger.info("Building package.");
@@ -25,7 +24,7 @@ export class AppStoreService implements IAppStoreService {
 				provisionTypes: [constants.ProvisionType.AppStore]
 			}).wait();
 			buildResult = _.filter(buildResult, (def: Server.IPackageDef) => !def.disposition || def.disposition === "BuildResult");
-			if(!buildResult[0] || !buildResult[0].solutionPath) {
+			if (!buildResult[0] || !buildResult[0].solutionPath) {
 				this.$errors.fail({ formatStr: "Build failed.", suppressCommandHelp: true });
 			}
 
@@ -49,5 +48,6 @@ export class AppStoreService implements IAppStoreService {
 		}).future<Server.Application[]>()();
 	}
 }
+
 $injector.register("appStoreService", AppStoreService);
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "appbuilder",
   "preferGlobal": true,
-  "version": "3.5.0",
+  "version": "3.5.1",
   "author": "Telerik <support@telerik.com>",
   "description": "command line interface to Telerik AppBuilder",
   "bin": {

--- a/test/itunes-connect.ts
+++ b/test/itunes-connect.ts
@@ -1,0 +1,143 @@
+import yok = require("../lib/common/yok");
+import Future = require("fibers/future");
+import {assert} from "chai";
+import {UploadApplicationCommand} from "../lib/commands/itunes-connect";
+
+let appIdentifier = "com.telerik.test";
+
+function createTestInjector() {
+	let testInjector = new yok.Yok();
+	testInjector.registerCommand("appstore|upload", UploadApplicationCommand);
+	testInjector.register("prompter", {});
+	testInjector.register("logger", {});
+	testInjector.register("errors", {});
+	testInjector.register("project", {
+		capabilities: {
+			uploadToAppstore: true
+		},
+		projectData: {
+			AppIdentifier: appIdentifier
+		}
+	});
+	testInjector.register("identityManager", {});
+	testInjector.register("loginManager", {
+		ensureLoggedIn: () => Future.fromResult()
+	});
+	testInjector.register("options", {});
+	testInjector.register("appStoreService", {
+		upload: () => Future.fromResult()
+	});
+	return testInjector;
+}
+
+describe("appstore upload", () => {
+	let uploadCommand: ICommand;
+	let prompter: IPrompter;
+	let testInjector: IInjector;
+	let hasAskedForInput: boolean;
+	let hasAskedForPassword: boolean;
+	let username = "userName";
+	let password = "somePassword";
+
+	function mockPrompter(options?: { getValueReturnValue?: any, getPasswordReturnValue?: string }): void {
+		options = options || {};
+
+		prompter.get = (): IFuture<any> => {
+			return ((): any => {
+				hasAskedForInput = true;
+				return options.getValueReturnValue;
+			}).future<any>()();
+		};
+
+		prompter.getPassword = (): IFuture<string> => {
+			return ((): any => {
+				hasAskedForPassword = true;
+				return options.getPasswordReturnValue;
+			}).future<any>()();
+		};
+	}
+
+	beforeEach(() => {
+		hasAskedForInput = false;
+		hasAskedForPassword = false;
+		testInjector = createTestInjector();
+		uploadCommand = testInjector.resolveCommand("appstore|upload");
+		prompter = testInjector.resolve("prompter");
+	});
+
+	it("should not ask for input if application, username and password are provided as parameters.", () => {
+		mockPrompter();
+
+		uploadCommand.execute([appIdentifier, username, password]).wait();
+
+		assert.isFalse(hasAskedForInput);
+		assert.isFalse(hasAskedForPassword);
+	});
+
+	it("should not ask for application if username and password are provided as parameters.", () => {
+		mockPrompter();
+
+		uploadCommand.execute([username, password]).wait();
+
+		assert.isFalse(hasAskedForInput);
+	});
+
+	it("should not ask for application if username is provided as parameters.", () => {
+		mockPrompter();
+
+		uploadCommand.execute([username]).wait();
+
+		assert.isFalse(hasAskedForInput);
+	});
+
+	it("should ask for username and password if only application is provided.", () => {
+		mockPrompter({ getValueReturnValue: {} });
+
+		uploadCommand.execute([appIdentifier]).wait();
+
+		assert.isTrue(hasAskedForInput);
+		assert.isTrue(hasAskedForPassword);
+	});
+
+	it("should ask for password if application identifier and username are provided.", () => {
+		mockPrompter();
+
+		uploadCommand.execute([appIdentifier, username]).wait();
+
+		assert.isTrue(hasAskedForPassword);
+	});
+
+	it("should pass correct values to appstore service.", () => {
+		let appStoreService: IAppStoreService = testInjector.resolve("appStoreService");
+		let shouldPassCorrectValuesExpectedResult = [appIdentifier, username, password];
+		let shouldPassCorrectValuesTestCases = [
+			[appIdentifier, username, password],
+			[appIdentifier, username],
+			[username, password],
+			[appIdentifier],
+			[username]
+		];
+		let appstoreApplication: string;
+		let appstoreUsername: string;
+		let appstorePassword: string;
+
+		appStoreService.upload = (receivedUsername: string, receivedPassword: string, receivedApplication: string): IFuture<void> => {
+			return (() => {
+				appstoreUsername = receivedUsername;
+				appstorePassword = receivedPassword;
+				appstoreApplication = receivedApplication;
+			}).future<void>()();
+		};
+
+		_.each(shouldPassCorrectValuesTestCases, (testCase: string[]) => {
+			mockPrompter({
+				getValueReturnValue: { appleId: username },
+				getPasswordReturnValue: password
+			});
+
+			uploadCommand.execute(testCase).wait();
+
+			assert.deepEqual([appstoreApplication, appstoreUsername, appstorePassword], shouldPassCorrectValuesExpectedResult);
+		});
+	});
+});


### PR DESCRIPTION
Some of our clients are having problems when uploading an application to the Apple App Store because they enter the Bundle Identifier instead of the Application Name. We have decided to make the <Application Name> optional and also the command will accept the Bundle Identifier.

Implements: https://github.com/Icenium/icenium-cli/issues/1106 (http://teampulse.telerik.com/view#item/322549)
