### PR TITLE
Fix getting ios simulator device logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "hex": "0.0.1",
     "iconv-lite": "0.4.3",
     "inquirer": "0.8.2",
-    "ios-sim-portable": "~1.3.0",
+    "ios-sim-portable": "~1.5.0",
     "ip": "0.3.2",
     "lodash": "4.13.1",
     "log4js": "0.6.9",


### PR DESCRIPTION
iOS Simulator device logs are printed directly to process.stdout from the ios-sim-portable. However this makes it really difficult to filter the logs and provide them to different callers (for example AppBuilder CLI, NativeScript CLI, Proton).
In order to fix this, use the ios-sim-portable just to start the process of getting device logs. Filter them in the CLI itself.
Also change the logic in ios-log-filter to use process pid in case it's passed. For iOS Simulator we have filtered logs based on the PID of the application. With these changes, simulator logs are passed to ios-log-filter, so that's why we need process' PID there.
When application is restarted (during livesync for example), we set the PID again and the filter will use the new PID.

Merger ONLY AFTER updating ios-sim-portable version and mobile-cli-lib SHA