### PR TITLE
Do not try to resolve hookArgs

### DIFF
--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -482,6 +482,9 @@ export class StaticConfig implements IStaticConfig {
 }
 
 export class HooksService implements IHooksService {
+	get hookArgsName(): string {
+		return "hookArgs";
+	}
 	initialize(commandName: string): void {
 	}
 	executeBeforeHooks(): IFuture<void> {


### PR DESCRIPTION
When we validate the hook arguments we try to resolve all of them but there is one argument which is not registered in the injector - hookArgs. If some hook wants to use it we will try to resolve it and fail. The solution is to skip the validation for the hookArgs argument.