### PR TITLE
Change the submodule url to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/common"]
 	path = lib/common
-	url = git@github.com:telerik/mobile-cli-lib.git
+	url = https://github.com/telerik/mobile-cli-lib.git


### PR DESCRIPTION
We should use https instead of ssh for the mobile-cli-lib.