### PR TITLE
Fix validation of -- options

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "winreg": "0.0.12",
     "xml-mapping": "1.5.2",
     "xmlhttprequest": "https://github.com/telerik/node-XMLHttpRequest/tarball/master",
-    "yargs": "4.8.1",
+    "yargs": "6.0.0",
     "zipstream": "https://github.com/Icenium/node-zipstream/tarball/master"
   },
   "analyze": true,


### PR DESCRIPTION
The validation of -- options passed on the command line depends on yargs module. Update it to latest versions as the previously used one didn't set correct values of options marked as strings.
Also in our code we pass object of valid options to yargs. Options which have `-` in the name are treated in a special manner in yargs. However instead of passing them with `-`, we pass their secondary representation (remove the `-` and capitalize the next letter).
This way, when the user passes option with `-`, yargs treat it with it's default behavior and does not respect our options for it (as we have not defined that we have option with `-`).
Example:
```JavaScript
var yargs = require("yargs");
var opts = {
  "profile-dir": { type: "string" }
};
console.log(yargs(process.argv).options(opts).argv);

var opts1 = {
  "profileDir": { type: "string" }
};
console.log(yargs(process.argv).options(opts1).argv);
```

When called with:
```
node testYargs.js --profile-dir
```
The result is:
```
{
  'profile-dir': '',
  profileDir: '',
  '$0': 'testYargs.js'
}

{
  'profile-dir': true,
  profileDir: true,
  '$0': 'testYargs.js'
}
```

As you can see, passing "profileDir" and defining it as string does not work. But when we use "profile-dir" in our opts, everything works as expected and yargs sets the value to empty string.

In order to resolve the problem, make sure we pass options with dashes to yargs.

When boolean value is passed to isNullOrWhitespace helper method, it fails as true.replace is not available function.

Add unit tests for:
 - options issue - assert correct behavior when dashed option is passed on the terminal
 - helpers isNullOrWhitespace method
 - helpers isBoolean method