### PR TITLE
Fix Cordova plugins search

### DIFF
--- a/lib/services/plugins/cordova-project-plugins-service.ts
+++ b/lib/services/plugins/cordova-project-plugins-service.ts
@@ -302,7 +302,7 @@ export class CordovaProjectPluginsService extends PluginsServiceBase implements 
 	}
 
 	protected composeSearchQuery(keywords: string[]): string[] {
-		keywords.unshift("ecosystem:cordova");
+		keywords.push("ecosystem:cordova");
 		return keywords;
 	}
 


### PR DESCRIPTION
Since there is some change in the npmjs search our current way of searching for plugins is broken. The problem is that now the order of the keywords in the search does matter.
For example if we search for "ecosystem:cordova console" we won't find any plugins but if we search for "console ecosystem:cordova" we will find the plugins that we are looking for.

Approved in https://github.com/Icenium/icenium-cli/pull/1590