### PR TITLE
Fix adding of NativeScript plugins

### DIFF
--- a/lib/services/plugins/nativescript-project-plugins-service.ts
+++ b/lib/services/plugins/nativescript-project-plugins-service.ts
@@ -567,8 +567,12 @@ export class NativeScriptProjectPluginsService extends PluginsServiceBase implem
 				};
 
 				if (jsonInfo.nativescript && jsonInfo.nativescript.platforms) {
-					let matchingVersion = semver.maxSatisfying(_.values<string>(jsonInfo.nativescript.platforms), `>=${this.$project.projectData.FrameworkVersion}`);
-					if (!matchingVersion) {
+					const requiredVersions = _.values<string>(jsonInfo.nativescript.platforms)
+						.filter(ver => !!semver.valid(ver));
+
+					const notSupportedValues = requiredVersions.filter(ver => semver.gt(ver, this.$project.projectData.FrameworkVersion));
+
+					if (requiredVersions.length && notSupportedValues.length === requiredVersions.length) {
 						this.$errors.failWithoutHelp(`Plugin ${name} requires newer version of NativeScript, your project targets ${this.$project.projectData.FrameworkVersion}.`);
 					}
 				}


### PR DESCRIPTION
Fix code that verifies if NativeScript plugin can be used in the project. Each nativescript plugin may describe the minimum required version of the framework. Our check is not correct and it does not allow adding of nativescript-plugin-livepatch plugin (it's required versions are 1.x.x).
Fix the check - now if all versions described in plugin's package.json are greater than current framework version, the plugin will not be added. In case at least one of the version described in plugin's package.json is compatible with our FrameworkVersion in .abproject, the plugin will be added.