### PR TITLE
Update submodule to latest SHA

### DIFF
--- a/lib/services/analytics-service.ts
+++ b/lib/services/analytics-service.ts
@@ -11,8 +11,9 @@ export class AnalyticsService extends AnalyticsServiceBase implements IAnalytics
 		$prompter: IPrompter,
 		$userSettingsService: UserSettings.IUserSettingsService,
 		$analyticsSettingsService: IAnalyticsSettingsService,
-		$progressIndicator: IProgressIndicator) {
-		super($logger, $options, $staticConfig, $errors, $prompter, $userSettingsService, $analyticsSettingsService, $progressIndicator);
+		$progressIndicator: IProgressIndicator,
+		$osInfo: IOsInfo) {
+		super($logger, $options, $staticConfig, $errors, $prompter, $userSettingsService, $analyticsSettingsService, $progressIndicator, $osInfo);
 	}
 
 	public trackFeature(featureName: string): IFuture<void> {


### PR DESCRIPTION
* Instead of using the application's own appid we should use the companion app's appid when performing LiveSync for the companion
* Fix compile error in analytics-service
* Update submodule to latest SHA

Ping @rosen-vladimirov @TsvetanMilanov 