### PR TITLE
Break CLI process when Node is not supported

### DIFF
--- a/bin/appbuilder.js
+++ b/bin/appbuilder.js
@@ -1,4 +1,9 @@
 #!/usr/bin/env node
 
 "use strict";
+// Use only var here, `let, const` are not supported in Node.js 0.10, 0.12
+var path = require("path");
+var node = require("../package.json").engines.node;
+require(path.join(__dirname, "..", "lib", "common", "verify-node-version")).verifyNodeVersion(node, "AppBuilder");
+
 require("../lib/appbuilder-cli.js");

--- a/lib/appbuilder-cli.ts
+++ b/lib/appbuilder-cli.ts
@@ -1,7 +1,3 @@
-// this call must be first to avoid requiring c++ dependencies
-let node = require("../package.json").engines.node;
-require("./common/verify-node-version").verifyNodeVersion(node, "AppBuilder", "3.7");
-
 require("./bootstrap");
 import fiberBootstrap = require("./common/fiber-bootstrap");
 import * as shelljs from "shelljs";


### PR DESCRIPTION
As old versions of Node.js cannot be used anymore (after transpiling to ES6), we should break the process when such case happens.
Use only var instead of let, const, as only var keyword is supported in Node.js 0.10.x