### PR TITLE
Fix livesync errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "rimraf": "2.2.6",
     "semver": "4.3.4",
     "shelljs": "0.7.5",
+    "source-map": "0.5.6",
     "tabtab": "https://github.com/Icenium/node-tabtab/tarball/master",
     "temp": "0.8.3",
     "typescript": "2.1.4",
@@ -87,6 +88,7 @@
   "devDependencies": {
     "@types/chai": "3.4.34",
     "@types/chai-as-promised": "0.0.29",
+    "@types/source-map": "0.5.0",
     "chai": "3.5.0",
     "chai-as-promised": "6.0.0",
     "file": "0.2.2",


### PR DESCRIPTION
`deviceProjectRootPath` had been renamed to `getDeviceProjectRootPath` in one of previous commits. It's been fixed in the base class, but the classes that extend the base class were still using the old name.
Rename the method everywhere.

Fix `unable to resolve callstack error`

When an error is raised we are trying to resolve the callstack, but there's no source map for TypeScript generated methods for `async` (`__awaiter`). This breaks our logic. In such case just print the line in `.js` instead of `.ts` file.
Remove `source-map.js` from `vendor` and use the npm package.