### PR TITLE
Use node.d.ts from @types

### DIFF
--- a/lib/commands/ensure-project-command.ts
+++ b/lib/commands/ensure-project-command.ts
@@ -7,7 +7,7 @@ export class EnsureProjectCommand implements ICommand {
 	public allowedParameters: ICommandParameter[] = [];
 
 	public async execute(args: string[]): Promise<void> {
-		assert.fail("", "", "You should never get here. Please contact Telerik support and send the output of your command, executed with `--log trace`.");
+		assert.fail("", "", "You should never get here. Please contact Telerik support and send the output of your command, executed with `--log trace`.", null);
 	}
 
 	public async canExecute(args: string[]): Promise<boolean> {

--- a/lib/commands/kendoui-base.ts
+++ b/lib/commands/kendoui-base.ts
@@ -23,7 +23,7 @@ export class KendoUIBaseCommand implements ICommand {
 	}
 
 	public async execute(args: string[]): Promise<void> {
-		assert.fail("", "", "You should never get here. Please contact Telerik support and send the output of your command, executed with `--log trace`.");
+		assert.fail("", "", "You should never get here. Please contact Telerik support and send the output of your command, executed with `--log trace`.", null);
 		return Promise.resolve();
 	}
 

--- a/lib/definitions/express.d.ts
+++ b/lib/definitions/express.d.ts
@@ -3,14 +3,12 @@
 // Definitions by: Boris Yankov <https://github.com/borisyankov/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-/* =================== USAGE =================== 
+/* =================== USAGE ===================
 
     import express = require('express');
     var app = express();
 
  =============================================== */
-
-/// <reference path="../common/definitions/node.d.ts" />
 
 declare module Express {
 
@@ -512,7 +510,7 @@ declare module "express" {
             sendFile(path: string, options: any): void;
             sendFile(path: string, fn: Errback): void;
             sendFile(path: string, options: any, fn: Errback): void;
-            
+
             sendfile(path: string): void;
             sendfile(path: string, options: any): void;
             sendfile(path: string, fn: Errback): void;

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -1,3 +1,5 @@
+import { WriteStream, ReadStream } from "tty";
+
 export function fromWindowsRelativePathToUnix(windowsRelativePath: string): string {
 	return windowsRelativePath.replace(/\\/g, "/");
 }
@@ -110,7 +112,7 @@ function formatListInMultipleColumns(list: string[], columns: number): IFormatti
 }
 
 export function formatListForDisplayInMultipleColumns(list: string[]): string {
-	let consoleWidth = process.stdout.columns;
+	let consoleWidth = (<WriteStream>process.stdout).columns;
 	let bestFormatting: IFormatting;
 	for (let i = 1; i <= 8; ++i) {
 		let formatting = formatListInMultipleColumns(list, i);
@@ -195,11 +197,11 @@ export function mergeRecursive(obj1: Object, obj2: Object): Object {
 
 export function block(operation: () => void): void {
 	if (isInteractive()) {
-		process.stdin.setRawMode(false);
+		(<ReadStream>process.stdin).setRawMode(false);
 	}
 	operation();
 	if (isInteractive()) {
-		process.stdin.setRawMode(true);
+		(<ReadStream>process.stdin).setRawMode(true);
 	}
 }
 

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
   "devDependencies": {
     "@types/chai": "3.4.34",
     "@types/chai-as-promised": "0.0.29",
+    "@types/node": "6.0.61",
     "@types/source-map": "0.5.0",
     "chai": "3.5.0",
     "chai-as-promised": "6.0.0",

--- a/test/project.ts
+++ b/test/project.ts
@@ -516,7 +516,7 @@ describe("project integration tests", () => {
 			let projectFolder = path.join(tempFolder, projectName);
 
 			fs.mkdirSync(projectFolder);
-			fs.closeSync(fs.openSync(path.join(projectFolder, "temp"), "a", "0666"));
+			fs.closeSync(fs.openSync(path.join(projectFolder, "temp"), "a", 666));
 			assert.throws(() => project.createTemplateFolder(projectFolder));
 		});
 	});

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -107,7 +107,7 @@ export class FileSystemStub implements IFileSystem {
 
 	openFile(filename: string): void { }
 
-	createReadStream(path: string, options?: { flags?: string; encoding?: string; fd?: string; mode?: number; bufferSize?: number }): any {
+	createReadStream(path: string, options?: { flags?: string; encoding?: string; fd?: number; mode?: number; bufferSize?: number }): any {
 		return undefined;
 	}
 

--- a/test/test-bootstrap.ts
+++ b/test/test-bootstrap.ts
@@ -1,5 +1,6 @@
-global._ = require("lodash");
-global.$injector = require("../lib/common/yok").injector;
+(<ICliGlobal>global)._ = require("lodash");
+(<ICliGlobal>global).$injector =  require("../lib/common/yok").injector;
+
 $injector.require("config", "../lib/config");
 $injector.require("resources", "../lib/common/resource-loader");
 $injector.require("hostInfo", "../lib/common/host-info");


### PR DESCRIPTION
Currently we are using `node.d.ts` from version `0.11.x`. In order to get latest updates, remove our own version of node.d.ts and use the one from `@types`. Use the version for Node 6.
Fix code according to new definitions. Introduce ICliGlobal interface in order to describe the global object that's used from CLI (we add some properties to the global object).
Add definition file for `xmlhttprequest` module.
Add definitions for Eqatec Analytics.
Modify `ws.d.ts` according to latest changes.