### PR TITLE
Fix ensure all platform assets

### DIFF
--- a/lib/project/cordova-project.ts
+++ b/lib/project/cordova-project.ts
@@ -1,7 +1,7 @@
 import * as path from "path";
 import * as util from "util";
-import {FrameworkProjectBase} from "./framework-project-base";
-import {TARGET_FRAMEWORK_IDENTIFIERS} from "../common/constants";
+import { FrameworkProjectBase } from "./framework-project-base";
+import { TARGET_FRAMEWORK_IDENTIFIERS } from "../common/constants";
 import helpers = require("./../common/helpers");
 import semver = require("semver");
 import Future = require("fibers/future");
@@ -157,7 +157,7 @@ export class CordovaProject extends FrameworkProjectBase implements Project.IFra
 				let relativePath = path.relative(appResourcesDir, appResourceFile);
 				let targetFilePath = path.join(projectDir, this.$staticConfig.APP_RESOURCES_DIR_NAME, relativePath);
 				this.$logger.trace("Checking app resources: %s must match %s", appResourceFile, targetFilePath);
-				if (!this.$fs.exists(targetFilePath).wait()) {
+				if (this.shouldCopyPlatformAsset(appResourceFile, targetFilePath).wait()) {
 					this.printAssetUpdateMessage();
 					this.$logger.trace("File not found, copying %s", appResourceFile);
 					this.$fs.copyFile(appResourceFile, targetFilePath).wait();

--- a/lib/project/framework-project-base.ts
+++ b/lib/project/framework-project-base.ts
@@ -1,3 +1,6 @@
+import * as path from "path";
+import { FileExtensions } from "../common/constants";
+
 export abstract class FrameworkProjectBase implements Project.IFrameworkProjectBase {
 	protected static MAX_MIGRATION_FILE_EDIT_TIME_DIFFERENCE = 60 * 60 * 1000 * 2;
 	private assetUpdateMessagePrinted = false;
@@ -87,6 +90,18 @@ export abstract class FrameworkProjectBase implements Project.IFrameworkProjectB
 	public abstract ensureProject(projectDir: string): IFuture<void>;
 
 	public abstract updateMigrationConfigFile(): IFuture<void>;
+
+	protected shouldCopyPlatformAsset(sourceFilePath: string, targetFilePath: string): IFuture<boolean> {
+		return ((): boolean => {
+			if (path.extname(sourceFilePath) === FileExtensions.PNG_FILE) {
+				let lastIndexOfExtension = targetFilePath.lastIndexOf(FileExtensions.PNG_FILE);
+				let ninePatchAssetPath = targetFilePath.substring(0, lastIndexOfExtension) + FileExtensions.NINE_PATCH_PNG_FILE;
+				return !this.$fs.exists(targetFilePath).wait() && !this.$fs.exists(ninePatchAssetPath).wait();
+			} else {
+				return !this.$fs.exists(targetFilePath).wait();
+			}
+		}).future<boolean>()();
+	}
 
 	private generateDefaultAppId(appName: string): string {
 		let sanitizedName = _.filter(appName.split(""), c => /[a-zA-Z0-9]/.test(c)).join("");

--- a/lib/project/nativescript-project.ts
+++ b/lib/project/nativescript-project.ts
@@ -1,8 +1,8 @@
 import * as path from "path";
 import * as util from "util";
 import * as temp from "temp";
-import {TARGET_FRAMEWORK_IDENTIFIERS} from "../common/constants";
-import {FrameworkProjectBase} from "./framework-project-base";
+import { TARGET_FRAMEWORK_IDENTIFIERS } from "../common/constants";
+import { FrameworkProjectBase } from "./framework-project-base";
 import Future = require("fibers/future");
 temp.track();
 
@@ -121,7 +121,7 @@ export class NativeScriptProject extends FrameworkProjectBase implements Project
 				let relativePath = path.relative(appResourcesDir, appResourceFile);
 				let targetFilePath = path.join(appResourcesHolderDirectory, this.$staticConfig.APP_RESOURCES_DIR_NAME, relativePath);
 				this.$logger.trace("Checking app resources: %s must match %s", appResourceFile, targetFilePath);
-				if (!this.$fs.exists(targetFilePath).wait()) {
+				if (this.shouldCopyPlatformAsset(appResourceFile, targetFilePath).wait()) {
 					this.printAssetUpdateMessage();
 					this.$logger.trace("File not found, copying %s", appResourceFile);
 					this.$fs.copyFile(appResourceFile, targetFilePath).wait();


### PR DESCRIPTION
We do not need to add .png asset when the project has the 9 patch png version of this asset.

Common lib reference: https://github.com/telerik/mobile-cli-lib/pull/884
TP reference: http://teampulse.telerik.com/view#item/328196