### PR TITLE
Fix upgrade of CLI

### DIFF
--- a/bin/appbuilder.cmd
+++ b/bin/appbuilder.cmd
@@ -1,0 +1,1 @@
+@node %~dp0\appbuilder %*

--- a/bin/appbuilder.js
+++ b/bin/appbuilder.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require("./appbuilder");


### PR DESCRIPTION
At the moment when you have CLI 3.6.x (from UAT or Live) and you try installing version from master (SIT), installation fails with:
```
npm ERR! Refusing to delete /usr/local/nvm/versions/node/v7.0.0/bin/appbuilder: ../lib/node_modules/appbuilder/bin/appbuilder.js symlink target is not controlled by npm /usr/local/nvm/versions/node/v7.0.0
npm ERR! File exists: /usr/local/nvm/versions/node/v7.0.0/bin/appbuilder
npm ERR! Move it away, and try again.
```
The problem is that in master branch we've tried to simplify the files that we have in CLI's bin dir.

However `npm` acts a little bit strange to these changes. In UAT and Live versions, when CLI is installed globally, npm makes symlink to CLI's `bin/appbuilder.js` file. We've removed this file, and in version from master the symlink should point to `bin/appbuilder` file. However during upgrade (when you have version from UAT/Live installed globally) npm does not delete the symlink to `bin/appbuilder.js` and later fails.
This can be fixed by manually uninstalling version from UAT/Live and installing version from master after that.
In order to allow upgrade to version from master when you already have earlier version installed, get back the `bin/appbuilder.js` file. This way npm successfully creates the new symlink to `bin/appbuilder`. We can delete the `bin/appbuilder.js` in 3.8.x or later.

During CLI development it is common practice to add path to <cli repo>/bin in your PATH environment variable.
This way you can execute appbuilder ... commands. However due to mistake, the appbuilder.cmd file had been deleted. Get it back, so you can call appbuilder in cmd in this case.

Fixes http://teampulse.telerik.com/view#item/328313