### PR TITLE
Do not open AppManager URL in browser when --skipUi is passed

### DIFF
--- a/lib/services/appmanager-service.ts
+++ b/lib/services/appmanager-service.ts
@@ -116,7 +116,10 @@ class AppManagerService implements IAppManagerService {
 	public openAppManagerStore(): void {
 		let tamUrl = `${this.$config.AB_SERVER_PROTO}://${this.$config.AB_SERVER}/appbuilder/Services/tam`;
 		this.$logger.info("Go to %s to manage your apps.", tamUrl);
-		this.$opener.open(tamUrl);
+
+		if (!this.$options.skipUi) {
+			this.$opener.open(tamUrl);
+		}
 	}
 
 	public async publishLivePatch(platforms: string[]): Promise<void> {


### PR DESCRIPTION
For automation purposes we should not open AppManager URL in the browser.
This will allow users to automate commands like `$ appbuilder appmanager upload <platform>`
and `$ appbuilder appmanager livesync <platform>`
So in case `--skipUi` is passed to these commands, all actions will be executed, but the last step (opening the URL in browser) will not be executed.