### PR TITLE
Fix check if package has `@types`

### DIFF
--- a/lib/services/cordova-migration-service.ts
+++ b/lib/services/cordova-migration-service.ts
@@ -202,7 +202,7 @@ export class CordovaMigrationService implements ICordovaMigrationService {
 
 		this.$logger.info("Migrating to Cordova version %s", versionDisplayName);
 		let oldVersion = this.$project.projectData.FrameworkVersion;
-		let availablePlugins = this.$pluginsService.getAvailablePlugins();
+		let availablePlugins = await this.$pluginsService.getAvailablePlugins();
 
 		await this.migrateWebView(oldVersion, newVersion);
 

--- a/lib/services/kendoui-service.ts
+++ b/lib/services/kendoui-service.ts
@@ -28,7 +28,9 @@ export class KendoUIService implements IKendoUIService {
 
 			if (options.latest) {
 				let latestPackage = _.first(packages);
-				packages = _.filter(packages, pack => pack.Version === latestPackage.Version);
+				packages = [_(packages)
+					.filter(pack => pack.Version === latestPackage.Version)
+					.first()];
 			}
 
 			this._packages = packages;


### PR DESCRIPTION
During migration from fibers to promises, we've lost one `!` in the check if npm package has typings in `@types` repo.
This led to incorrect behavior:
 - typings of packages, which are available in `@types`, are not installed (for example `lodash`).
 - trying to install plugin, which does not have typing in `@types` leads to error (something like `Error while installing dependency: Command npm.cmd failed with exit code 4294963238.`).

Fix the check (add the missing `!`) which will fix the incorrect behavior.