### PR TITLE
Fix building of the package 

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ The AppBuilder CLI lets you build, test, deploy, and publish cross-platform hybr
 Installation
 ===
 
-Latest version: AppBuilder 3.6.7
-<br/>Release date: February 2, 2016
+Latest version: AppBuilder 3.7.0
+<br/>Release date: February 23, 2017
 
-> AppBuilder 3.6.7 is an update release. For a complete list of the improvements and updates available in this release, see <a href="http://docs.telerik.com/platform/appbuilder/release-notes/v3-6-7" target="_blank">AppBuilder 3.6.7 Release Notes</a>.<br/>For a complete list of the improvements and updates available in the earlier major release, see <a href="http://docs.telerik.com/platform/appbuilder/release-notes/v3-6" target="_blank">AppBuilder 3.6 Release Notes</a>.
+> For a complete list of the improvements and updates available in the earlier major release, see <a href="http://docs.telerik.com/platform/appbuilder/release-notes/v3-7" target="_blank">AppBuilder 3.7 Release Notes</a>.
 
 ### System Requirements
 
@@ -371,10 +371,10 @@ If addressing the configuration issues does not resolve your problem, you can [r
 Features
 ===
 
-Latest version: AppBuilder 3.6.7
-<br/>Release date: February 2, 2016
+Latest version: AppBuilder 3.7.0
+<br/>Release date: February 23, 2017
 
-> AppBuilder 3.6.7 is an update release. For a complete list of the improvements and updates available in this release, see <a href="http://docs.telerik.com/platform/appbuilder/release-notes/v3-6-7" target="_blank">AppBuilder 3.6.7 Release Notes</a>.<br/>For a complete list of the improvements and updates available in the earlier major release, see <a href="http://docs.telerik.com/platform/appbuilder/release-notes/v3-6" target="_blank">AppBuilder 3.6 Release Notes</a>.
+> For a complete list of the improvements and updates available in the earlier major release, see <a href="http://docs.telerik.com/platform/appbuilder/release-notes/v3-7" target="_blank">AppBuilder 3.7 Release Notes</a>.
 
 #### What you can do with this version of the AppBuilder CLI
 

--- a/lib/services/nativescript-migration-service.ts
+++ b/lib/services/nativescript-migration-service.ts
@@ -1,9 +1,6 @@
 import * as path from "path";
 
 export class NativeScriptMigrationService implements IFrameworkMigrationService {
-	private static TYPESCRIPT_ABBREVIATION = "TS";
-	private static JAVASCRIPT_ABBREVIATION = "JS";
-	private static SUPPORTED_LANGUAGES = [NativeScriptMigrationService.JAVASCRIPT_ABBREVIATION, NativeScriptMigrationService.TYPESCRIPT_ABBREVIATION];
 	private static REMOTE_NATIVESCRIPT_MIGRATION_DATA_FILENAME = "NativeScript.json";
 	private static TYPINGS = "typings";
 	private static TNS_CORE_MODULES = "tns-core-modules";
@@ -68,13 +65,7 @@ export class NativeScriptMigrationService implements IFrameworkMigrationService 
 
 		// Make sure to download this file first, as data from it is used for fileDownloadFutures
 		await this.downloadMigrationConfigFile();
-
-		let fileDownloadPromises = _(this.nativeScriptMigrationData.supportedVersions)
-			.map(supportedVersion => _.map(NativeScriptMigrationService.SUPPORTED_LANGUAGES, language => this.downloadTnsPackage(language, supportedVersion.version)))
-			.flatten<Promise<void>>()
-			.value();
-		fileDownloadPromises.push(this.downloadPackageJsonResourceFile());
-		await Promise.all(fileDownloadPromises);
+		await this.downloadPackageJsonResourceFile();
 	}
 
 	public getSupportedVersions(): string[] {
@@ -135,21 +126,6 @@ export class NativeScriptMigrationService implements IFrameworkMigrationService 
 		}
 
 		this.$logger.info(`Project migrated successfully from ${currentVersion} to ${newVersion}.`);
-	}
-
-	private async downloadTnsPackage(language: string, version: string): Promise<void> {
-		if (language === NativeScriptMigrationService.TYPESCRIPT_ABBREVIATION) {
-			let fileName = this.getFileNameByVersion(version);
-			let remotePathUrl = `${this.remoteNativeScriptResourcesPath}/${NativeScriptMigrationService.TNS_MODULES}/${language}/${fileName}`;
-			let filePath = path.join(this.tnsModulesDirectoryPath, language, fileName);
-			return this.$resourceDownloader.downloadResourceFromServer(remotePathUrl, filePath);
-		}
-
-		return Promise.resolve();
-	}
-
-	private getFileNameByVersion(version: string): string {
-		return `${version}${NativeScriptMigrationService.TNS_CORE_MODULES}.zip`;
 	}
 
 	private getDeprecatedVersions(): string[] {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "appbuilder",
   "preferGlobal": true,
-  "version": "3.6.7",
+  "version": "3.7.0",
   "author": "Telerik <support@telerik.com>",
   "description": "command line interface to Telerik AppBuilder",
   "bin": {


### PR DESCRIPTION
Currently building the package fails when CLI tries to download `https://<environment>/appbuilder/Resources/NativeScript/tns_modules/TS/2.5.0tns-core-modules.zip`
As we are now using tns-core-modules 2.5.1 the zip name that CLI tries to download is incorrect (should be 2.5.1). This leads to error, so other resources AFTER this one are not downloaded.
So the produced package is not correct.
As these zip files had been used in older CLI versions, skip their download. They have been required when we've been using local `.d.ts` files for `tns-core-modules`. Now we rely on the `.d.ts` files in the npm package, so no need ot include any of the `.zip` files in CLI.