### PR TITLE
Fix iOS device detection with Node.js 4

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
 		"removeComments": false,
 		"noImplicitAny": true,
 		"experimentalDecorators": true,
-		"noUnusedLocals": true
+		"noUnusedLocals": true,
+		"alwaysStrict": true
 	},
 	"exclude": [
 		"node_modules",


### PR DESCRIPTION
When Node.js 4 is used, CLI hangs when iOS device is detected. There are two problems:
 - an error is raised in our deviceNotificationCallback. This error is not propagated by ffi back to us, so the process waits for calling a callback that will never be called as we've already thrown exception. This behavior will be fixed when we remove ffi and ref as dependencies.
 - The raised error is: `[SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode]`. With Node.js 4.x.x, when you use "const" or "let" in the code, you have to place "use strict" at the top of the `.js` file. This is done by TypeScript itself during transpilation. However not in all cases. For some files, TypeScript decides to omit this "use strict". This way when we require any of these files and we are using Node.js 4, we receive the mentioned error. In order to fix this, force TypeScript to place "use strict" at the top of all files. This is exactly what "alwaysStrict" option of tsconfig does.