### PR TITLE
Fix prompting for plugin variables

### DIFF
--- a/lib/services/plugins/cordova-project-plugins-service.ts
+++ b/lib/services/plugins/cordova-project-plugins-service.ts
@@ -905,7 +905,7 @@ export class CordovaProjectPluginsService extends PluginsServiceBase implements 
 		return xmlMapping.tojson(this.$fs.readText(pathToPluginXml));
 	}
 
-	private async setPluginVariables(pluginIdentifier: string, variables: string[], configuration: string): Promise<void> {
+	private async setPluginVariables(pluginIdentifier: string, variables: any[], configuration: string): Promise<void> {
 		let originalPluginVariables = this.$project.getProperty(CordovaProjectPluginsService.CORDOVA_PLUGIN_VARIABLES_PROPERTY_NAME, configuration) || {};
 		let cordovaPluginVariables: any = _.cloneDeep(originalPluginVariables);
 
@@ -914,11 +914,12 @@ export class CordovaProjectPluginsService extends PluginsServiceBase implements 
 				cordovaPluginVariables[pluginIdentifier] = {};
 			}
 
-			await Promise.all(_.map(variables, async (variable: any) => {
+			for (let variable of variables) {
 				let variableName: string = variable.name || variable;
 				let variableInformation = await this.gatherVariableInformation(pluginIdentifier, variableName, configuration);
 				cordovaPluginVariables[pluginIdentifier][variableName] = variableInformation[variableName];
-			}));
+			}
+
 			this.$project.setProperty(CordovaProjectPluginsService.CORDOVA_PLUGIN_VARIABLES_PROPERTY_NAME, cordovaPluginVariables, configuration);
 		}
 	}

--- a/lib/services/plugins/nativescript-project-plugins-service.ts
+++ b/lib/services/plugins/nativescript-project-plugins-service.ts
@@ -603,10 +603,12 @@ export class NativeScriptProjectPluginsService extends PluginsServiceBase implem
 			let pluginVariableNameInPackageJson = `${basicPlugin.name}-variables`;
 			let currentVariablesValues = packageJsonContent.nativescript[pluginVariableNameInPackageJson] || {};
 			let newObj: IStringDictionary = Object.create(null);
-			await Promise.all(_.map(variablesInformation, async (variableInfo: any, variableName: string) => {
+
+			for (let variableName in variablesInformation) {
+				let variableInfo = variablesInformation[variableName];
 				let currentValue = currentVariablesValues[variableName] || variableInfo.defaultValue;
 				newObj[variableName] = (await this.gatherVariableInformation(variableName, currentValue))[variableName];
-			}));
+			}
 
 			delete packageJsonContent.nativescript[pluginVariableNameInPackageJson];
 			if (_.keys(newObj).length) {

--- a/lib/services/web-view-service.ts
+++ b/lib/services/web-view-service.ts
@@ -42,7 +42,7 @@ export class WebViewService implements IWebViewService {
 		return _.map(webViews, webView => webView.name.toLowerCase());
 	}
 
-	public async  getCurrentWebViewName(platform: string): Promise<string> {
+	public async getCurrentWebViewName(platform: string): Promise<string> {
 		let webViews = this.getWebViews(platform);
 		let webViewsToFilter = await Promise.all(_.map(webViews, async _webView => {
 			return !_webView.default && await this.$pluginsService.isPluginInstalled(_webView.pluginIdentifier) ? _webView : null;


### PR DESCRIPTION
When a plugin has variables that has to be set, CLI checks the command line and in case the `--var` option is not passed, a prompt is shown to the user to enter a value.
At the moment this is broken as we are prompting in parallel promises. This leads to several issues - user is not able to enter values for the variables and also a memory leak warning is shown.

Fix the execution to be sync.

Bug is reproducible for both Cordova and NativeScript projects.