### PR TITLE
Update grunt-shell

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "grunt": "1.0.1",
     "grunt-contrib-clean": "1.0.0",
     "grunt-contrib-watch": "1.0.0",
-    "grunt-shell": "1.3.0",
+    "grunt-shell": "2.1.0",
     "grunt-ts": "6.0.0-beta.10",
     "grunt-tslint": "4.0.0",
     "istanbul": "0.4.5",


### PR DESCRIPTION
We started to receive `stdout maxBuffer exceeded Use --force to continue` in our PR builds. This happens because we use old version of grunt-shell.