### PR TITLE
Fix installation of plugins without description.

### DIFF
--- a/lib/services/plugins/cordova-project-plugins-service.ts
+++ b/lib/services/plugins/cordova-project-plugins-service.ts
@@ -874,8 +874,8 @@ export class CordovaProjectPluginsService extends PluginsServiceBase implements 
 	private getLocalPluginBasicInformation(pluginXml: any): IBasicPluginInformation {
 		// Need to add $t because of the xmlMapping library.
 		let basicPluginInformation: IBasicPluginInformation = {
-			name: pluginXml.plugin.name.$t,
-			description: pluginXml.plugin.description.$t,
+			name: pluginXml.plugin.name ? pluginXml.plugin.name.$t : "",
+			description: pluginXml.plugin.description ? pluginXml.plugin.description.$t : "",
 			version: pluginXml.plugin.version
 		};
 


### PR DESCRIPTION
When try to fetch plugin and the plugin doesn't have a description or name,
appbuilder-cli throw error `Cannot read property '$t' of undefined`.

Fix: [#329398](http://teampulse.telerik.com/view#item/329398) 