### PR TITLE
Fix expected Cordova version in tests to 6.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "grunt": "1.0.1",
     "grunt-contrib-clean": "1.0.0",
     "grunt-contrib-watch": "1.0.0",
-    "grunt-shell": "1.3.0",
+    "grunt-shell": "2.1.0",
     "grunt-ts": "6.0.0-beta.10",
     "grunt-tslint": "4.0.0",
     "istanbul": "0.4.5",

--- a/test/resources/blank-Cordova.abproject
+++ b/test/resources/blank-Cordova.abproject
@@ -19,7 +19,7 @@
         "ID_CAP_WEBBROWSERCOMPONENT"
      ]
     ,"WP8Requirements": []
-    ,"FrameworkVersion": "4.0.0"
+    ,"FrameworkVersion": "6.4.0"
     ,"AndroidPermissions": [
         "android.permission.INTERNET"
     ]


### PR DESCRIPTION
Also update `grunt-shell` as the old version fails to run the tests with `maxbuffer exceeded`.