### PR TITLE
Do not throw upon failure to get nativeScriptMigrationFileName

### DIFF
--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -63,6 +63,9 @@ export class FileSystemStub implements IFileSystem {
 		return null;
 	}
 
+	utimes(path: string, atime: Date, mtime: Date): void {
+	}
+
 	getFileSize(path: string): number {
 		return undefined;
 	}


### PR DESCRIPTION
Try-catch the whole thing.
Also replace shelljs.touch with a simple set of atime/ctime/mtime. This is done because shelljs.touch process.exits in case of a locked file or whatnot.

Merge after https://github.com/telerik/mobile-cli-lib/pull/946
Fixes [Incorrect failure upon inability to download nativeScript-migration-data.json from server](http://teampulse.telerik.com/view#item/344124)

Ping @TsvetanMilanov @rosen-vladimirov 