### PR TITLE
Cloud export missing await

### DIFF
--- a/lib/services/remote-projects-service.ts
+++ b/lib/services/remote-projects-service.ts
@@ -108,7 +108,7 @@ export class RemoteProjectService implements IRemoteProjectService {
 		let solutionZipFilePath = temp.path({ prefix: "appbuilder-cli-", suffix: '.zip' });
 		let unzipStream = this.$fs.createWriteStream(solutionZipFilePath);
 
-		this.$serviceProxy.makeTapServiceCall(async () => await tapServiceCall.apply(null, [unzipStream]), solutionSpaceHeaderOptions);
+		await this.$serviceProxy.makeTapServiceCall(async () => await tapServiceCall.apply(null, [unzipStream]), solutionSpaceHeaderOptions);
 		await this.$fs.unzip(solutionZipFilePath, exportDir);
 
 		return exportDir;


### PR DESCRIPTION
Add missing await - else `cloud export` fails because we try to unzip before downloading

Ping @rosen-vladimirov 
TP: [[CLI] Cloud export command fails](http://teampulse.telerik.com/view#item/344205)