### PR TITLE
Deprecate Node.js 4 and 5, full support for Node.js 8

### DIFF
--- a/bin/appbuilder
+++ b/bin/appbuilder
@@ -6,7 +6,7 @@ var path = require("path"),
 	pathToLib = path.join(__dirname, "..", "lib"),
 	pathToCommon = path.join(pathToLib, "common");
 
-require(path.join(pathToCommon, "verify-node-version")).verifyNodeVersion(node, "AppBuilder");
+require(path.join(pathToCommon, "verify-node-version")).verifyNodeVersion(node, "AppBuilder", ["^4.0.0", "^5.0.0"]);
 
 var pathToCliExecutable = path.join(pathToLib, "appbuilder-cli.js");
 

--- a/package.json
+++ b/package.json
@@ -108,6 +108,6 @@
   "bundledDependencies": [],
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=4.2.1 <5.0.0 || >=5.1.0 <8.0.0"
+    "node": ">=6.0.0 <9.0.0"
   }
 }


### PR DESCRIPTION
Deprecate the support for Node.js 4 and 5 - on each CLI command, users who use any version starting with 4.x or 5.x will see warning.
Add full support for Node.js - currently we have warning that support for Node.js 8.x.x is not verified - add the 8.x.x versions in package.json as verified.