### PR TITLE
Deprecate all ScreenBuilder commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+env:
+  global:
+  - APPBUILDER_SKIP_POSTINSTALL_TASKS=1
+  - ResourceDownloadEnvironment=LIVE
+  - DeploymentEnvironment=SIT
+language: node_js
+node_js:
+- '6'
+git:
+  submodules: true
+install:
+- npm install --ignore-scripts
+before_script:
+- npm install grunt
+script:
+- node_modules/.bin/grunt lint
+- node_modules/.bin/grunt pack --no-color

--- a/docs/man_pages/project/creation/create-screenbuilder.md
+++ b/docs/man_pages/project/creation/create-screenbuilder.md
@@ -1,6 +1,8 @@
 create screenbuilder
 ==========
 
+<span style="color:red;font-size:15px"><%= #{screenBuilderService.getDeprecationWarning} %> </span>
+
 Usage | Synopsis
 ------|-------
 General | `$ appbuilder create screenbuilder <App name> [--answers <File Path>] [--path <Directory>] [--appid <App ID>] [--no-simulator]`

--- a/docs/man_pages/project/creation/create.md
+++ b/docs/man_pages/project/creation/create.md
@@ -5,7 +5,7 @@ Usage | Synopsis
 ------|-------
 Create hybrid | `$ appbuilder create hybrid <App name>`
 Create native | `$ appbuilder create native <App name>`
-Create with Screen Builder | `$ appbuilder create screenbuilder <App Name> [--answers <File Path>] [--no-simulator]` OR `$ appbuilder create <App Name> [--answers <File Path>] [--no-simulator]`
+Create with Screen Builder | `$ appbuilder create screenbuilder <App Name> [--answers <File Path>] [--no-simulator]` OR `$ appbuilder create <App Name> [--answers <File Path>] [--no-simulator]` <span style="color:red;font-size:13px">\*\* <%= #{screenBuilderService.getDeprecationWarning} %> </span>
 
 Creates a project for hybrid or native development. If `screenbuilder` and `<Type>` are not specified, creates a new project for hybrid development with Screen Builder.
 

--- a/docs/man_pages/screenbuilder/add-about.md
+++ b/docs/man_pages/screenbuilder/add-about.md
@@ -1,6 +1,8 @@
 add-about
 ==========
 
+<span style="color:red;font-size:15px"><%= #{screenBuilderService.getDeprecationWarning} %> </span>
+
 Usage | Synopsis
 ------|-------
 General | `$ appbuilder add-about` [--answers <File Path>]

--- a/docs/man_pages/screenbuilder/add-authentication.md
+++ b/docs/man_pages/screenbuilder/add-authentication.md
@@ -1,6 +1,8 @@
 add-authentication
 ==========
 
+<span style="color:red;font-size:15px"><%= #{screenBuilderService.getDeprecationWarning} %> </span>
+
 Usage | Synopsis
 ------|-------
 General | `$ appbuilder add-authentication` [--answers <File Path>]

--- a/docs/man_pages/screenbuilder/add-dataprovider.md
+++ b/docs/man_pages/screenbuilder/add-dataprovider.md
@@ -1,6 +1,8 @@
 add-dataProvider
 ==========
 
+<span style="color:red;font-size:15px"><%= #{screenBuilderService.getDeprecationWarning} %> </span>
+
 Usage | Synopsis
 ------|-------
 General | `$ appbuilder add-dataProvider` [--answers <File Path>]

--- a/docs/man_pages/screenbuilder/add-field.md
+++ b/docs/man_pages/screenbuilder/add-field.md
@@ -1,6 +1,8 @@
 add-field
 ==========
 
+<span style="color:red;font-size:15px"><%= #{screenBuilderService.getDeprecationWarning} %> </span>
+
 Usage | Synopsis
 ------|-------
 General | `$ appbuilder add-field` [--answers <File Path>]

--- a/docs/man_pages/screenbuilder/add-form.md
+++ b/docs/man_pages/screenbuilder/add-form.md
@@ -1,6 +1,8 @@
 add-form
 ==========
 
+<span style="color:red;font-size:15px"><%= #{screenBuilderService.getDeprecationWarning} %> </span>
+
 Usage | Synopsis
 ------|-------
 General | `$ appbuilder add-form` [--answers <File Path>]

--- a/docs/man_pages/screenbuilder/add-list.md
+++ b/docs/man_pages/screenbuilder/add-list.md
@@ -1,6 +1,8 @@
 add-list
 ==========
 
+<span style="color:red;font-size:15px"><%= #{screenBuilderService.getDeprecationWarning} %> </span>
+
 Usage | Synopsis
 ------|-------
 General | `$ appbuilder add-list` [--answers <File Path>]

--- a/docs/man_pages/screenbuilder/add-view.md
+++ b/docs/man_pages/screenbuilder/add-view.md
@@ -1,6 +1,8 @@
 add-view
 ==========
 
+<span style="color:red;font-size:15px"><%= #{screenBuilderService.getDeprecationWarning} %> </span>
+
 Usage | Synopsis
 ------|-------
 General | `$ appbuilder add-view` [--answers <File Path>]

--- a/docs/man_pages/screenbuilder/screenbuilder.md
+++ b/docs/man_pages/screenbuilder/screenbuilder.md
@@ -1,6 +1,8 @@
 screenbuilder
 ==========
 
+<span style="color:red;font-size:15px"><%= #{screenBuilderService.getDeprecationWarning} %> </span>
+
 Usage | Synopsis
 ------|-------
 General | `$ appbuilder screenbuilder`

--- a/docs/man_pages/screenbuilder/upgrade-screenbuilder.md
+++ b/docs/man_pages/screenbuilder/upgrade-screenbuilder.md
@@ -1,6 +1,8 @@
 upgrade-screenbuilder
 ==========
 
+<span style="color:red;font-size:15px"><%= #{screenBuilderService.getDeprecationWarning} %> </span>
+
 Usage | Synopsis
 ------|-------
 General | `$ appbuilder upgrade-screenbuilder`

--- a/lib/commands/project/create.ts
+++ b/lib/commands/project/create.ts
@@ -17,6 +17,8 @@ export class CreateCommand extends ProjectCommandBaseLib.ProjectCommandBase {
 	}
 
 	public async execute(args: string[]): Promise<void> {
+		this.$screenBuilderService.printDeprecationWarning();
+
 		this.validateProjectData();
 
 		let projectName = args[0];

--- a/lib/commands/screenbuilder.ts
+++ b/lib/commands/screenbuilder.ts
@@ -1,7 +1,9 @@
 export class ScreenBuilderCommand implements ICommand {
-	constructor(private $commandsService: ICommandsService) { }
+	constructor(private $commandsService: ICommandsService,
+		private $screenBuilderService: IScreenBuilderService) { }
 
 	public async execute(args: string[]): Promise<void> {
+		this.$screenBuilderService.printDeprecationWarning();
 		return this.$commandsService.tryExecuteCommand("help", ["screenbuilder"]);
 	}
 

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -453,6 +453,11 @@ interface IScreenBuilderService {
 	ensureScreenBuilderProject(projectPath: string): void;
 	shouldUpgrade(projectPath: string): Promise<boolean>;
 	upgrade(projectPath: string): Promise<void>;
+
+	/**
+	 * Prints warning that ScreenBuilder commands are deprecated.
+	 */
+	printDeprecationWarning(): void;
 }
 
 /**

--- a/lib/services/screen-builder-service.ts
+++ b/lib/services/screen-builder-service.ts
@@ -1,6 +1,7 @@
 import * as path from "path";
 import * as util from "util";
 import { deferPromise } from "../common/helpers";
+import { cache } from "../common/decorators";
 
 export class ScreenBuilderService implements IScreenBuilderService {
 	private static UPGRADE_ERROR_MESSAGES = ["Your app has been build with an obsolete version of Screen Builder. Please, migrate it to latest version and retry.",
@@ -38,8 +39,14 @@ export class ScreenBuilderService implements IScreenBuilderService {
 		return "add";
 	}
 
+	@cache()
 	public printDeprecationWarning(): void {
-		this.$logger.warn("This command is deprecated and will be removed in the next official release.");
+		this.$logger.warn(this.getDeprecationWarning());
+	}
+
+	@cache()
+	public getDeprecationWarning(): string {
+		return "This command is deprecated and will be removed in the next official release.";
 	}
 
 	private async promptForUpgrade(projectPath: string, generatorName: string, screenBuilderOptions?: IScreenBuilderOptions): Promise<IScreenBuilderMigrationData> {
@@ -121,6 +128,7 @@ export class ScreenBuilderService implements IScreenBuilderService {
 	}
 
 	public ensureScreenBuilderProject(projectDir: string): void {
+		this.printDeprecationWarning();
 		if (!_.every(this.screenBuilderSpecificFiles, file => this.$fs.exists(path.join(projectDir, file)))) {
 			this.$errors.failWithoutHelp("This command is applicable only to Screen Builder projects.");
 		}
@@ -239,7 +247,6 @@ class ScreenBuilderDynamicCommand implements ICommand {
 		private $screenBuilderService: IScreenBuilderService) { }
 
 	public async execute(args: string[]): Promise<void> {
-		this.$screenBuilderService.printDeprecationWarning();
 		await this.$project.ensureProject();
 		let projectDir = this.$project.getProjectDir();
 		this.$screenBuilderService.ensureScreenBuilderProject(projectDir);

--- a/lib/services/screen-builder-service.ts
+++ b/lib/services/screen-builder-service.ts
@@ -38,6 +38,10 @@ export class ScreenBuilderService implements IScreenBuilderService {
 		return "add";
 	}
 
+	public printDeprecationWarning(): void {
+		this.$logger.warn("This command is deprecated and will be removed in the next official release.");
+	}
+
 	private async promptForUpgrade(projectPath: string, generatorName: string, screenBuilderOptions?: IScreenBuilderOptions): Promise<IScreenBuilderMigrationData> {
 		let wasMigrated = !(await this.shouldUpgrade(projectPath)),
 			didMigrate = false;
@@ -235,6 +239,7 @@ class ScreenBuilderDynamicCommand implements ICommand {
 		private $screenBuilderService: IScreenBuilderService) { }
 
 	public async execute(args: string[]): Promise<void> {
+		this.$screenBuilderService.printDeprecationWarning();
 		await this.$project.ensureProject();
 		let projectDir = this.$project.getProjectDir();
 		this.$screenBuilderService.ensureScreenBuilderProject(projectDir);


### PR DESCRIPTION
ScreenBuilder commands can work with Node.js 4, but not with newer Node.js versions.
As we deprecate support for Node.js 4, deprecate the screenbuilder related commands as well and inform the user that we'll delete them in the next official release.