### PR TITLE
Fix passing `--debug`(`--release`) when there's no such build config

### DIFF
--- a/lib/project.ts
+++ b/lib/project.ts
@@ -70,6 +70,19 @@ export class Project extends ProjectBase implements Project.IProject {
 
 	public get projectData(): Project.IData {
 		if (!this._projectData) {
+			const projectDir = this.getProjectDir();
+			if (projectDir) {
+				const debugProjectFile = path.join(projectDir, this.$projectConstants.DEBUG_PROJECT_FILE_NAME);
+				if (this.$options.debug && !this.$fs.exists(debugProjectFile)) {
+					this.$fs.writeJson(debugProjectFile, {});
+				}
+
+				const releaseProjectFile = path.join(projectDir, this.$projectConstants.RELEASE_PROJECT_FILE_NAME);
+				if (this.$options.release && !this.$fs.exists(releaseProjectFile)) {
+					this.$fs.writeJson(releaseProjectFile, {});
+				}
+			}
+
 			this.readProjectData();
 		}
 


### PR DESCRIPTION
At the moment, when `--debug` option is passed and there's no `.debug.abproject` in the project, CLI fails with error:
```
Operation cannot be completed because configurations Debug are invalid.
```

In the previous versions of CLI, we have been creating the file manually and the operation continues.
The new behavior is introduced with a change in `mobile-cli-lib` (https://github.com/telerik/mobile-cli-lib/pull/970)  where it has been causing other issues.
Return the old behavior only for AppBuilder CLI by placing the deleted code in its source. Add check if `projectDir` is set, so the creation of project (which also uses the same code) will not fail.