### PR TITLE
Introduce export command

### DIFF
--- a/docs/man_pages/index.md
+++ b/docs/man_pages/index.md
@@ -23,6 +23,7 @@ Command | Description
 [create `<Type>`](project/creation/create.html) | Creates a new project from template.
 [sample](project/creation/sample.html) | Lists sample apps.
 [sample&nbsp;clone](project/creation/sample-clone.html) | Clones a selected sample app.
+[export](project/creation/export.html) | Exports a cloud-based project from a selected solution to facilitate the migration to a different framework.
 [init](project/creation/init.html) | Initializes an existing project for development.
 [cloud](project/creation/cloud.html) | Lists all solutions and projects associated with your Progress Telerik Platform account.
 [cloud&nbsp;export](project/creation/cloud-export.html) | Exports one or all projects from a selected solution from the cloud.

--- a/docs/man_pages/project/creation/cloud-export.md
+++ b/docs/man_pages/project/creation/cloud-export.md
@@ -30,6 +30,7 @@ Command | Description
 [create hybrid](create-hybrid.html) | Creates a new project from an Apache Cordova-based template.
 [create native](create-native.html) | Creates a new project from a NativeScript-based template.
 [create screenbuilder](create-screenbuilder.html) | Creates a new project for hybrid development with Screen Builder.
+[export](export.html) | Exports a cloud-based project from a selected solution to facilitate the migration to a different framework.
 [init](init.html) | Initializes an existing project for development.
 [init hybrid](init-hybrid.html) | Initializes an existing Apache Cordova project for development in the current directory.
 [init native](init-native.html) | Initializes an existing NativeScript project for development in the current directory.

--- a/docs/man_pages/project/creation/cloud.md
+++ b/docs/man_pages/project/creation/cloud.md
@@ -28,6 +28,7 @@ Command | Description
 [create hybrid](create-hybrid.html) | Creates a new project from an Apache Cordova-based template.
 [create native](create-native.html) | Creates a new project from a NativeScript-based template.
 [create screenbuilder](create-screenbuilder.html) | Creates a new project for hybrid development with Screen Builder.
+[export](export.html) | Exports a cloud-based project from a selected solution to facilitate the migration to a different framework.
 [init](init.html) | Initializes an existing project for development.
 [init hybrid](init-hybrid.html) | Initializes an existing Apache Cordova project for development in the current directory.
 [init native](init-native.html) | Initializes an existing NativeScript project for development in the current directory.

--- a/docs/man_pages/project/creation/create-hybrid.md
+++ b/docs/man_pages/project/creation/create-hybrid.md
@@ -32,6 +32,7 @@ Command | Description
 [create](create.html) | Creates a project for hybrid or native development.
 [create native](create-native.html) | Creates a new project from a NativeScript-based template.
 [create screenbuilder](create-screenbuilder.html) | Creates a new project for hybrid development with Screen Builder.
+[export](export.html) | Exports a cloud-based project from a selected solution to facilitate the migration to a different framework.
 [init](init.html) | Initializes an existing project for development.
 [init hybrid](init-hybrid.html) | Initializes an existing Apache Cordova project for development in the current directory.
 [init native](init-native.html) | Initializes an existing NativeScript project for development in the current directory.

--- a/docs/man_pages/project/creation/create-native.md
+++ b/docs/man_pages/project/creation/create-native.md
@@ -30,6 +30,7 @@ Command | Description
 [create](create.html) | Creates a project for hybrid or native development.
 [create hybrid](create-hybrid.html) | Creates a new project from an Apache Cordova-based template.
 [create screenbuilder](create-screenbuilder.html) | Creates a new project for hybrid development with Screen Builder.
+[export](export.html) | Exports a cloud-based project from a selected solution to facilitate the migration to a different framework.
 [init](init.html) | Initializes an existing project for development.
 [init hybrid](init-hybrid.html) | Initializes an existing Apache Cordova project for development in the current directory.
 [init native](init-native.html) | Initializes an existing NativeScript project for development in the current directory.

--- a/docs/man_pages/project/creation/create-screenbuilder.md
+++ b/docs/man_pages/project/creation/create-screenbuilder.md
@@ -29,6 +29,7 @@ Command | Description
 [cloud export](cloud-export.html) | Exports one or all projects from a selected solution from the cloud.
 [create hybrid](create-hybrid.html) | Creates a new project from an Apache Cordova-based template.
 [create native](create-native.html) | Creates a new project from a NativeScript-based template.
+[export](export.html) | Exports a cloud-based project from a selected solution to facilitate the migration to a different framework.
 [init](init.html) | Initializes an existing project for development.
 [init hybrid](init-hybrid.html) | Initializes an existing Apache Cordova project for development in the current directory.
 [init native](init-native.html) | Initializes an existing NativeScript project for development in the current directory.

--- a/docs/man_pages/project/creation/create.md
+++ b/docs/man_pages/project/creation/create.md
@@ -38,6 +38,7 @@ Command | Description
 [create hybrid](create-hybrid.html) | Creates a new project from an Apache Cordova-based template.
 [create native](create-native.html) | Creates a new project from a NativeScript-based template.
 [create screenbuilder](create-screenbuilder.html) | Creates a new project for hybrid development with Screen Builder.
+[export](export.html) | Exports a cloud-based project from a selected solution to facilitate the migration to a different framework.
 [init](init.html) | Initializes an existing project for development.
 [init hybrid](init-hybrid.html) | Initializes an existing Apache Cordova project for development in the current directory.
 [init native](init-native.html) | Initializes an existing NativeScript project for development in the current directory.

--- a/docs/man_pages/project/creation/export.md
+++ b/docs/man_pages/project/creation/export.md
@@ -1,19 +1,23 @@
-sample
+export
 ==========
 
 Usage | Synopsis
 ------|-------
-General | `$ appbuilder sample [<Command>]`
+Export selected project from solution so that it can be used with Cordova CLI | `$ appbuilder cloud export [<Solution Name or Index> [<Project Name or Index> [--path <Directory or File>]]]`
 
-Lists all available sample apps with name, description, GitHub repository and clone command. To clone a selected sample app, run its clone command as listed by `$ appbuilder sample`
+Exports a cloud-based project from a selected solution to facilitate the migration to a different framework. NativeScript projects can be developed with the NativeScript CLI, whereas Hybrid projects can be developed with the Cordova CLI.
+
+### Options
+* `--path` - Specifies the directory or file where to download your exported project.
 
 ### Attributes
-`<Command>` extends the `sample` command. You can set the following values for this attribute.
-* `hybrid` - Lists all available Apache Cordova sample apps.
-* `native` - Lists all available NativeScript sample apps.
-* `clone` - Clones a selected sample app.
-
+* `<Solution Name or Index>` is the name of the solution as listed by `$ appbuilder cloud --all` or as it appears in the AppBuilder in-browser client or the AppBuilder Windows client. You need to set a solution and a project if you are running a non-interactive console.
+* `<Project Name or Index>` is the name or the index of project, relative to its parent solution, as listed by `appbuilder cloud` or as it appears in the AppBuilder in-browser client or the AppBuilder Windows client.
 <% if(isHtml) { %>
+### Command Limitations
+
+* In order to export a hybrid project it must target Cordova 6.4.0
+
 ### Related Commands
 
 Command | Description
@@ -24,12 +28,11 @@ Command | Description
 [create hybrid](create-hybrid.html) | Creates a new project from an Apache Cordova-based template.
 [create native](create-native.html) | Creates a new project from a NativeScript-based template.
 [create screenbuilder](create-screenbuilder.html) | Creates a new project for hybrid development with Screen Builder.
-[export](export.html) | Exports a cloud-based project from a selected solution to facilitate the migration to a different framework.
 [init](init.html) | Initializes an existing project for development.
 [init hybrid](init-hybrid.html) | Initializes an existing Apache Cordova project for development in the current directory.
 [init native](init-native.html) | Initializes an existing NativeScript project for development in the current directory.
 [sample](sample.html) | Lists all available sample apps with name, description, GitHub repository, and clone command.
-[sample clone](sample-clone.html) | Clones the selected sample app from GitHub to your local file system.
 [sample native](sample-native.html) | Lists all available NativeScript sample apps.
 [sample hybrid](sample-hybrid.html) | Lists all available Apache Cordova sample apps.
+[sample clone](sample-clone.html) | Clones the selected sample app from GitHub to your local file system.
 <% } %>

--- a/docs/man_pages/project/creation/init-hybrid.md
+++ b/docs/man_pages/project/creation/init-hybrid.md
@@ -33,6 +33,7 @@ Command | Description
 [create hybrid](create-hybrid.html) | Creates a new project from an Apache Cordova-based template.
 [create native](create-native.html) | Creates a new project from a NativeScript-based template.
 [create screenbuilder](create-screenbuilder.html) | Creates a new project for hybrid development with Screen Builder.
+[export](export.html) | Exports a cloud-based project from a selected solution to facilitate the migration to a different framework.
 [init](init.html) | Initializes an existing project for development.
 [init native](init-native.html) | Initializes an existing NativeScript project for development in the current directory.
 [sample](sample.html) | Lists all available sample apps with name, description, GitHub repository, and clone command.

--- a/docs/man_pages/project/creation/init-native.md
+++ b/docs/man_pages/project/creation/init-native.md
@@ -5,10 +5,10 @@ Usage | Synopsis
 ------|-------
 General | `$ appbuilder init native [--appid <App ID>]`
 
-Initializes an existing NativeScript project for development in the current directory. <% if(isHtml) { %>If the directory contains an existing AppBuilder project (created with the Telerik AppBuilder extension for Visual Studio or synchronized from GitHub), the project retains any existing project configuration.<% } %> 
+Initializes an existing NativeScript project for development in the current directory. <% if(isHtml) { %>If the directory contains an existing AppBuilder project (created with the Telerik AppBuilder extension for Visual Studio or synchronized from GitHub), the project retains any existing project configuration.<% } %>
 
 ### Options
-* `--appid` - Sets the application identifier for your app. 
+* `--appid` - Sets the application identifier for your app.
 
 ### Attributes
 * `<App ID>` must consist of one or more alphanumeric strings, separated by a dot. The strings must be valid uniform type identifiers (UTIs), containing letters, numbers, hyphens, underscores or periods. The application identifier corresponds to the Bundle ID for iOS apps and to the package identifier for Android apps. If not specified, the application identifier is set to `com.telerik.<current directory name>`.
@@ -28,6 +28,7 @@ Command | Description
 [create hybrid](create-hybrid.html) | Creates a new project from an Apache Cordova-based template.
 [create native](create-native.html) | Creates a new project from a NativeScript-based template.
 [create screenbuilder](create-screenbuilder.html) | Creates a new project for hybrid development with Screen Builder.
+[export](export.html) | Exports a cloud-based project from a selected solution to facilitate the migration to a different framework.
 [init](init.html) | Initializes an existing project for development.
 [init hybrid](init-hybrid.html) | Initializes an existing Apache Cordova project for development in the current directory.
 [sample](sample.html) | Lists all available sample apps with name, description, GitHub repository, and clone command.

--- a/docs/man_pages/project/creation/init.md
+++ b/docs/man_pages/project/creation/init.md
@@ -26,6 +26,7 @@ Command | Description
 [create hybrid](create-hybrid.html) | Creates a new project from an Apache Cordova-based template.
 [create native](create-native.html) | Creates a new project from a NativeScript-based template.
 [create screenbuilder](create-screenbuilder.html) | Creates a new project for hybrid development with Screen Builder.
+[export](export.html) | Exports a cloud-based project from a selected solution to facilitate the migration to a different framework.
 [init hybrid](init-hybrid.html) | Initializes an existing Apache Cordova project for development in the current directory.
 [init native](init-native.html) | Initializes an existing NativeScript project for development in the current directory.
 [sample](sample.html) | Lists all available sample apps with name, description, GitHub repository, and clone command.

--- a/docs/man_pages/project/creation/sample-clone.md
+++ b/docs/man_pages/project/creation/sample-clone.md
@@ -3,22 +3,22 @@ sample clone
 
 Usage | Synopsis
 ------|-------
-General | `$ appbuilder sample clone <Clone ID> [--path <Directory>]`	
+General | `$ appbuilder sample clone <Clone ID> [--path <Directory>]`
 
 Clones the selected sample app from GitHub to your local file system and preserves its existing project configuration. <% if(isHtml) { %>You can examine and modify the sample code, run it in the simulator, and build and deploy it on your devices. To list all available sample apps with their clone commands, run `$ appbuilder sample`<% } %>
 
 <% if(isConsole) { %>
 WARNING: Always run this command in an empty directory or specify `--path` to an empty directory.
-<% } %> 
+<% } %>
 ### Options
-* `--path` - Specifies the directory where you want to clone the sample app, if different from the current directory. The directory must be empty. 
+* `--path` - Specifies the directory where you want to clone the sample app, if different from the current directory. The directory must be empty.
 
 ### Attributes
 * `<Clone ID>` is the title of the sample app as listed by `$ appbuilder sample`<% if(isHtml) { %>. If the title consists of two or more strings,    separated by a space, you must replace the spaces with hyphens. For example, to clone the Pinch and zoom sample app, run `$ appbuilder sample clone pinch-and-zoom`.
 
 ### Command Limitations
- 
-* You must run this command in an empty directory or specify `--path` to an empty directory. 
+
+* You must run this command in an empty directory or specify `--path` to an empty directory.
 
 ### Related Commands
 
@@ -30,6 +30,7 @@ Command | Description
 [create hybrid](create-hybrid.html) | Creates a new project from an Apache Cordova-based template.
 [create native](create-native.html) | Creates a new project from a NativeScript-based template.
 [create screenbuilder](create-screenbuilder.html) | Creates a new project for hybrid development with Screen Builder.
+[export](export.html) | Exports a cloud-based project from a selected solution to facilitate the migration to a different framework.
 [init](init.html) | Initializes an existing project for development.
 [init hybrid](init-hybrid.html) | Initializes an existing Apache Cordova project for development in the current directory.
 [init native](init-native.html) | Initializes an existing NativeScript project for development in the current directory.

--- a/docs/man_pages/project/creation/sample-hybrid.md
+++ b/docs/man_pages/project/creation/sample-hybrid.md
@@ -3,10 +3,10 @@ sample hybrid
 
 Usage | Synopsis
 ------|-------
-General | `$ appbuilder sample hybrid`    
+General | `$ appbuilder sample hybrid`
 
 Lists all available Apache Cordova sample apps with name, description, GitHub repository and clone command. To clone a selected sample app, run its clone command.
-<% if(isHtml) { %> 
+<% if(isHtml) { %>
 
 ### Related Commands
 
@@ -19,6 +19,7 @@ in the current directory.
 [create native](create-native.html) | Creates a new project from a NativeScript-based template.
 [create screenbuilder](create-screenbuilder.html) | Creates a new project for hybrid development with Screen Builder.
 [create](create.html) | Creates a project for hybrid or native development.
+[export](export.html) | Exports a cloud-based project from a selected solution to facilitate the migration to a different framework.
 [init hybrid](init-hybrid.html) | Initializes an existing Apache Cordova project for development in the current directory.
 [init native](init-native.html) | Initializes an existing NativeScript project for development in the current directory.
 [init](init.html) | Initializes an existing project for development.

--- a/docs/man_pages/project/creation/sample-native.md
+++ b/docs/man_pages/project/creation/sample-native.md
@@ -3,10 +3,10 @@ sample native
 
 Usage | Synopsis
 ------|-------
-General | `$ appbuilder sample native`    
+General | `$ appbuilder sample native`
 
 Lists all available NativeScript sample apps with name, description, GitHub repository and clone command. To clone a selected sample app, run its clone command.
-<% if(isHtml) { %> 
+<% if(isHtml) { %>
 
 ### Related Commands
 
@@ -19,6 +19,7 @@ in the current directory.
 [create native](create-native.html) | Creates a new project from a NativeScript-based template.
 [create screenbuilder](create-screenbuilder.html) | Creates a new project for hybrid development with Screen Builder.
 [create](create.html) | Creates a project for hybrid or native development.
+[export](export.html) | Exports a cloud-based project from a selected solution to facilitate the migration to a different framework.
 [init hybrid](init-hybrid.html) | Initializes an existing Apache Cordova project for development in the current directory.
 [init native](init-native.html) | Initializes an existing NativeScript project for development in the current directory.
 [init](init.html) | Initializes an existing project for development.

--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -19,6 +19,7 @@ $injector.require("templatesService", "./templates-service");
 $injector.require("serverExtensionsService", "./services/server-extensions");
 $injector.require("appScaffoldingExtensionsService", "./services/app-scaffolding-extensions-service");
 $injector.require("screenBuilderService", "./services/screen-builder-service");
+$injector.require("cloudProjectsService", "./services/cloud-projects-service");
 
 $injector.require("darwinDebuggerService", "./services/debug/darwin-debugger-service");
 $injector.require("winDebuggerService", "./services/debug/win-debugger-service");
@@ -111,6 +112,7 @@ $injector.requireCommand("prop|print|androidversioncode", "./commands/prop/prop-
 
 $injector.requireCommand("cloud|*list", "./commands/cloud-projects");
 $injector.requireCommand("cloud|export", "./commands/cloud-projects");
+$injector.requireCommand("export", "./commands/cloud-projects");
 
 $injector.require("deployHelper", "./commands/deploy");
 $injector.requireCommand("deploy|*devices", "./commands/deploy");

--- a/lib/commands/cloud-projects.ts
+++ b/lib/commands/cloud-projects.ts
@@ -1,4 +1,6 @@
 import commonHelpers = require("../common/helpers");
+import { EOL } from "os";
+import { resolve, join, extname, dirname } from "path";
 
 class SolutionIdCommandParameter implements ICommandParameter {
 	constructor(private $remoteProjectService: IRemoteProjectService) { }
@@ -55,33 +57,25 @@ export class CloudListProjectsCommand implements ICommand {
 $injector.registerCommand("cloud|*list", CloudListProjectsCommand);
 
 export class CloudExportProjectsCommand implements ICommand {
-	constructor(private $errors: IErrors,
-		private $remoteProjectService: IRemoteProjectService,
-		private $prompter: IPrompter,
-		private $project: Project.IProject) { }
+	protected _shouldCheckProject = true;
+	constructor(protected $errors: IErrors,
+		protected $remoteProjectService: IRemoteProjectService,
+		protected $cloudProjectsService: ICloudProjectsService,
+		protected $project: Project.IProject) { }
 
 	public allowedParameters: ICommandParameter[] = [];
 
 	public async execute(args: string[]): Promise<void> {
-		let projectIdentifier = args[1];
-		let slnName = args[0];
-		if (!slnName) {
-			let all = (await this.$remoteProjectService.getAvailableAppsAndSolutions()).map(sln => sln.colorizedDisplayName) || [];
-			slnName = await this.$prompter.promptForChoice("Select solution to export", all);
-			let projects = (await this.$remoteProjectService.getProjectsForSolution(slnName)).map(proj => proj.Name);
-			let exportSolutionItem = "Export the whole solution";
-			projects.push(exportSolutionItem);
-			let selection = await this.$prompter.promptForChoice("Select project to export", projects);
-			if (selection !== exportSolutionItem) {
-				projectIdentifier = selection;
-			}
-		}
+		const solutionProjectInfo = await this.$cloudProjectsService.getSolutionProjectInfo({
+			projectName: args[1],
+			solutionName: args[0],
+			enableExportWholeSolution: true
+		});
 
-		if (projectIdentifier) {
-			let projectName = await this.$remoteProjectService.getProjectName(slnName, projectIdentifier);
-			await this.$remoteProjectService.exportProject(slnName, projectName);
+		if (solutionProjectInfo.projectName) {
+			await this.$remoteProjectService.exportProject(solutionProjectInfo.solutionName, solutionProjectInfo.projectName);
 		} else {
-			await this.$remoteProjectService.exportSolution(slnName);
+			await this.$remoteProjectService.exportSolution(solutionProjectInfo.solutionName);
 		}
 	}
 
@@ -91,7 +85,7 @@ export class CloudExportProjectsCommand implements ICommand {
 			this.$errors.failWithoutHelp("You do not have any projects in the cloud.");
 		}
 
-		if (this.$project.projectData) {
+		if (this._shouldCheckProject && this.$project.projectData) {
 			this.$errors.failWithoutHelp("Cannot create project in this location because the specified directory is part of an existing project. Switch to or specify another location and try again.");
 		}
 
@@ -117,5 +111,73 @@ export class CloudExportProjectsCommand implements ICommand {
 		return true;
 	}
 }
-
 $injector.registerCommand("cloud|export", CloudExportProjectsCommand);
+
+export class ExportCommand extends CloudExportProjectsCommand implements ICommand {
+	constructor($project: Project.IProject,
+		protected $errors: IErrors,
+		protected $remoteProjectService: IRemoteProjectService,
+		protected $cloudProjectsService: ICloudProjectsService,
+		private $server: Server.IServer,
+		private $logger: ILogger,
+		private $httpClient: Server.IHttpClient,
+		private $fs: IFileSystem,
+		private $progressIndicator: IProgressIndicator,
+		private $options: IOptions) {
+		super($errors, $remoteProjectService, $cloudProjectsService, $project);
+	}
+
+	public allowedParameters: ICommandParameter[] = [];
+	protected _shouldCheckProject = false;
+
+	public async execute(args: string[]): Promise<void> {
+		const solutionProjectInfo = await this.$cloudProjectsService.getSolutionProjectInfo({
+			projectName: args[1],
+			solutionName: args[0],
+			forceChooseProject: true
+		});
+
+		const properties = {
+			Framework: solutionProjectInfo.framework,
+			AcceptResults: "Url;LocalPath"
+		};
+
+		this.$logger.info("Exporting project...");
+		// Fail early if the download path exists
+		let downloadPath = resolve(this.$options.path || ".");
+		const downloadPathExists = this.$fs.exists(downloadPath);
+		let downloadPathIsDirectory = true;
+		if (downloadPathExists) {
+			downloadPathIsDirectory = this.$fs.getFsStats(downloadPath).isDirectory();
+			if (!downloadPathIsDirectory) {
+				this.$errors.failWithoutHelp(`Cannot download result package in ${downloadPath} as it already exists.`);
+			}
+		}
+
+		const exportPromise = this.$server.appsBuild.exportProject(solutionProjectInfo.id, solutionProjectInfo.projectName, { Properties: properties, Targets: [] });
+		const response = await this.$progressIndicator.showProgressIndicator<Server.BuildResultData>(exportPromise, 2000);
+		if (response.Errors.length) {
+			this.$errors.failWithoutHelp(`Export errors:${EOL}${response.Errors.map(e => e.Message).join(EOL)}`);
+		} else {
+			const buildItem = response.ResultsByTarget["Build"].Items[0];
+			const downloadUrl = buildItem.FullPath;
+			if (!downloadPathExists || downloadPathIsDirectory) {
+				if (extname(downloadPath)) {
+					this.$fs.ensureDirectoryExists(dirname(downloadPath));
+				} else {
+					this.$fs.ensureDirectoryExists(downloadPath);
+					downloadPath = join(downloadPath, buildItem.Filename);
+				}
+			}
+
+			this.$logger.info(`Downloading ${buildItem.Filename} to ${downloadPath}...`);
+			const targetFile = this.$fs.createWriteStream(downloadPath);
+			await this.$httpClient.httpRequest({
+				url: downloadUrl,
+				pipeTo: targetFile
+			});
+		}
+	}
+}
+
+$injector.registerCommand("export", ExportCommand);

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -3,3 +3,7 @@ export class UserSettings {
 	static LocalFileName = "local-user-settings.json";
 	static FileExtension = ".user-settings.xml";
 }
+
+export class ExportOptions {
+	static WholeSolution = "Export the whole solution";
+}

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -165,7 +165,7 @@ interface ILoginManager {
 	telerikLogin(user: string, password: string): Promise<void>;
 }
 
-declare module Server2.Contract {
+declare module Server.Contract {
 	interface IParameter {
 		name: string;
 		binding: {

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -13,6 +13,7 @@ declare module Server {
 
 	interface IAppBuilderServiceProxy extends IServiceProxy {
 		makeTapServiceCall<T>(call: () => Promise<T>, solutionSpaceHeaderOptions?: { discardSolutionSpaceHeader: boolean }): Promise<T>
+		callWithoutSolutionSpaceHeader<T>(action: () => Promise<T>): Promise<T>;
 	}
 
 	interface IServiceContractProvider {
@@ -164,7 +165,7 @@ interface ILoginManager {
 	telerikLogin(user: string, password: string): Promise<void>;
 }
 
-declare module Server.Contract {
+declare module Server2.Contract {
 	interface IParameter {
 		name: string;
 		binding: {
@@ -1236,6 +1237,31 @@ interface IIonicProjectTransformator {
 	 * Creates AppBuilder project from Ionic project by removing unnecesary files, copying the resources and parsing the Ionic config.xml file.
 	 */
 	transformToAppBuilderProject(createBackup: boolean): Promise<void>
+}
+
+interface ISolutionName {
+	solutionName: string;
+}
+
+interface IId {
+	id: string;
+}
+
+interface ISolutionProjectInfoBase extends ISolutionName {
+	projectName?: string;
+}
+
+interface ISolutionProjectInfo extends ISolutionProjectInfoBase, IId {
+	framework: string;
+}
+
+interface ISolutionProjectPairOptions extends ISolutionProjectInfoBase {
+	enableExportWholeSolution?: boolean;
+	forceChooseProject?: boolean;
+}
+
+interface ICloudProjectsService {
+	getSolutionProjectInfo(opts: ISolutionProjectPairOptions): Promise<ISolutionProjectInfo>;
 }
 
 /**

--- a/lib/server-api.d.ts
+++ b/lib/server-api.d.ts
@@ -483,6 +483,8 @@ declare module Server {
 		Properties: IDictionary<string>;
 		Comparer: any;
 		Count: number;
+		FullPath: string;
+		Filename: string;
 		Keys: string[];
 		Values: string[];
 		Item: string;
@@ -508,6 +510,7 @@ declare module Server {
 	}
 	interface IAppsBuildServiceContract {
 		buildProject(appId: string, projectName: string, buildRequest: Server.BuildRequestData): Promise<Server.BuildResultData>;
+		exportProject(appId: string, projectName: string, buildRequest: Server.BuildRequestData): Promise<Server.BuildResultData>;
 	}
 	interface IBuildServiceContract {
 		buildProject(solutionName: string, projectName: string, buildRequest: Server.BuildRequestData): Promise<Server.BuildResultData>;

--- a/lib/server-api.ts
+++ b/lib/server-api.ts
@@ -427,10 +427,14 @@ export class BowerService implements Server.IBowerServiceContract {
 	}
 }
 export class AppsBuildService implements Server.IAppsBuildServiceContract {
-	constructor(private $serviceProxy: Server.IServiceProxy) {
+	constructor(private $serviceProxy: Server.IAppBuilderServiceProxy) {
 	}
 	public buildProject(appId: string, projectName: string, buildRequest: Server.BuildRequestData): Promise<Server.BuildResultData> {
 		return this.$serviceProxy.call<Server.BuildResultData>('BuildProject', 'POST', ['api', 'apps', encodeURI(appId.replace(/\\/g, '/')), 'build', encodeURI(projectName.replace(/\\/g, '/'))].join('/'), 'application/json', [{ name: 'buildRequest', value: JSON.stringify(buildRequest), contentType: 'application/json' }], null);
+	}
+	public exportProject(appId: string, projectName: string, buildRequest: Server.BuildRequestData): Promise<Server.BuildResultData> {
+		const call = this.$serviceProxy.call.bind(this.$serviceProxy, 'ExportProject', 'POST', ['api', 'apps', encodeURI(appId.replace(/\\/g, '/')), 'build', 'export', encodeURI(projectName.replace(/\\/g, '/'))].join('/'), 'application/json', [{ name: 'buildRequest', value: JSON.stringify(buildRequest), contentType: 'application/json' }], null);
+		return this.$serviceProxy.callWithoutSolutionSpaceHeader<Server.BuildResultData>(call);
 	}
 }
 export class BuildService implements Server.IBuildServiceContract {

--- a/lib/service-util.ts
+++ b/lib/service-util.ts
@@ -137,7 +137,7 @@ export class AppBuilderServiceProxy extends ServiceProxyBase implements Server.I
 		}
 	}
 
-	private async callWithoutSolutionSpaceHeader(action: () => Promise<any>): Promise<any> {
+	public async callWithoutSolutionSpaceHeader<T>(action: () => Promise<T>): Promise<T> {
 		let cachedUseSolutionSpaceNameValue = this.useSolutionSpaceNameHeader;
 		this.useSolutionSpaceNameHeader = false;
 		let result: any;

--- a/lib/services/cloud-projects-service.ts
+++ b/lib/services/cloud-projects-service.ts
@@ -1,0 +1,53 @@
+import { ExportOptions } from "../constants";
+
+export class CloudProjectsService implements ICloudProjectsService {
+	constructor(private $remoteProjectService: IRemoteProjectService,
+		private $errors: IErrors,
+		private $prompter: IPrompter) { }
+
+	public async getSolutionProjectInfo(opts: ISolutionProjectPairOptions): Promise<ISolutionProjectInfo> {
+		const apps = await this.$remoteProjectService.getAvailableAppsAndSolutions();
+		let framework = "";
+		let id = "";
+		const noSolutionNamePassed = !opts.solutionName;
+
+		if (noSolutionNamePassed) {
+			const solutionNames = apps.map(sln => sln.colorizedDisplayName) || [];
+			opts.solutionName = await this.$prompter.promptForChoice("Select solution to export", solutionNames);
+		}
+
+		const solutionData = await this.$remoteProjectService.getSolutionData(opts.solutionName);
+		if (!solutionData.Items || !solutionData.Items.length) {
+			this.$errors.failWithoutHelp(`Solution ${solutionData.Name} does not contain any projects.`);
+		}
+
+		if ((noSolutionNamePassed && !opts.projectName) || (opts.forceChooseProject && !opts.projectName)) {
+			const projects = (await this.$remoteProjectService.getProjectsForSolution(opts.solutionName)).map(proj => proj.Name);
+			if (opts.enableExportWholeSolution) {
+				projects.push(ExportOptions.WholeSolution);
+			}
+
+			const selection = await this.$prompter.promptForChoice("Select project to export", projects);
+			if (selection !== ExportOptions.WholeSolution) {
+				opts.projectName = selection;
+			}
+		}
+
+		if (opts.projectName) {
+			opts.projectName = await this.$remoteProjectService.getProjectName(opts.solutionName, opts.projectName);
+			const solution = solutionData.Items[0];
+			framework = solution.Framework;
+			const app = apps.find(sln => sln.colorizedDisplayName === solution.Name);
+			id = app && app.id;
+		}
+
+		return {
+			id,
+			framework,
+			projectName: opts.projectName,
+			solutionName: opts.solutionName
+		};
+	}
+}
+
+$injector.register("cloudProjectsService", CloudProjectsService);

--- a/test/cloud-projects.ts
+++ b/test/cloud-projects.ts
@@ -4,6 +4,7 @@ import yok = require("../lib/common/yok");
 import remoteProjectsServiceLib = require("../lib/services/remote-projects-service");
 import cloudProjectsCommandsLib = require("../lib/commands/cloud-projects");
 import projectConstantsLib = require("../lib/common/appbuilder/project-constants");
+import { CloudProjectsService } from "../lib/services/cloud-projects-service";
 import { EOL } from "os";
 import { assert } from "chai";
 import * as path from "path";
@@ -84,6 +85,7 @@ function createTestInjector(promptSlnName?: string, promptPrjName?: string, isIn
 	testInjector.register("userDataStore", {
 		getUser: () => Promise.resolve({ tenant: { id: "id" } }),
 	});
+	testInjector.register("cloudProjectsService", CloudProjectsService);
 	testInjector.register("serviceProxy", {
 		makeTapServiceCall: (call: () => Promise<any>, solutionSpaceHeaderOptions?: { discardSolutionSpaceHeader: boolean }) => { return call(); }
 	});


### PR DESCRIPTION
Introduce `$ appbuilder export` command, which enables exporting a project for development with Cordova/NativeScript CLI.

Ping @rosen-vladimirov @nadyaA @TomaNikolov 